### PR TITLE
add check and helpful exception message on inconsistent type situation

### DIFF
--- a/src/JMS/Serializer/NavigatorContext.php
+++ b/src/JMS/Serializer/NavigatorContext.php
@@ -58,6 +58,9 @@ class NavigatorContext
 
     public function isVisiting($object)
     {
+        if (! is_object($object)) {
+            throw new \LogicException('Expected object but got ' . gettype($object) . '. Do you have the wrong @Type mapping or could this be a Doctrine many-to-many relation?');
+        }
         return $this->visitingSet->contains($object);
     }
 


### PR DESCRIPTION
follow-up of #10 i try to add a mesage.

not sure if there would be a possibility to detect the mistake earlier - but i think not. i was looking at GraphNavigator too, but thought doing the exception right next to where the error could happen is the most reliable even in case the context is going to be used in different ways later.
