### PR TITLE
Typecast when serializing primitive types

### DIFF
--- a/tests/JMS/Serializer/Tests/Serializer/GraphNavigatorTest.php
+++ b/tests/JMS/Serializer/Tests/Serializer/GraphNavigatorTest.php
@@ -121,58 +121,6 @@ class GraphNavigatorTest extends \PHPUnit_Framework_TestCase
         $this->navigator->accept($object, null, $this->visitor);
     }
 
-    public function getPrimitiveTypes()
-    {
-        return array(
-            array(
-                'type' => 'boolean',
-                'data' => true,
-            ),
-            array(
-                'type' => 'boolean',
-                'data' => 1,
-            ),
-            array(
-                'type' => 'integer',
-                'data' => 123,
-            ),
-            array(
-                'type' => 'integer',
-                'data' => "123",
-            ),
-            array(
-                'type' => 'string',
-                'data' => "hello",
-            ),
-            array(
-                'type' => 'string',
-                'data' => 123,
-            ),
-            array(
-                'type' => 'double',
-                'data' => 0.1234,
-            ),
-            array(
-                'type' => 'double',
-                'data' => "0.1234",
-            ),
-        );
-    }
-
-    /**
-     * @dataProvider getPrimitiveTypes
-     * @param  string $primitiveType
-     * @param  mixed  $data
-     */
-    public function testSerializationCastsType($primitiveType, $data)
-    {
-        $this->navigator = new GraphNavigator(GraphNavigator::DIRECTION_SERIALIZATION, $this->metadataFactory, 'foo', $this->handlerRegistry, $this->objectConstructor, null, $this->dispatcher);
-
-        $this->visitor->expects($this->once())
-            ->method('visit' . ucfirst($primitiveType));
-        $this->navigator->accept($data, array('name' => $primitiveType), $this->visitor);
-    }
-
     protected function setUp()
     {
         $this->visitor = $this->getMock('JMS\Serializer\VisitorInterface');

--- a/tests/JMS/Serializer/Tests/Serializer/JsonSerializationTest.php
+++ b/tests/JMS/Serializer/Tests/Serializer/JsonSerializationTest.php
@@ -111,6 +111,58 @@ class JsonSerializationTest extends BaseSerializationTest
         $this->assertEquals('[{"full_name":"foo","_links":{"details":"http:\/\/foo.bar\/details\/foo","comments":"http:\/\/foo.bar\/details\/foo\/comments"}},{"full_name":"bar","_links":{"details":"http:\/\/foo.bar\/details\/bar","comments":"http:\/\/foo.bar\/details\/bar\/comments"}}]', $this->serialize($list));
     }
 
+    public function getPrimitiveTypes()
+    {
+        return array(
+            array(
+                'type' => 'boolean',
+                'data' => true,
+            ),
+            array(
+                'type' => 'boolean',
+                'data' => 1,
+            ),
+            array(
+                'type' => 'integer',
+                'data' => 123,
+            ),
+            array(
+                'type' => 'integer',
+                'data' => "123",
+            ),
+            array(
+                'type' => 'string',
+                'data' => "hello",
+            ),
+            array(
+                'type' => 'string',
+                'data' => 123,
+            ),
+            array(
+                'type' => 'double',
+                'data' => 0.1234,
+            ),
+            array(
+                'type' => 'double',
+                'data' => "0.1234",
+            ),
+        );
+    }
+
+    /**
+     * @dataProvider getPrimitiveTypes
+     */
+    public function testPrimitiveTypes($primitiveType, $data)
+    {
+        $visitor = $this->serializationVisitors->get('json')->get();
+        $functionToCall = 'visit' . ucfirst($primitiveType);
+        $result = $visitor->$functionToCall($data, array());
+        if ($primitiveType == 'double') {
+            $primitiveType = 'float';
+        }
+        $this->assertInternalType($primitiveType, $result);
+    }
+
     protected function getFormat()
     {
         return 'json';


### PR DESCRIPTION
I have noticed that the serializer does not fully enforce primitive types. I am not sure whether that is desired or not. 
