### PR TITLE
Fix DateTimeZone issue when using the DateTime type

### DIFF
--- a/src/JMS/Serializer/Handler/DateHandler.php
+++ b/src/JMS/Serializer/Handler/DateHandler.php
@@ -98,7 +98,7 @@ class DateHandler implements SubscribingHandlerInterface
 
     private function parseDateTime($data, array $type)
     {
-        $timezone = isset($type['params'][1]) ? $type['params'][1] : $this->defaultTimezone;
+        $timezone = isset($type['params'][1]) ? new \DateTimeZone($type['params'][1]) : $this->defaultTimezone;
         $format = $this->getFormat($type);
         $datetime = \DateTime::createFromFormat($format, (string) $data, $timezone);
         if (false === $datetime) {


### PR DESCRIPTION
Currently, (unless I'm missing something), using the timezone parameter of the DateTime type does not work. It attempts to pass the timezone to the createFromFormat method as a string, rather than converting it to a DateTimeZone object first (as it does with the default timezone).

This PR simply wraps that line with a new \DateTimeZone call.
