### PR TITLE
Extract json specific logic from GenericSerializationVisitor

### DIFF
--- a/src/JMS/Serializer/GenericSerializationVisitor.php
+++ b/src/JMS/Serializer/GenericSerializationVisitor.php
@@ -92,9 +92,7 @@ abstract class GenericSerializationVisitor extends AbstractVisitor
             $this->root = array();
             $rs = &$this->root;
         } else {
-            // ArrayObject is specially treated by the json_encode function and
-            // serialized to { } while a mere array would be serialized to [].
-            $rs = isset($type['params'][1]) ? new \ArrayObject() : array();
+            $rs = array();
         }
 
         foreach ($data as $k => $v) {

--- a/src/JMS/Serializer/JsonSerializationVisitor.php
+++ b/src/JMS/Serializer/JsonSerializationVisitor.php
@@ -36,4 +36,17 @@ class JsonSerializationVisitor extends GenericSerializationVisitor
     {
         $this->options = (integer) $options;
     }
+
+    public function visitArray($data, array $type)
+    {
+        $result = parent::visitArray($data, $type);
+
+        if (null !== $this->getRoot() && isset($type['params'][1]) && 0 === count($result)) {
+            // ArrayObject is specially treated by the json_encode function and
+            // serialized to { } while a mere array would be serialized to [].
+            return new \ArrayObject();
+        }
+
+        return $result;
+    }
 }


### PR DESCRIPTION
Hey,

I've seen in https://github.com/schmittjoh/serializer/pull/20 that @tystr had to add more "json" knowledge inside the `GenericSerializationVisitor` class. So here's a simple fix.
