### PR TITLE
Make serializer works with Doctrine Entities as Interfaces

### DIFF
--- a/src/JMS/Serializer/EventDispatcher/Subscriber/DoctrineProxySubscriber.php
+++ b/src/JMS/Serializer/EventDispatcher/Subscriber/DoctrineProxySubscriber.php
@@ -13,6 +13,7 @@ class DoctrineProxySubscriber implements EventSubscriberInterface
     public function onPreSerialize(PreSerializeEvent $event)
     {
         $object = $event->getObject();
+        $type   = $event->getType();
 
         if ($object instanceof PersistentCollection) {
             $event->setType('ArrayCollection');
@@ -21,6 +22,14 @@ class DoctrineProxySubscriber implements EventSubscriberInterface
         }
 
         if ( ! $object instanceof Proxy && ! $object instanceof ORMProxy) {
+            try {
+                $class = new \ReflectionClass($type['name']);
+
+                if ($class->isInterface()) {
+                    $event->setType(get_class($object));
+                }
+            } catch (\ReflectionException $e) {}
+
             return;
         }
 


### PR DESCRIPTION
We had this case:
- bundle core has user entity, user has avatar field
- bundle media has file entity, user avatar field is a file

So we would have a bi-directional dependency where core depends on media and media depends on core.

To avoid that case we came up with an entity interface on bundle core, after some investigation we noticed that serializer was dropping the avatar property because it was an interface and `DoctrineProxySubscriber` was failing to turn it into a class instance.

This pull request fixes this case.
