### PR TITLE
Dispatching an event on pre-deserialization

### DIFF
--- a/src/JMS/Serializer/EventDispatcher/PreDeserializeEvent.php
+++ b/src/JMS/Serializer/EventDispatcher/PreDeserializeEvent.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace JMS\Serializer\EventDispatcher;
+
+class PreDeserializeEvent extends Event
+{
+    /**
+     * @param string $typeName
+     * @param array $params
+     */
+    public function setType($typeName, array $params = array())
+    {
+        $this->type = array('name' => $typeName, 'params' => $params);
+    }
+}

--- a/src/JMS/Serializer/GraphNavigator.php
+++ b/src/JMS/Serializer/GraphNavigator.php
@@ -18,12 +18,13 @@
 
 namespace JMS\Serializer;
 
-use JMS\Serializer\EventDispatcher\PreSerializeEvent;
 use JMS\Serializer\Exception\RuntimeException;
 use JMS\Serializer\Construction\ObjectConstructorInterface;
 use JMS\Serializer\Handler\HandlerRegistryInterface;
 use JMS\Serializer\EventDispatcher\Event;
 use JMS\Serializer\EventDispatcher\EventDispatcherInterface;
+use JMS\Serializer\EventDispatcher\PreDeserializeEvent;
+use JMS\Serializer\EventDispatcher\PreSerializeEvent;
 use JMS\Serializer\Metadata\ClassMetadata;
 use Metadata\MetadataFactoryInterface;
 use JMS\Serializer\Exception\InvalidArgumentException;
@@ -159,6 +160,11 @@ final class GraphNavigator
                 if ($isSerializing) {
                     if (null !== $this->dispatcher && $this->dispatcher->hasListeners('serializer.pre_serialize', $type['name'], $this->context->getFormat())) {
                         $this->dispatcher->dispatch('serializer.pre_serialize', $type['name'], $this->context->getFormat(), $event = new PreSerializeEvent($visitor, $data, $type));
+                        $type = $event->getType();
+                    }
+                } else {
+                    if (null !== $this->dispatcher && $this->dispatcher->hasListeners('serializer.pre_deserialize', $type['name'], $this->context->getFormat())) {
+                        $this->dispatcher->dispatch('serializer.pre_deserialize', $type['name'], $this->context->getFormat(), $event = new PreDeserializeEvent($visitor, $data, $type));
                         $type = $event->getType();
                     }
                 }


### PR DESCRIPTION
Created a very simple event on pre-deserialization. Very useful if you need to modify the incoming xml/json before it is deserialized.
In my case I needed to convert a yes/no value to true/false so it could be correctly converted to a boolean.
