### PR TITLE
Allow passing parameters to Doctrine entities when serializing

### DIFF
--- a/src/JMS/Serializer/EventDispatcher/Subscriber/DoctrineProxySubscriber.php
+++ b/src/JMS/Serializer/EventDispatcher/Subscriber/DoctrineProxySubscriber.php
@@ -51,7 +51,7 @@ class DoctrineProxySubscriber implements EventSubscriberInterface
         $object->__load();
 
         if ( ! $virtualType) {
-            $event->setType(get_parent_class($object));
+            $event->setType(get_parent_class($object), $type['params']);
         }
     }
 


### PR DESCRIPTION
I have a use case where I need to be able to pass in some parameters to a SubscribingHandlerInterface which serializes Doctrine entities. Currently, the DoctrineProxySubscriber will remove these because of : 

```
        if ( ! $virtualType) {
            $event->setType(get_parent_class($object));
        }
```

in the onPreSerialize function (which will effectively throw away any parameters you have provided). This pull request should fix this.

BTW I also think this is some leftover code that is only needed for Symfony 2.0, at first I just commented it out and that worked as well on Symfony 2.1.
