### PR TITLE
Fixed the license identifier

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
     "description": "Library for (de-)serializing data of any complexity; supports XML, JSON, and YAML.",
     "keywords": ["serialization", "deserialization", "json", "jaxb", "xml"],
     "homepage": "http://jmsyst.com/libs/serializer",
-    "license": "Apache2",
+    "license": "Apache-2.0",
     "authors": [
         {
             "name": "Johannes M. Schmitt",


### PR DESCRIPTION
Using the proper SPDX identifier for the license allows to keep the
composer.json file valid, which is required by Packagist to accept the package.

The same change is probably required by all your projects
