### PR TITLE
Use the AnnotationReader interface in the SerializerBuilder, instead of the implemented AnnotationReader itself

### DIFF
--- a/src/JMS/Serializer/SerializerBuilder.php
+++ b/src/JMS/Serializer/SerializerBuilder.php
@@ -36,6 +36,7 @@ use JMS\Serializer\Construction\ObjectConstructorInterface;
 use JMS\Serializer\EventDispatcher\Subscriber\DoctrineProxySubscriber;
 use JMS\Serializer\Naming\CamelCaseNamingStrategy;
 use JMS\Serializer\Naming\PropertyNamingStrategyInterface;
+use Doctrine\Common\Annotations\Reader;
 use Doctrine\Common\Annotations\AnnotationReader;
 use Doctrine\Common\Annotations\FileCacheReader;
 use Metadata\Cache\FileCache;
@@ -80,7 +81,7 @@ class SerializerBuilder
         $this->deserializationVisitors = new Map();
     }
 
-    public function setAnnotationReader(AnnotationReader $reader)
+    public function setAnnotationReader(Reader $reader)
     {
         $this->annotationReader = $reader;
 


### PR DESCRIPTION
When setting the annotation reader to the SerializerBuilder, the reader must be an instance of the _Doctrine\Common\Annotations\AnnotationReader_ class. This disallows the possibility of using other annotation readers, such as the _CachedReader_ of Doctrine or a custom implementation. A better solution would be to use the interface which describes the Annotation Reader: _Doctrine\Common\Annotations\Reader_.

The set annotation reader is passed into the _AnnotationDriver_, which uses already this interface.
