### PR TITLE
Attach `xmlns:xsi namespace` when serializing NULL values

### DIFF
--- a/src/JMS/Serializer/XmlSerializationVisitor.php
+++ b/src/JMS/Serializer/XmlSerializationVisitor.php
@@ -40,6 +40,7 @@ class XmlSerializationVisitor extends AbstractVisitor
     private $currentNode;
     private $currentMetadata;
     private $hasValue;
+    private $hasNullNamespace;
 
     public function setDefaultRootName($name)
     {
@@ -76,10 +77,12 @@ class XmlSerializationVisitor extends AbstractVisitor
             $node = $this->document->createAttribute('xsi:nil');
             $node->value = 'true';
             $this->currentNode->appendChild($node);
-
+            $this->attachNullNamespace();
+            
             return;
         }
 
+        $this->attachNullNamespace();
         $node = $this->document->createAttribute('xsi:nil');
         $node->value = 'true';
 
@@ -318,5 +321,13 @@ class XmlSerializationVisitor extends AbstractVisitor
     private function isElementNameValid($name)
     {
         return $name && false === strpos($name, ' ') && preg_match('#^[\pL_][\pL0-9._-]*$#ui', $name);
+    }
+    
+    private function attachNullNamespace() 
+    {
+        if (!$this->hasNullNamespace) {
+            $this->document->documentElement->setAttributeNS('http://www.w3.org/2000/xmlns/', 'xmlns:xsi', 'http://www.w3.org/2001/XMLSchema-instance');
+            $this->hasNullNamespace = true;
+        }
     }
 }


### PR DESCRIPTION
this was the quickest (may not be the best) way to fix `XML Parsing Error: prefix not bound to a namespace` when serializing any `null` value (property, array value or just null).

fixes schmittjoh/JMSSerializerBundle#293
