### PR TITLE
Register annotations namespace

### DIFF
--- a/src/JMS/Serializer/SerializerBuilder.php
+++ b/src/JMS/Serializer/SerializerBuilder.php
@@ -39,6 +39,7 @@ use JMS\Serializer\Naming\PropertyNamingStrategyInterface;
 use Doctrine\Common\Annotations\Reader;
 use Doctrine\Common\Annotations\AnnotationReader;
 use Doctrine\Common\Annotations\FileCacheReader;
+use Doctrine\Common\Annotations\AnnotationRegistry;
 use Metadata\Cache\FileCache;
 use JMS\Serializer\Naming\SerializedNameAnnotationStrategy;
 use JMS\Serializer\Exception\InvalidArgumentException;
@@ -321,6 +322,7 @@ class SerializerBuilder
 
     public function build()
     {
+        $this->registerAnnotationsNamespace();
         $annotationReader = $this->annotationReader;
         if (null === $annotationReader) {
             $annotationReader = new AnnotationReader();
@@ -371,6 +373,17 @@ class SerializerBuilder
             $this->serializationVisitors,
             $this->deserializationVisitors,
             $this->eventDispatcher
+        );
+    }
+
+    /**
+     * Registers the Annotations with the Doctrine autoloader
+     */
+    private function registerAnnotationsNamespace()
+    {
+        AnnotationRegistry::registerAutoloadNamespace(
+            'JMS\\Serializer\\Annotation',
+            __DIR__ . "/../../"
         );
     }
 


### PR DESCRIPTION
When using the standalone library, it is necessary to register the library's namespace with doctrine using the method call:

```
\Doctrine\Common\Annotations\AnnotationRegistry::registerAutoloadNamespace(
    'JMS\\Serializer\\Annotation',
    "path/to/jms/serializer/"
);
```

otherwise there is a fatal error.

This pull request fixes this issue by registering the autoload namespace in the builder.
