### PR TITLE
Always serialize PHP indexed arrays as JSON arrays, not objects

### DIFF
--- a/src/JMS/Serializer/GenericSerializationVisitor.php
+++ b/src/JMS/Serializer/GenericSerializationVisitor.php
@@ -98,7 +98,8 @@ abstract class GenericSerializationVisitor extends AbstractVisitor
             $rs = array();
         }
 
-        $innerType = ($isAssociative = isset($type['params'][1]))
+        $isAssociative = false;
+        $innerType = isset($type['params'][1])
             ? $type['params'][1]
             : isset($type['params'][0]) ? $type['params'][0] : null;
 
@@ -109,11 +110,15 @@ abstract class GenericSerializationVisitor extends AbstractVisitor
                 continue;
             }
 
-            if ($isAssociative) {
-                $rs[$k] = $v;
-            } else {
-                $rs[] = $v;
+            if (is_string($k)) {
+                $isAssociative = true;
             }
+
+            $rs[$k] = $v;
+        }
+
+        if (!$isAssociative) {
+            $rs = array_values($rs);
         }
 
         return $rs;

--- a/tests/JMS/Serializer/Tests/Serializer/BaseSerializationTest.php
+++ b/tests/JMS/Serializer/Tests/Serializer/BaseSerializationTest.php
@@ -254,6 +254,17 @@ abstract class BaseSerializationTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($this->getContent('array_mixed'), $this->serialize(array('foo', 1, true, new SimpleObject('foo', 'bar'), array(1, 3, true))));
     }
 
+    public function testArrayIndexedNonSequential()
+    {
+        $data = array('one', 'two', 'three');
+        unset($data[1]);
+
+        $this->assertEquals(
+            $this->getContent('array_non_sequential'),
+            $this->serializer->serialize($data, $this->getFormat())
+        );
+    }
+
     /**
      * @dataProvider getDateTime
      * @group datetime

--- a/tests/JMS/Serializer/Tests/Serializer/JsonSerializationTest.php
+++ b/tests/JMS/Serializer/Tests/Serializer/JsonSerializationTest.php
@@ -49,6 +49,7 @@ class JsonSerializationTest extends BaseSerializationTest
             $outputs['array_floats'] = '[1.34,3,6.42]';
             $outputs['array_objects'] = '[{"foo":"foo","moo":"bar","camel_case":"boo"},{"foo":"baz","moo":"boo","camel_case":"boo"}]';
             $outputs['array_mixed'] = '["foo",1,true,{"foo":"foo","moo":"bar","camel_case":"boo"},[1,3,true]]';
+            $outputs['array_non_sequential'] = '["one","three"]';
             $outputs['blog_post'] = '{"title":"This is a nice title.","created_at":"2011-07-30T00:00:00+0000","is_published":false,"comments":[{"author":{"full_name":"Foo Bar"},"text":"foo"}],"comments2":[{"author":{"full_name":"Foo Bar"},"text":"foo"}],"metadata":{"foo":"bar"},"author":{"full_name":"Foo Bar"}}';
             $outputs['blog_post_unauthored'] = '{"title":"This is a nice title.","created_at":"2011-07-30T00:00:00+0000","is_published":false,"comments":[],"comments2":[],"metadata":{"foo":"bar"},"author":null}';
             $outputs['price'] = '{"price":3}';

--- a/tests/JMS/Serializer/Tests/Serializer/YamlSerializationTest.php
+++ b/tests/JMS/Serializer/Tests/Serializer/YamlSerializationTest.php
@@ -42,6 +42,11 @@ class YamlSerializationTest extends BaseSerializationTest
         $this->markTestSkipped('This is not available for the YAML format.');
     }
 
+    public function testArrayIndexedNonSequential()
+    {
+        $this->markTestSkipped('This is not available for the YAML format.');
+    }
+
     protected function getContent($key)
     {
         if (!file_exists($file = __DIR__.'/yml/'.$key.'.yml')) {

--- a/tests/JMS/Serializer/Tests/Serializer/xml/array_non_sequential.xml
+++ b/tests/JMS/Serializer/Tests/Serializer/xml/array_non_sequential.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<result>
+  <entry><![CDATA[one]]></entry>
+  <entry><![CDATA[three]]></entry>
+</result>


### PR DESCRIPTION
When an indexed array has a removed item at the middle (i.e. not sequential indexes) it is not anymore serialized as JSON array.
For example in Symfony2, when using Collection Form Type and removing an item (with an ArrayCollection it's the same problem).
The array inner type was also not used during serialization with form "array<T>", but only with "array<K, V>".
