### PR TITLE
Recursion was creating nested objects that had a loop.

### DIFF
--- a/src/JMS/Serializer/JsonSerializationVisitor.php
+++ b/src/JMS/Serializer/JsonSerializationVisitor.php
@@ -2,13 +2,13 @@
 
 /*
  * Copyright 2013 Johannes M. Schmitt <schmittjoh@gmail.com>
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -26,6 +26,10 @@ class JsonSerializationVisitor extends GenericSerializationVisitor
 
     public function getResult()
     {
+        if (array() === $this->getRoot()) {
+            $this->setRoot(new \ArrayObject());
+        }
+
         return json_encode($this->getRoot(), $this->options);
     }
 
@@ -59,10 +63,6 @@ class JsonSerializationVisitor extends GenericSerializationVisitor
         // Force JSON output to "{}" instead of "[]" if it contains either no properties or all properties are null.
         if (empty($rs)) {
             $rs = new \ArrayObject();
-
-            if (array() === $this->getRoot()) {
-                $this->setRoot($rs);
-            }
         }
 
         return $rs;


### PR DESCRIPTION
While in the recursion, the root of the object was being updated, this was causing some serialized objects to have the initial root nested in an attribute causing a loop problem when calling `json_encode`.

So I moved the `setRoot` to `ArrayObject` only when calling `getResult` and for nodes is okay to change it to `ArrayObject`.
