### PR TITLE
Deserialization fail

### DIFF
--- a/src/JMS/Serializer/GenericDeserializationVisitor.php
+++ b/src/JMS/Serializer/GenericDeserializationVisitor.php
@@ -162,7 +162,7 @@ abstract class GenericDeserializationVisitor extends AbstractVisitor
     {
         $name = $this->namingStrategy->translateName($metadata);
 
-        if (null === $data || ! array_key_exists($name, $data)) {
+        if (null === $data || !is_array($data) || ! array_key_exists($name, $data)) {
             return;
         }
 


### PR DESCRIPTION
In different cases, when JSON is sent this error occurs:
`Warning: array_key_exists() expects parameter 2 to be array, string given in`
or
`Warning: array_key_exists() expects parameter 2 to be array, integer given in`