### PR TITLE
DoctrineObjectConstructor - NamingStrategy and SerializedName

### DIFF
--- a/src/JMS/Serializer/Construction/DoctrineObjectConstructor.php
+++ b/src/JMS/Serializer/Construction/DoctrineObjectConstructor.php
@@ -2,13 +2,13 @@
 
 /*
  * Copyright 2013 Johannes M. Schmitt <schmittjoh@gmail.com>
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -74,11 +74,23 @@ class DoctrineObjectConstructor implements ObjectConstructorInterface
         $identifierList = array();
 
         foreach ($classMetadata->getIdentifierFieldNames() as $name) {
-            if ( ! array_key_exists($name, $data)) {
+
+            $identifierName = $name;
+            //Retrieve translated name
+            if (isset($metadata->propertyMetadata[$name])) {
+               $identifierName = $visitor->getNamingStrategy()->translateName($metadata->propertyMetadata[$name]);
+
+               //Retrieve serialized name if needed
+               if ( ! array_key_exists($identifierName, $data)) {
+                   $identifierName = $metadata->propertyMetadata[$name]->serializedName;
+               }
+            }
+
+            if ( ! array_key_exists($identifierName, $data) || $data[$identifierName] == null) {
                 return $this->fallbackConstructor->construct($visitor, $metadata, $data, $type);
             }
 
-            $identifierList[$name] = $data[$name];
+            $identifierList[$name] = $data[$identifierName];
         }
 
         // Entity update, load it from database

--- a/tests/JMS/Serializer/Tests/Construction/DoctrineObjectConstructorTest.php
+++ b/tests/JMS/Serializer/Tests/Construction/DoctrineObjectConstructorTest.php
@@ -1,0 +1,112 @@
+<?php
+namespace JMS\Serializer\Tests\Construction;
+
+use Doctrine\Common\Annotations\AnnotationReader;
+use JMS\Serializer\Metadata\Driver\AnnotationDriver;
+use Metadata\MetadataFactory;
+use JMS\Serializer\Metadata\ClassMetadata;
+use JMS\Serializer\Naming\CamelCaseNamingStrategy;
+use JMS\Serializer\JsonDeserializationVisitor;
+use JMS\Serializer\Construction\DoctrineObjectConstructor;
+
+class DoctrineObjectConstructorTest extends \PHPUnit_Framework_TestCase
+{
+    protected $managerRegistryMock;
+    protected $fallbackConstructorMock;
+    protected $entityManagerMock;
+
+    protected function setUp()
+    {
+        parent::setUp();
+
+        $this->managerRegistryMock = $this->getMockBuilder('Doctrine\Common\Persistence\ManagerRegistry')->disableOriginalConstructor()->getMock();
+        $this->fallbackConstructorMock = $this->getMockBuilder('JMS\Serializer\Construction\UnserializeObjectConstructor')->disableOriginalConstructor()->getMock();
+    }
+
+    protected function getDoctrineObjectConstructor()
+    {
+        return new DoctrineObjectConstructor($this->managerRegistryMock, $this->fallbackConstructorMock);
+    }
+
+
+    protected function initObjectManager($isTransient)
+    {
+        $this->entityManagerMock = $this->getMockBuilder('Doctrine\ORM\EntityManager')->disableOriginalConstructor()->getMock();
+        $classMetadataFactory = $this->getMockBuilder('Doctrine\Common\Persistence\Mapping\ClassMetadataFactory')->disableOriginalConstructor()->getMock();
+
+        $this->managerRegistryMock->expects($this->any())->method('getManagerForClass')->will($this->returnValue($this->entityManagerMock));
+        $this->entityManagerMock->expects($this->any())->method('getMetadataFactory')->will($this->returnValue($classMetadataFactory));
+        $classMetadataFactory->expects($this->any())->method('isTransient')->will($this->returnValue($isTransient));
+    }
+
+
+    public function testMissingObjectManager()
+    {
+        $this->managerRegistryMock->expects($this->any())->method('getManagerForClass')->will($this->returnValue(null));
+        $this->fallbackConstructorMock->expects($this->once())->method('construct');
+
+        $visitor = new JsonDeserializationVisitor(new CamelCaseNamingStrategy());
+        $metadata = new ClassMetadata('JMS\Serializer\Tests\Fixtures\Article');
+
+        $this->getDoctrineObjectConstructor()->construct($visitor, $metadata, array(), array());
+    }
+
+    public function testTransientObject()
+    {
+        $this->initObjectManager(true);
+        $this->fallbackConstructorMock->expects($this->once())->method('construct');
+
+        $visitor = new JsonDeserializationVisitor(new CamelCaseNamingStrategy());
+        $metadata = new ClassMetadata('JMS\Serializer\Tests\Fixtures\Article');
+
+        $this->getDoctrineObjectConstructor()->construct($visitor, $metadata, array(), array());
+    }
+
+    public function testProxyLoad()
+    {
+        $this->initObjectManager(false);
+
+        $this->entityManagerMock->expects($this->once())->method('getReference');
+
+        $metadata = new ClassMetadata('JMS\Serializer\Tests\Fixtures\Article');
+        $visitor = new JsonDeserializationVisitor(new CamelCaseNamingStrategy());
+
+        $this->getDoctrineObjectConstructor()->construct($visitor, $metadata, 12, array());
+    }
+
+    public function providerFind()
+    {
+        return array(
+                array(array('id' => 45), false, 'JMS\Serializer\Tests\Fixtures\Doctrine\Author', array('id' => 45), array('id'), new CamelCaseNamingStrategy()),
+                array(array('idFirst' => 45, 'idSecond' => 78), false, 'JMS\Serializer\Tests\Fixtures\Doctrine\CompositePrimaryKey', array('id_first_serialized' => 45, 'id_second_serialized' => 78), array('idFirst', 'idSecond'), new CamelCaseNamingStrategy()),
+                array(array(), true, 'JMS\Serializer\Tests\Fixtures\Doctrine\CompositePrimaryKey', array('id_first_serialized' => 45), array('idFirst', 'idSecond'), new CamelCaseNamingStrategy()),
+                array(array(), true, 'JMS\Serializer\Tests\Fixtures\Doctrine\CompositePrimaryKey', array('id_first_serialized' => 45, 'id_second_serialized' => null), array('idFirst', 'idSecond'), new CamelCaseNamingStrategy()),
+        );
+    }
+
+    /**
+     * @dataProvider providerFind
+     */
+    public function testFind($expectedIdentifierList, $fallback, $entity, $data, $identifierFieldNames, $namingStrategy)
+    {
+        $this->initObjectManager(false);
+
+        $classMetadataMock = $this->getMockBuilder('Doctrine\ORM\Mapping\ClassMetadata')->disableOriginalConstructor()->getMock();
+
+        $this->entityManagerMock->expects($this->once())->method('getClassMetadata')->will($this->returnValue($classMetadataMock));
+        $classMetadataMock->expects($this->once())->method('getIdentifierFieldNames')->will($this->returnValue($identifierFieldNames));
+
+        $metadataFactory = new MetadataFactory(new AnnotationDriver(new AnnotationReader()));
+        $metadata = $metadataFactory->getMetadataForClass($entity);
+
+        $visitor = new JsonDeserializationVisitor($namingStrategy);
+
+        if ($fallback) {
+            $this->fallbackConstructorMock->expects($this->once())->method('construct');
+        } else {
+            $this->entityManagerMock->expects($this->once())->method('find')->with($metadata->name, $expectedIdentifierList);
+        }
+
+        $this->getDoctrineObjectConstructor()->construct($visitor, $metadata, $data, array());
+    }
+}

--- a/tests/JMS/Serializer/Tests/Fixtures/Doctrine/CompositePrimaryKey.php
+++ b/tests/JMS/Serializer/Tests/Fixtures/Doctrine/CompositePrimaryKey.php
@@ -1,0 +1,41 @@
+<?php
+namespace JMS\Serializer\Tests\Fixtures\Doctrine;
+
+use Doctrine\ORM\Mapping as ORM;
+use JMS\Serializer\Annotation as Serializer;
+
+class CompositePrimaryKey
+{
+    /**
+     * @ORM\Id @ORM\Column(type="integer")
+     * @Serializer\SerializedName("id_first_serialized")
+     */
+    protected $idFirst;
+
+    /**
+     * @ORM\Id @ORM\Column(type="integer")
+     * @Serializer\SerializedName("id_second_serialized")
+     */
+    private $idSecond;
+
+    public function getIdFirst()
+    {
+        return $this->idFirst;
+    }
+
+    public function setIdFirst($idFirst)
+    {
+        $this->idFirst = $idFirst;
+    }
+
+    public function getIdSecond()
+    {
+        return $this->idSecond;
+    }
+
+    public function setIdSecond($idSecond)
+    {
+        $this->idSecond = $idSecond;
+    }
+
+}


### PR DESCRIPTION
Using DoctrineObjectConstructor in our projects we faced an issue because our primary keys are post-fixed by the name of the entity.
So the primary key serialized name of an entity "Entity" is "idEntity" as DoctrineObjectConstructor is not using the namingStrategy of the visitor. For example using camelCase strategy, he failed to match id_entity in the $data array.
He also wasn't able to handle custom serializedName.
And finally if primary key exist in data array but is null, he was trying to load entity with a null value and failed.
