### PR TITLE
Add Serializer::getMetadataFactory

### DIFF
--- a/src/JMS/Serializer/Serializer.php
+++ b/src/JMS/Serializer/Serializer.php
@@ -120,4 +120,12 @@ class Serializer implements SerializerInterface
 
         return $visitorResult;
     }
+
+    /**
+     * @return MetadataFactoryInterface
+     */
+    public function getMetadataFactory()
+    {
+        return $this->factory;
+    }
 }


### PR DESCRIPTION
The metadata factory can be injected into other services with the bundle. However, with the lib alone, there is no way to access the metadata factory. This solves that.
