### PR TITLE
Add getter for the xml serialization visitor defaultRootName property

### DIFF
--- a/src/JMS/Serializer/XmlSerializationVisitor.php
+++ b/src/JMS/Serializer/XmlSerializationVisitor.php
@@ -46,6 +46,14 @@ class XmlSerializationVisitor extends AbstractVisitor
         $this->defaultRootName = $name;
     }
 
+    /**
+     * @return boolean
+     */
+    public function hasDefaultRootName()
+    {
+        return 'result' === $this->defaultRootName;
+    }
+
     public function setDefaultVersion($version)
     {
         $this->defaultVersion = $version;


### PR DESCRIPTION
In the FSCHateoasBundle, I currently use reflection to know whether the default root name is the default `result` (I only override the default root name if it's still the default..).
This will avoid using reflection.
