### PR TITLE
Added PreSerializeEvent to the pre-serialize call-back.

### DIFF
--- a/src/JMS/Serializer/GraphNavigator.php
+++ b/src/JMS/Serializer/GraphNavigator.php
@@ -194,7 +194,7 @@ final class GraphNavigator
 
                 if ($context instanceof SerializationContext) {
                     foreach ($metadata->preSerializeMethods as $method) {
-                        $method->invoke($data);
+                        $method->invoke($data, array(new PreSerializeEvent($context, $data, $type)));
                     }
                 }
 


### PR DESCRIPTION
I needed access to the context in the pre-serialize call-back. The event listeners have access to the context so I thought it reasonable that the call-backs should too?