### PR TITLE
make FormErrorHandler more easily extendable

### DIFF
--- a/src/JMS/Serializer/Handler/FormErrorHandler.php
+++ b/src/JMS/Serializer/Handler/FormErrorHandler.php
@@ -29,7 +29,7 @@ use JMS\Serializer\XmlSerializationVisitor;
 
 class FormErrorHandler implements SubscribingHandlerInterface
 {
-    private $translator;
+    protected $translator;
 
     public static function getSubscribingMethods()
     {
@@ -114,7 +114,7 @@ class FormErrorHandler implements SubscribingHandlerInterface
         return $this->getErrorMessage($formError);
     }
 
-    private function getErrorMessage(FormError $error)
+    protected function getErrorMessage(FormError $error)
     {
         if (null !== $error->getMessagePluralization()) {
             return $this->translator->transChoice($error->getMessageTemplate(), $error->getMessagePluralization(), $error->getMessageParameters(), 'validators');
@@ -123,7 +123,7 @@ class FormErrorHandler implements SubscribingHandlerInterface
         return $this->translator->trans($error->getMessageTemplate(), $error->getMessageParameters(), 'validators');
     }
 
-    private function convertFormToArray(GenericSerializationVisitor $visitor, Form $data)
+    protected function convertFormToArray(GenericSerializationVisitor $visitor, Form $data)
     {
         $isRoot = null === $visitor->getRoot();
 


### PR DESCRIPTION
I wanted to override FormErrorHandler so it would return error messages in the format

```
error:
    message: Parsed error message
    template: Error message template
    parameters: Error message parameters
```

instead of

```
error: Parsed error message
```

and it's pretty hard to do with private members.
