### PR TITLE
fix wrong quote in used in docs

### DIFF
--- a/doc/reference/annotations.rst
+++ b/doc/reference/annotations.rst
@@ -214,7 +214,7 @@ by the object iself.
 .. code-block :: php
 
     <?php
-    
+
     class Article
     {
         /**
@@ -275,10 +275,10 @@ Available Types:
 +---------------------------+--------------------------------------------------+
 | DateTime                  | PHP's DateTime object (default format/timezone)  |
 +---------------------------+--------------------------------------------------+
-| DateTime<"format">        | PHP's DateTime object (custom format/default     |
+| DateTime<'format'>        | PHP's DateTime object (custom format/default     |
 |                           | timezone)                                        |
 +---------------------------+--------------------------------------------------+
-| DateTime<"format", "zone">| PHP's DateTime object (custom format/timezone)   |
+| DateTime<'format', 'zone'>| PHP's DateTime object (custom format/timezone)   |
 +---------------------------+--------------------------------------------------+
 | T                         | Where T is a fully qualified class name.         |
 +---------------------------+--------------------------------------------------+
@@ -320,6 +320,11 @@ Examples:
          * @Type("DateTime")
          */
         private $createdAt;
+
+        /**
+         * @Type("DateTime<'Y-m-d'>")
+         */
+        private $updatedAt;
 
         /**
          * @Type("boolean")


### PR DESCRIPTION
In the annotation documentation are the wrong quotes used. It should be a single quote, not a double one. 

I added an example to make things more clear.
