### PR TITLE
Make tests fail for DateTime fields in U format with negative dates

### DIFF
--- a/tests/JMS/Serializer/Tests/Fixtures/Author.php
+++ b/tests/JMS/Serializer/Tests/Fixtures/Author.php
@@ -29,13 +29,24 @@ class Author
      */
     private $name;
 
-    public function __construct($name)
+    /**
+     * @Type("DateTime<'U','UTC'>")
+     */
+    private $birthday;
+
+    public function __construct($name, $birthday = null)
     {
         $this->name = $name;
+        $this->birthday = $birthday;
     }
 
     public function getName()
     {
         return $this->name;
+    }
+
+    public function getBirthday()
+    {
+        return $this->birthday;
     }
 }

--- a/tests/JMS/Serializer/Tests/Serializer/BaseSerializationTest.php
+++ b/tests/JMS/Serializer/Tests/Serializer/BaseSerializationTest.php
@@ -288,7 +288,7 @@ abstract class BaseSerializationTest extends \PHPUnit_Framework_TestCase
 
     public function testBlogPost()
     {
-        $post = new BlogPost('This is a nice title.', $author = new Author('Foo Bar'), new \DateTime('2011-07-30 00:00', new \DateTimeZone('UTC')));
+        $post = new BlogPost('This is a nice title.', $author = new Author('Foo Bar', new \DateTime('1960-01-01 00:00', new \DateTimeZone('UTC'))), new \DateTime('2011-07-30 00:00', new \DateTimeZone('UTC')));
         $post->addComment($comment = new Comment($author, 'foo'));
 
         $this->assertEquals($this->getContent('blog_post'), $this->serialize($post));

--- a/tests/JMS/Serializer/Tests/Serializer/JsonSerializationTest.php
+++ b/tests/JMS/Serializer/Tests/Serializer/JsonSerializationTest.php
@@ -49,7 +49,7 @@ class JsonSerializationTest extends BaseSerializationTest
             $outputs['array_floats'] = '[1.34,3,6.42]';
             $outputs['array_objects'] = '[{"foo":"foo","moo":"bar","camel_case":"boo"},{"foo":"baz","moo":"boo","camel_case":"boo"}]';
             $outputs['array_mixed'] = '["foo",1,true,{"foo":"foo","moo":"bar","camel_case":"boo"},[1,3,true]]';
-            $outputs['blog_post'] = '{"title":"This is a nice title.","created_at":"2011-07-30T00:00:00+0000","is_published":false,"comments":[{"author":{"full_name":"Foo Bar"},"text":"foo"}],"comments2":[{"author":{"full_name":"Foo Bar"},"text":"foo"}],"metadata":{"foo":"bar"},"author":{"full_name":"Foo Bar"}}';
+            $outputs['blog_post'] = '{"title":"This is a nice title.","created_at":"2011-07-30T00:00:00+0000","is_published":false,"comments":[{"author":{"full_name":"Foo Bar","birthday":"-315619200"},"text":"foo"}],"comments2":[{"author":{"full_name":"Foo Bar","birthday":"-315619200"},"text":"foo"}],"metadata":{"foo":"bar"},"author":{"full_name":"Foo Bar","birthday":"-315619200"}}';
             $outputs['blog_post_unauthored'] = '{"title":"This is a nice title.","created_at":"2011-07-30T00:00:00+0000","is_published":false,"comments":[],"comments2":[],"metadata":{"foo":"bar"},"author":null}';
             $outputs['price'] = '{"price":3}';
             $outputs['currency_aware_price'] = '{"currency":"EUR","amount":2.34}';

--- a/tests/JMS/Serializer/Tests/Serializer/xml/blog_post.xml
+++ b/tests/JMS/Serializer/Tests/Serializer/xml/blog_post.xml
@@ -4,12 +4,14 @@
   <comment>
     <author>
       <full_name><![CDATA[Foo Bar]]></full_name>
+      <birthday><![CDATA[-315619200]]></birthday>
     </author>
     <text><![CDATA[foo]]></text>
   </comment>
   <comment2>
     <author>
       <full_name><![CDATA[Foo Bar]]></full_name>
+      <birthday><![CDATA[-315619200]]></birthday>
     </author>
     <text><![CDATA[foo]]></text>
   </comment2>
@@ -18,5 +20,6 @@
   </metadata>
   <author>
     <full_name><![CDATA[Foo Bar]]></full_name>
+    <birthday><![CDATA[-315619200]]></birthday>
   </author>
 </blog-post>

--- a/tests/JMS/Serializer/Tests/Serializer/yml/blog_post.yml
+++ b/tests/JMS/Serializer/Tests/Serializer/yml/blog_post.yml
@@ -5,13 +5,16 @@ comments:
     -
         author:
             full_name: 'Foo Bar'
+            birthday: '-315619200'
         text: foo
 comments2:
     -
         author:
             full_name: 'Foo Bar'
+            birthday: '-315619200'
         text: foo
 metadata:
     foo: bar
 author:
     full_name: 'Foo Bar'
+    birthday: '-315619200'


### PR DESCRIPTION
When dates are prior to Unix Epoch (January 1 1970), timestamps are negative.

When `DateHandler` performs a `DateTime::createFromFormat('U', $negativeTimestamp)` false is returned and and exception is thrown. It seems a PHP bug not supporting these negative timestamps on the `createFromFormat` method.

If you try this example, it works perfectly.

``` php
$a = DateTime::createFromFormat('Y-m-d H:i:s', date('Y-m-d H:i:s', -315619200));
```

I made tests fail, do you think we can create a workaround to patch this PHP issue?
