### PR TITLE
Fixed problem with Warning: array_key_exists() expects parameter 2 to be...

### DIFF
--- a/src/JMS/Serializer/GenericDeserializationVisitor.php
+++ b/src/JMS/Serializer/GenericDeserializationVisitor.php
@@ -162,7 +162,7 @@ abstract class GenericDeserializationVisitor extends AbstractVisitor
     {
         $name = $this->namingStrategy->translateName($metadata);
 
-        if (null === $data || ! array_key_exists($name, $data)) {
+        if (null === $data || !is_array($data) || ! array_key_exists($name, $data)) {
             return;
         }
 


### PR DESCRIPTION
When property of object is type of antoher object and input data is not array then warning of array_key_exists is thrown. 

I've added checking is data is array.
It has been fixed some time ago (https://github.com/thomasquiroga/serializer/commit/a636e3c03485a81388fc2f8b374e33e080df3e20) but in some way gone.