### PR TITLE
xml_attribute_map fix for the yaml driver

### DIFF
--- a/src/JMS/Serializer/Metadata/Driver/YamlDriver.php
+++ b/src/JMS/Serializer/Metadata/Driver/YamlDriver.php
@@ -167,7 +167,7 @@ class YamlDriver extends AbstractFileDriver
                     }
 
                     if (isset($pConfig['xml_attribute_map'])) {
-                        $pMetadata->xmlAttribute = (Boolean) $pConfig['xml_attribute_map'];
+                        $pMetadata->xmlAttributeMap = (Boolean) $pConfig['xml_attribute_map'];
                     }
 
                     if (isset($pConfig['xml_value'])) {


### PR DESCRIPTION
There is a slight error in the yaml driver for the attribute xml_attribute_map as you can see
