### PR TITLE
Add Doctrine\ODM\PHPCR\ChildrenCollection to ArrayCollectionHandler

### DIFF
--- a/src/JMS/Serializer/Handler/ArrayCollectionHandler.php
+++ b/src/JMS/Serializer/Handler/ArrayCollectionHandler.php
@@ -31,7 +31,13 @@ class ArrayCollectionHandler implements SubscribingHandlerInterface
     {
         $methods = array();
         $formats = array('json', 'xml', 'yml');
-        $collectionTypes = array('ArrayCollection', 'Doctrine\Common\Collections\ArrayCollection', 'Doctrine\ORM\PersistentCollection', 'Doctrine\ODM\MongoDB\PersistentCollection', 'Doctrine\ODM\PHPCR\ChildrenCollection');
+        $collectionTypes = array(
+            'ArrayCollection',
+            'Doctrine\Common\Collections\ArrayCollection',
+            'Doctrine\ORM\PersistentCollection',
+            'Doctrine\ODM\MongoDB\PersistentCollection',
+            'Doctrine\ODM\PHPCR\ChildrenCollection'
+        );
 
         foreach ($collectionTypes as $type) {
             foreach ($formats as $format) {


### PR DESCRIPTION
Using PHPCR ODM I ran into an issue where it tries to serialize [PHPCRs ChildrenCollection](https://github.com/doctrine/phpcr-odm/blob/master/lib/Doctrine/ODM/PHPCR/ChildrenCollection.php).

@schmittjoh: Should I multiline the array?
