### PR TITLE
Fix XML null DateTime deserialization

### DIFF
--- a/src/JMS/Serializer/Handler/DateHandler.php
+++ b/src/JMS/Serializer/Handler/DateHandler.php
@@ -2,13 +2,13 @@
 
 /*
  * Copyright 2013 Johannes M. Schmitt <schmittjoh@gmail.com>
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -75,9 +75,8 @@ class DateHandler implements SubscribingHandlerInterface
 
     public function deserializeDateTimeFromXml(XmlDeserializationVisitor $visitor, $data, array $type)
     {
-        $attributes = $data->attributes();
-        if ((isset($attributes['nil'][0]) && (string) $attributes['nil'][0] === 'true') ||
-            (isset($attributes['xsi:nil'][0]) && (string) $attributes['xsi:nil'][0] === 'true')) {
+        $attributes = $data->attributes('xsi', true);
+        if (isset($attributes['nil'][0]) && (string) $attributes['nil'][0] === 'true') {
             return null;
         }
 


### PR DESCRIPTION
Tests fail on XML deserialization of null value for DateTime type. 
XML nil is not detected due to invalid namespaced atributes fetching
