### PR TITLE
bignum little fix for GenericSerializationVisitor::visitInteger

### DIFF
--- a/src/JMS/Serializer/GenericSerializationVisitor.php
+++ b/src/JMS/Serializer/GenericSerializationVisitor.php
@@ -73,7 +73,7 @@ abstract class GenericSerializationVisitor extends AbstractVisitor
             $this->root = $data;
         }
 
-        return (int) $data;
+        return is_numeric($data) ? $data :(int)$data;
     }
 
     public function visitDouble($data, array $type, Context $context)


### PR DESCRIPTION
sorry for my english. I have big numbers from my database (4957872600 and etc) and simple (int) make numbers in PHP_INT_MAX. I don't know is my choice best, but it works.
