### PR TITLE
Discriminator related metadata overwritten by subsequent MetadataDriver in DriverChain

### DIFF
--- a/src/JMS/Serializer/Metadata/ClassMetadata.php
+++ b/src/JMS/Serializer/Metadata/ClassMetadata.php
@@ -155,6 +155,15 @@ class ClassMetadata extends MergeableClassMetadata
                 $this->discriminatorBaseClass
             ));
         }
+        
+        //Respect already configured discriminator related settings, after which they can be processed
+        $this->discriminatorDisabled = $object->discriminatorDisabled;
+        $this->discriminatorDisabled = $object->discriminatorDisabled;
+        $this->discriminatorBaseClass = $object->discriminatorBaseClass;
+        $this->discriminatorFieldName = $object->discriminatorFieldName;
+        $this->discriminatorValue = $object->discriminatorValue;
+        $this->discriminatorMap = array_merge($this->discriminatorMap, $object->discriminatorMap);
+        
 
         if ($this->discriminatorMap && ! $this->reflection->isAbstract()) {
             if (false === $typeValue = array_search($this->name, $this->discriminatorMap, true)) {

--- a/src/JMS/Serializer/Metadata/ClassMetadata.php
+++ b/src/JMS/Serializer/Metadata/ClassMetadata.php
@@ -158,7 +158,6 @@ class ClassMetadata extends MergeableClassMetadata
         
         //Respect already configured discriminator related settings, after which they can be processed
         $this->discriminatorDisabled = $object->discriminatorDisabled;
-        $this->discriminatorDisabled = $object->discriminatorDisabled;
         $this->discriminatorBaseClass = $object->discriminatorBaseClass;
         $this->discriminatorFieldName = $object->discriminatorFieldName;
         $this->discriminatorValue = $object->discriminatorValue;


### PR DESCRIPTION
While trying to configure discriminator-related settings for the serialization/deserialization using the XmlDriver which processes .xml files in a specified metadata directory, it seemed the indicated settings were lost somehow. 

It turned out they were overruled by the settings defined in the AnnotationDriver, which comes after the XmlDriver in the DriverChain:

```php
$metadataDriver = new DriverChain(array(
                new YamlDriver($fileLocator),
                new XmlDriver($fileLocator),
                new AnnotationDriver($annotationReader),
            ));
```

Settings that are already 'set' by the XmlDriver, are overruled by the AnnotationDriver, which results in 'empty' / null-like values. 

```php
["discriminatorDisabled"] => bool(false)
["discriminatorBaseClass"] => NULL
["discriminatorFieldName"] => NULL
["discriminatorValue"] => NULL
["discriminatorMap"] => array(0) {}
```

The ClassMetadata::merge() function seems not to respect the discriminator-related properties.

NOTE: for me this approach works, but additional testing might be appropriate!