### PR TITLE
Metadata filename convention added to yml/xml references

### DIFF
--- a/doc/reference/xml_reference.rst
+++ b/doc/reference/xml_reference.rst
@@ -2,7 +2,7 @@ XML Reference
 -------------
 ::
 
-    <!-- MyBundle\Resources\config\serializer\ClassName.xml -->
+    <!-- MyBundle\Resources\config\serializer\Fully.Qualified.ClassName.xml -->
     <?xml version="1.0" encoding="UTF-8" ?>
     <serializer>
         <class name="Fully\Qualified\ClassName" exclusion-policy="ALL" xml-root-name="foo-bar" exclude="true"

--- a/doc/reference/yml_reference.rst
+++ b/doc/reference/yml_reference.rst
@@ -2,7 +2,7 @@ YAML Reference
 --------------
 ::
 
-    # MyBundle\Resources\config\serializer\ClassName.yml
+    # MyBundle\Resources\config\serializer\Fully.Qualified.ClassName.yml
     Fully\Qualified\ClassName:
         exclusion_policy: ALL
         xml_root_name: foobar


### PR DESCRIPTION
This confused me while using JMSSerializerBundle in my Symfony projects. Metadata filename must follow a convention wich is explained but not used in the yml/xml references
