### PR TITLE
Throw JsonErrorException when `json_encode()` fails

### DIFF
--- a/src/JMS/Serializer/Exception/JsonErrorException.php
+++ b/src/JMS/Serializer/Exception/JsonErrorException.php
@@ -43,9 +43,7 @@ class JsonErrorException extends RuntimeException
 
     private static function getLastErrorMessage()
     {
-        // PHP 5.5.0 has a new function 'json_last_error_msg' which provides the
-        // error message from the last json error. This should be used in place
-        // of this function where possible.
+        // >= PHP 5.5
         if (function_exists('json_last_error_msg')) {
             return json_last_error_msg();
         }
@@ -63,16 +61,10 @@ class JsonErrorException extends RuntimeException
                 return 'Control character error, possibly incorrectly encoded';
             case JSON_ERROR_SYNTAX:
                 return 'Syntax error';
-        }
-
-        // Any PHP versions less than 5.3.3 won't have access to these constants
-        if (version_compare(phpversion(), '5.3.3', '>=')) {
-            if ($code === JSON_ERROR_UTF8) {
+            case JSON_ERROR_UTF8:
                 return 'Malformed UTF-8 characters, possibly incorrectly encoded';
-            }
+            default:
+                return "Unknown error ($code)";
         }
-
-        // Other codes are unknown
-        return "Unknown error ($code)";
     }
 }

--- a/src/JMS/Serializer/Exception/JsonErrorException.php
+++ b/src/JMS/Serializer/Exception/JsonErrorException.php
@@ -66,12 +66,10 @@ class JsonErrorException extends RuntimeException
         }
 
         // Any PHP versions less than 5.3.3 won't have access to these constants
-        if (version_compare(phpversion(), '5.3.3', '<')) {
-            return null;
-        }
-
-        if ($code === JSON_ERROR_UTF8) {
-            return 'Malformed UTF-8 characters, possibly incorrectly encoded';
+        if (version_compare(phpversion(), '5.3.3', '>=')) {
+            if ($code === JSON_ERROR_UTF8) {
+                return 'Malformed UTF-8 characters, possibly incorrectly encoded';
+            }
         }
 
         // Other codes are unknown

--- a/src/JMS/Serializer/Exception/JsonErrorException.php
+++ b/src/JMS/Serializer/Exception/JsonErrorException.php
@@ -1,0 +1,80 @@
+<?php
+
+/*
+ * Copyright 2013 Johannes M. Schmitt <schmittjoh@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace JMS\Serializer\Exception;
+
+/**
+ * JSON Error Exception
+ *
+ * Encapsulates an error which occured when serializing data into a string using
+ * the json_encode() method or deserializing using the json_decode() method.
+ *
+ * @author Josiah <josiah@jjs.id.au>
+ */
+class JsonErrorException extends RuntimeException
+{
+    /**
+     * Returns a new exception from the last json error
+     * 
+     * @return JsonErrorException
+     */
+    public static function fromLastError()
+    {
+        $code = json_last_error();
+        $message = static::getLastErrorMessage();
+
+        return new static($message, $code);
+    }
+
+    private static function getLastErrorMessage()
+    {
+        // PHP 5.5.0 has a new function 'json_last_error_msg' which provides the
+        // error message from the last json error. This should be used in place
+        // of this function where possible.
+        if (function_exists('json_last_error_msg')) {
+            return json_last_error_msg();
+        }
+
+        $code = json_last_error();
+
+        switch ($code) {
+            case JSON_ERROR_NONE:
+                return null;
+            case JSON_ERROR_DEPTH:
+                return 'The maximum stack depth has been exceeded';
+            case JSON_ERROR_STATE_MISMATCH:
+                return 'Invalid or malformed JSON';
+            case JSON_ERROR_CTRL_CHAR:
+                return 'Control character error, possibly incorrectly encoded';
+            case JSON_ERROR_SYNTAX:
+                return 'Syntax error';
+        }
+
+        // Any PHP versions less than 5.3.3 won't have access to these constants
+        if (version_compare(phpversion(), '5.3.3', '<')) {
+            return null;
+        }
+
+        if ($code === JSON_ERROR_UTF8) {
+            return 'Malformed UTF-8 characters, possibly incorrectly encoded';
+        }
+
+        // Other codes are unknown
+        return "Unknown error ($code)";
+    }
+}

--- a/src/JMS/Serializer/JsonDeserializationVisitor.php
+++ b/src/JMS/Serializer/JsonDeserializationVisitor.php
@@ -18,7 +18,7 @@
 
 namespace JMS\Serializer;
 
-use JMS\Serializer\Exception\RuntimeException;
+use JMS\Serializer\Exception\JsonErrorException;
 
 class JsonDeserializationVisitor extends GenericDeserializationVisitor
 {
@@ -31,22 +31,22 @@ class JsonDeserializationVisitor extends GenericDeserializationVisitor
                 return $decoded;
 
             case JSON_ERROR_DEPTH:
-                throw new RuntimeException('Could not decode JSON, maximum stack depth exceeded.');
+                throw new JsonErrorException('Could not decode JSON, maximum stack depth exceeded.');
 
             case JSON_ERROR_STATE_MISMATCH:
-                throw new RuntimeException('Could not decode JSON, underflow or the nodes mismatch.');
+                throw new JsonErrorException('Could not decode JSON, underflow or the nodes mismatch.');
 
             case JSON_ERROR_CTRL_CHAR:
-                throw new RuntimeException('Could not decode JSON, unexpected control character found.');
+                throw new JsonErrorException('Could not decode JSON, unexpected control character found.');
 
             case JSON_ERROR_SYNTAX:
-                throw new RuntimeException('Could not decode JSON, syntax error - malformed JSON.');
+                throw new JsonErrorException('Could not decode JSON, syntax error - malformed JSON.');
 
             case JSON_ERROR_UTF8:
-                throw new RuntimeException('Could not decode JSON, malformed UTF-8 characters (incorrectly encoded?)');
+                throw new JsonErrorException('Could not decode JSON, malformed UTF-8 characters (incorrectly encoded?)');
 
             default:
-                throw new RuntimeException('Could not decode JSON.');
+                throw new JsonErrorException('Could not decode JSON.');
         }
     }
 }

--- a/src/JMS/Serializer/JsonSerializationVisitor.php
+++ b/src/JMS/Serializer/JsonSerializationVisitor.php
@@ -19,6 +19,7 @@
 namespace JMS\Serializer;
 
 use JMS\Serializer\Metadata\ClassMetadata;
+use JMS\Serializer\Exception\JsonErrorException;
 
 class JsonSerializationVisitor extends GenericSerializationVisitor
 {
@@ -26,7 +27,14 @@ class JsonSerializationVisitor extends GenericSerializationVisitor
 
     public function getResult()
     {
-        return json_encode($this->getRoot(), $this->options);
+        $result = json_encode($this->getRoot(), $this->options);
+
+        // When JSON serialization fails an exception will be thrown
+        if (false === $result) {
+            throw JsonErrorException::fromLastError();
+        }
+
+        return $result;
     }
 
     public function getOptions()

--- a/src/JMS/Serializer/JsonSerializationVisitor.php
+++ b/src/JMS/Serializer/JsonSerializationVisitor.php
@@ -27,7 +27,12 @@ class JsonSerializationVisitor extends GenericSerializationVisitor
 
     public function getResult()
     {
-        $result = json_encode($this->getRoot(), $this->options);
+        $root = $this->getRoot();
+        $options = $this->options;
+
+        // Errors intentionally suppressed here to deliver consistency across
+        // PHP versions (PHP 5.5 does not emit warnings when encoding fails)
+        $result = @json_encode($root, $options);
 
         // When JSON serialization fails an exception will be thrown
         if (false === $result) {

--- a/tests/JMS/Serializer/Tests/Serializer/JsonSerializationVisitorTest.php
+++ b/tests/JMS/Serializer/Tests/Serializer/JsonSerializationVisitorTest.php
@@ -39,7 +39,7 @@ class JsonSerializationVisitorTest extends \PHPUnit_Framework_TestCase
         $data[] = $data;
 
         $visitor = $this->getMockBuilder('JMS\Serializer\JsonSerializationVisitor')
-            ->setMethods(['getRoot'])
+            ->setMethods(array('getRoot'))
             ->disableOriginalConstructor()
             ->getMock();
         $visitor

--- a/tests/JMS/Serializer/Tests/Serializer/JsonSerializationVisitorTest.php
+++ b/tests/JMS/Serializer/Tests/Serializer/JsonSerializationVisitorTest.php
@@ -1,0 +1,53 @@
+<?php
+
+/*
+ * Copyright 2013 Johannes M. Schmitt <schmittjoh@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace JMS\Serializer\Tests\Serializer;
+
+use JMS\Serializer\JsonSerializationVisitor;
+
+class JsonSerializationVisitorTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * Tests that an exception is thrown when the PHP `json_encode` method fails
+     * to serialize the data.
+     *
+     * This is a rare but possible occurance. The cause of the serialization
+     * failure is invariably the data which is being serialized, however in
+     * certain edge cases the serializer doesn't catch the issue which cased the
+     * json serialization error.
+     *
+     * @expectedException JMS\Serializer\Exception\JsonErrorException
+     */
+    public function testExceptionThrownOnJsonFailure()
+    {
+        $data = new \ArrayObject([]);
+        $data[] = $data;
+
+        $visitor = $this->getMockBuilder('JMS\Serializer\JsonSerializationVisitor')
+            ->setMethods(['getRoot'])
+            ->disableOriginalConstructor()
+            ->getMock();
+        $visitor
+            ->expects($this->once())
+            ->method('getRoot')
+            ->with()
+            ->will($this->returnValue($data));
+
+        $visitor->getResult();
+    }
+}

--- a/tests/JMS/Serializer/Tests/Serializer/JsonSerializationVisitorTest.php
+++ b/tests/JMS/Serializer/Tests/Serializer/JsonSerializationVisitorTest.php
@@ -35,7 +35,7 @@ class JsonSerializationVisitorTest extends \PHPUnit_Framework_TestCase
      */
     public function testExceptionThrownOnJsonFailure()
     {
-        $data = new \ArrayObject([]);
+        $data = new \ArrayObject(array());
         $data[] = $data;
 
         $visitor = $this->getMockBuilder('JMS\Serializer\JsonSerializationVisitor')

--- a/tests/JMS/Serializer/Tests/Serializer/JsonSerializationVisitorTest.php
+++ b/tests/JMS/Serializer/Tests/Serializer/JsonSerializationVisitorTest.php
@@ -23,15 +23,8 @@ use JMS\Serializer\JsonSerializationVisitor;
 class JsonSerializationVisitorTest extends \PHPUnit_Framework_TestCase
 {
     /**
-     * Tests that an exception is thrown when the PHP `json_encode` method fails
-     * to serialize the data.
-     *
-     * This is a rare but possible occurance. The cause of the serialization
-     * failure is invariably the data which is being serialized, however in
-     * certain edge cases the serializer doesn't catch the issue which cased the
-     * json serialization error.
-     *
      * @expectedException JMS\Serializer\Exception\JsonErrorException
+     * @expectedExceptionMessage Recursion detected
      */
     public function testExceptionThrownOnJsonFailure()
     {


### PR DESCRIPTION
Currently when the PHP built-in method json_encode() as part of the `JsonSerializationVisitor` fails it does so silently and returns false instead of the JSON encoded string.

To make it simpler to debug situations which cause this error I have added a `JsonErrorException` which is thrown containing the error reported by json_last_error().

New unit test supplied which covers added code, all tests passing.