### PR TITLE
Added the support for class inheritance and skipping handlers

### DIFF
--- a/src/JMS/Serializer/Exception/SkipStepException.php
+++ b/src/JMS/Serializer/Exception/SkipStepException.php
@@ -1,0 +1,27 @@
+<?php
+
+/*
+ * Copyright 2013 Johannes M. Schmitt <schmittjoh@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace JMS\Serializer\Exception;
+
+/**
+ * @author Kinn Coelho Julião <kinncj@gmail.com>
+ * @author Juti Noppornpitak <shiroyuki@gmail.com>
+ */
+class SkipStepException extends RuntimeException
+{
+}

--- a/src/JMS/Serializer/GraphNavigator.php
+++ b/src/JMS/Serializer/GraphNavigator.php
@@ -28,6 +28,7 @@ use JMS\Serializer\EventDispatcher\EventDispatcherInterface;
 use JMS\Serializer\Metadata\ClassMetadata;
 use Metadata\MetadataFactoryInterface;
 use JMS\Serializer\Exception\InvalidArgumentException;
+use JMS\Serializer\Exception\SkipStepException;
 
 /**
  * Handles traversal along the object graph.
@@ -169,10 +170,12 @@ final class GraphNavigator
                 // before loading metadata because the type name might not be a class, but
                 // could also simply be an artifical type.
                 if (null !== $handler = $this->handlerRegistry->getHandler($context->getDirection(), $type['name'], $context->getFormat())) {
-                    $rs = call_user_func($handler, $visitor, $data, $type, $context);
-                    $this->leaveScope($context, $data);
+                    try {
+                        $rs = call_user_func($handler, $visitor, $data, $type, $context);
+                        $this->leaveScope($context, $data);
 
-                    return $rs;
+                        return $rs;
+                    } catch (SkipStepException $e) {}
                 }
 
                 $exclusionStrategy = $context->getExclusionStrategy();


### PR DESCRIPTION
(Originally submitted as #175)

This PR is to add the support to allow the handler to tell the graph navigator to skip itself and proceed with the normal procedure. For instance,

``` php
use PhpOption\None;

class MyHandler implements SubscribingHandlerInterface
{
    public function serializeProxy(JsonSerializationVisitor $visitor, $entity, array $type, Context $context)
    {
        if ($visitor->getRoot() === null) {
            throw new SkipStepException('Skip This');
        }

        return array(/* ... */);
    }
}
```

Also, this PR _supports the class inheritance_ such that we can specify a parent class in `getSubscribingMethods`. For instance,

``` php
class MyHandler implements SubscribingHandlerInterface
{
    public static function getSubscribingMethods()
    {
        return array(
            array(
                'direction' => GraphNavigator::DIRECTION_SERIALIZATION,
                'format' => 'json',
                'type' => 'EntityParentClassOrInterface',
                'method' => 'serializeProxy',
            ),
        );
    }

    public function serializeProxy(JsonSerializationVisitor $visitor, $entity, array $type, Context $context)
    {
        /* ... */
    }
}
```
