### PR TITLE
Avoided to get circular reference for empty object in array

### DIFF
--- a/src/JMS/Serializer/GenericSerializationVisitor.php
+++ b/src/JMS/Serializer/GenericSerializationVisitor.php
@@ -105,7 +105,7 @@ abstract class GenericSerializationVisitor extends AbstractVisitor
                 continue;
             }
 
-            $rs[$k] = $v;
+            $rs[$k] = $rs !== $v ? $v : clone $v;
         }
 
         return $rs;


### PR DESCRIPTION
If I have tried to serialize array with empty objects (or serialized map exclude all properties), I catch the circular reference.