### PR TITLE
Simplifying Util/Writer indentation

### DIFF
--- a/src/JMS/Serializer/Util/Writer.php
+++ b/src/JMS/Serializer/Util/Writer.php
@@ -29,7 +29,7 @@ use JMS\Serializer\Exception\RuntimeException;
  */
 class Writer
 {
-    public $indentationSpaces = 4;
+    public $indentationUnit = '    ';
     public $indentationLevel = 0;
     public $content = '';
     public $changeCount = 0;
@@ -87,7 +87,7 @@ class Writer
             if ($this->indentationLevel > 0
                 && !empty($lines[$i])
                 && ((empty($addition) && "\n" === substr($this->content, -1)) || "\n" === substr($addition, -1))) {
-                $addition .= str_repeat(' ', $this->indentationLevel * $this->indentationSpaces);
+                $addition .= str_repeat($this->indentationUnit, $this->indentationLevel);
             }
 
             $addition .= $lines[$i];

--- a/src/JMS/Serializer/Util/Writer.php
+++ b/src/JMS/Serializer/Util/Writer.php
@@ -36,16 +36,26 @@ class Writer
 
     private $changes = array();
 
-    public function indent()
+    /**
+     * @param integer $amount
+     * 
+     * @return $this
+     */
+    public function indent($amount = 1)
     {
-        $this->indentationLevel += 1;
+        $this->indentationLevel += $amount;
 
         return $this;
     }
 
-    public function outdent()
+    /**
+     * @param integer $amount
+     * 
+     * @return $this
+     */
+    public function outdent($amount = 1)
     {
-        $this->indentationLevel -= 1;
+        $this->indentationLevel -= $amount;
 
         if ($this->indentationLevel < 0) {
             throw new RuntimeException('The identation level cannot be less than zero.');

--- a/src/JMS/Serializer/Util/Writer.php
+++ b/src/JMS/Serializer/Util/Writer.php
@@ -145,6 +145,13 @@ class Writer
         return $this->content;
     }
 
+    public function __get($name)
+    {
+        if ($name === 'indentationSpaces') {
+            return strlen($this->indentationUnit);
+        }
+    }
+
     public function __set($name, $value)
     {
         if ($name === 'indentationSpaces') {

--- a/src/JMS/Serializer/Util/Writer.php
+++ b/src/JMS/Serializer/Util/Writer.php
@@ -150,6 +150,8 @@ class Writer
         if ($name === 'indentationSpaces') {
             return strlen($this->indentationUnit);
         }
+        
+        return $this->{$name};
     }
 
     public function __set($name, $value)
@@ -157,5 +159,7 @@ class Writer
         if ($name === 'indentationSpaces') {
             $this->indentationUnit = str_repeat(' ', $value);
         }
+        
+        $this->{$name} = $value;
     }
 }

--- a/src/JMS/Serializer/Util/Writer.php
+++ b/src/JMS/Serializer/Util/Writer.php
@@ -144,4 +144,11 @@ class Writer
     {
         return $this->content;
     }
+
+    public function __set($name, $value)
+    {
+        if ($name === 'indentationSpaces') {
+            $this->indentationUnit = str_repeat(' ', $value);
+        }
+    }
 }


### PR DESCRIPTION
Using `$indentationUnit * $indentationLevel` instead of `' ' * $indentationSpaces * $indentationLevel`

Additionally, this allows to indent with different characters, like tabs for example. Or in my case, comas or some other delimiter for CSV files.

By default, $indentationUnit is 4 spaces, just like before.