### PR TITLE
Option in serialization context to choose if the type annotation must be...

### DIFF
--- a/src/JMS/Serializer/GraphNavigator.php
+++ b/src/JMS/Serializer/GraphNavigator.php
@@ -88,6 +88,15 @@ final class GraphNavigator
     {
         $visitor = $context->getVisitor();
 
+        // When serializing, if the type is an abstract class, check the option in the context to
+        // know if this annotation must be ignored
+        if ($context instanceof SerializationContext && gettype($data) === 'object' && $type !== null) {
+            $rc = new \ReflectionClass($type['name']);
+            if ($rc->isAbstract() && $context->isAbstractClassTypeIgnored()) {
+                $type = null;
+            }
+        }
+
         // If the type was not given, we infer the most specific type from the
         // input data in serialization mode.
         if (null === $type) {

--- a/src/JMS/Serializer/SerializationContext.php
+++ b/src/JMS/Serializer/SerializationContext.php
@@ -30,6 +30,12 @@ class SerializationContext extends Context
     /** @var \SplStack */
     private $visitingStack;
 
+    /**
+     * True if the Type annotation must be ignored when it is an abstract class.
+     * @var boolean
+     */
+    private $abstractClassTypeIgnored = false;
+
     public static function create()
     {
         return new self();
@@ -108,5 +114,15 @@ class SerializationContext extends Context
     public function getVisitingSet()
     {
         return $this->visitingSet;
+    }
+
+    public function setAbstractClassTypeIgnored($abstractClassTypeIgnored)
+    {
+        $this->abstractClassTypeIgnored = $abstractClassTypeIgnored;
+    }
+
+    public function isAbstractClassTypeIgnored()
+    {
+        return $this->abstractClassTypeIgnored;
     }
 }


### PR DESCRIPTION
... ignored in the case of an abstract class.

I'm not sure the best way to do is to add this code in GraphNavigator. But I propose this pull request to get your opinion.

I posted an issue called "Serializing an object that contains an abstract class" to describe the use case.
