### PR TITLE
@XmlElement notation consistency

### DIFF
--- a/doc/reference/xml_reference.rst
+++ b/doc/reference/xml_reference.rst
@@ -27,14 +27,13 @@ XML Reference
                       xml-key-value-pairs="true"
                       xml-attribute-map="true"
                       max-depth="2"
-                      xml-namespace="http://www.w3.org/2005/Atom"
             >
                 <!-- You can also specify the type as element which is necessary if
                      your type contains "<" or ">" characters. -->
                 <type><![CDATA[]]></type>
                 <xml-list inline="true" entry-name="foobar" />
                 <xml-map inline="true" key-attribute-name="foo" entry-name="bar" />
-                <xml-element cdata="false" />
+                <xml-element cdata="false" namespace="http://www.w3.org/2005/Atom"/>
             </property>
             <callback-method name="foo" type="pre-serialize" />
             <callback-method name="bar" type="post-serialize" />

--- a/doc/reference/yml_reference.rst
+++ b/doc/reference/yml_reference.rst
@@ -47,8 +47,8 @@ YAML Reference
                 xml_attribute_map: true
                 xml_element:
                     cdata: false
+                    namespace: http://www.w3.org/2005/Atom
                 max_depth: 2
-                xml_namespace: http://www.w3.org/2005/Atom
 
         handler_callbacks:
             serialization:

--- a/src/JMS/Serializer/Metadata/Driver/XmlDriver.php
+++ b/src/JMS/Serializer/Metadata/Driver/XmlDriver.php
@@ -154,10 +154,6 @@ class XmlDriver extends AbstractFileDriver
                     if (null !== $groups = $pElem->attributes()->groups) {
                         $pMetadata->groups =  preg_split('/\s*,\s*/', (string) $groups);
                     }
-
-                    if (null !== $xmlNamespace = $pElem->attributes()->{'xml-namespace'}) {
-                        $pMetadata->xmlNamespace = (string) $xmlNamespace;
-                    }
                     
                     if (isset($pElem->{'xml-list'})) {
                         $pMetadata->xmlCollection = true;
@@ -193,6 +189,10 @@ class XmlDriver extends AbstractFileDriver
                         $colConfig = $pElem->{'xml-element'};
                         if (isset($colConfig->attributes()->cdata)) {
                             $pMetadata->xmlElementCData = 'true' === (string) $colConfig->attributes()->cdata;
+                        }
+
+                        if (isset($colConfig->attributes()->namespace)) {
+                            $pMetadata->xmlNamespace = (string) $colConfig->attributes()->namespace;
                         }
                     }
 

--- a/src/JMS/Serializer/Metadata/Driver/YamlDriver.php
+++ b/src/JMS/Serializer/Metadata/Driver/YamlDriver.php
@@ -140,10 +140,6 @@ class YamlDriver extends AbstractFileDriver
                         $pMetadata->groups = $pConfig['groups'];
                     }
 
-                    if (isset($pConfig['xml_namespace'])) {
-                        $pMetadata->xmlNamespace = (string) $pConfig['xml_namespace'];
-                    }
-
                     if (isset($pConfig['xml_list'])) {
                         $pMetadata->xmlCollection = true;
 
@@ -178,6 +174,10 @@ class YamlDriver extends AbstractFileDriver
                         $colConfig = $pConfig['xml_element'];
                         if (isset($colConfig['cdata'])) {
                             $pMetadata->xmlElementCData = (Boolean) $colConfig['cdata'];
+                        }
+
+                        if (isset($colConfig['namespace'])) {
+                            $pMetadata->xmlNamespace = (string) $colConfig['namespace'];
                         }
                     }
 

--- a/tests/JMS/Serializer/Tests/Metadata/Driver/xml/BlogPost.xml
+++ b/tests/JMS/Serializer/Tests/Metadata/Driver/xml/BlogPost.xml
@@ -8,14 +8,20 @@
         <property name="id" type="string" groups="comments,post">
             <xml-element cdata="false"/>
         </property>
-        <property name="title" type="string" groups="comments,post" xml-namespace="http://purl.org/dc/elements/1.1/"/>
+        <property name="title" type="string" groups="comments,post">
+            <xml-element namespace="http://purl.org/dc/elements/1.1/"/>
+        </property>
         <property name="createdAt" xml-attribute="true" type="DateTime"/>
         <property name="published" type="boolean" serialized-name="is_published" xml-attribute="true" groups="post" />
-        <property name="etag" type="string" xml-attribute="true" xml-namespace="http://schemas.google.com/g/2005" groups="post" />
+        <property name="etag" type="string" xml-attribute="true" groups="post">
+            <xml-element namespace="http://schemas.google.com/g/2005"/>
+        </property>
         <property name="comments" groups="comments">
             <type><![CDATA[ArrayCollection<JMS\Serializer\Tests\Fixtures\Comment>]]></type>
             <xml-list inline="true" entry-name="comment" />
         </property>
-        <property name="author" groups="post" type="JMS\Serializer\Tests\Fixtures\Author" xml-namespace="http://www.w3.org/2005/Atom"/>
+        <property name="author" groups="post" type="JMS\Serializer\Tests\Fixtures\Author">
+            <xml-element namespace="http://www.w3.org/2005/Atom"/>
+        </property>
     </class>
 </serializer>

--- a/tests/JMS/Serializer/Tests/Metadata/Driver/xml/ObjectWithXmlNamespaces.xml
+++ b/tests/JMS/Serializer/Tests/Metadata/Driver/xml/ObjectWithXmlNamespaces.xml
@@ -4,10 +4,18 @@
         <xml-namespace uri="http://example.com/namespace"/>
         <xml-namespace prefix="gd" uri="http://schemas.google.com/g/2005"/>
         <xml-namespace prefix="atom" uri="http://www.w3.org/2005/Atom"/>
-        <property name="title" type="string" xml-namespace="http://purl.org/dc/elements/1.1/"/>
+        <property name="title" type="string">
+            <xml-element namespace="http://purl.org/dc/elements/1.1/"/>
+        </property>
         <property name="createdAt" xml-attribute="true" type="DateTime"/>
-        <property name="etag" type="string" xml-attribute="true" xml-namespace="http://schemas.google.com/g/2005"/>
-        <property name="author" type="string" xml-namespace="http://www.w3.org/2005/Atom"/>
-        <property name="language" type="string" xml-attribute="true" xml-namespace="http://purl.org/dc/elements/1.1/"/>
+        <property name="etag" type="string" xml-attribute="true">
+            <xml-element namespace="http://schemas.google.com/g/2005"/>
+        </property>
+        <property name="author" type="string">
+            <xml-element namespace="http://www.w3.org/2005/Atom"/>
+        </property>
+        <property name="language" type="string" xml-attribute="true">
+            <xml-element namespace="http://purl.org/dc/elements/1.1/"/>
+        </property>
     </class>
 </serializer>

--- a/tests/JMS/Serializer/Tests/Metadata/Driver/xml/SimpleClassObject.xml
+++ b/tests/JMS/Serializer/Tests/Metadata/Driver/xml/SimpleClassObject.xml
@@ -4,8 +4,14 @@
         <xml-namespace prefix="foo" uri="http://foo.example.org"/>
         <xml-namespace prefix="old_foo" uri="http://old.foo.example.org"/>
         <xml-namespace prefix="new_foo" uri="http://new.foo.example.org"/>
-        <property name="foo" type="string" xml-attribute="true" xml-namespace="http://old.foo.example.org"/>
-        <property name="bar" type="string" xml-namespace="http://foo.example.org"/>
-        <property name="moo" type="string" xml-namespace="http://new.foo.example.org"/>
+        <property name="foo" type="string" xml-attribute="true">
+            <xml-element namespace="http://old.foo.example.org"/>
+        </property>
+        <property name="bar" type="string">
+            <xml-element namespace="http://foo.example.org"/>
+        </property>
+        <property name="moo" type="string">
+            <xml-element namespace="http://new.foo.example.org"/>
+        </property>
     </class>
 </serializer>

--- a/tests/JMS/Serializer/Tests/Metadata/Driver/xml/SimpleSubClassObject.xml
+++ b/tests/JMS/Serializer/Tests/Metadata/Driver/xml/SimpleSubClassObject.xml
@@ -3,8 +3,14 @@
     <class name="JMS\Serializer\Tests\Fixtures\SimpleSubClassObject">
         <xml-namespace prefix="foo" uri="http://better.foo.example.org"/>
         <xml-namespace prefix="old_foo" uri="http://foo.example.org"/>
-        <property name="moo" type="string" xml-namespace="http://better.foo.example.org"/>
-        <property name="baz" type="string" xml-namespace="http://foo.example.org"/>
-        <property name="qux" type="string" xml-namespace="http://new.foo.example.org"/>
+        <property name="moo" type="string">
+            <xml-element namespace="http://better.foo.example.org"/>
+        </property>
+        <property name="baz" type="string">
+            <xml-element namespace="http://foo.example.org"/>
+        </property>
+        <property name="qux" type="string">
+            <xml-element namespace="http://new.foo.example.org"/>
+        </property>
     </class>
 </serializer>

--- a/tests/JMS/Serializer/Tests/Metadata/Driver/yml/BlogPost.yml
+++ b/tests/JMS/Serializer/Tests/Metadata/Driver/yml/BlogPost.yml
@@ -14,7 +14,8 @@ JMS\Serializer\Tests\Fixtures\BlogPost:
         title:
             type: string
             groups: [comments, post]
-            xml_namespace: http://purl.org/dc/elements/1.1/
+            xml_element:
+                namespace: http://purl.org/dc/elements/1.1/
         createdAt:
             type: DateTime
             xml_attribute: true
@@ -27,7 +28,8 @@ JMS\Serializer\Tests\Fixtures\BlogPost:
             type: string
             groups: [post]
             xml_attribute: true
-            xml_namespace: http://schemas.google.com/g/2005
+            xml_element:
+                namespace: http://schemas.google.com/g/2005
         comments:
             type: ArrayCollection<JMS\Serializer\Tests\Fixtures\Comment>
             groups: [comments]
@@ -37,4 +39,5 @@ JMS\Serializer\Tests\Fixtures\BlogPost:
         author:
             type: JMS\Serializer\Tests\Fixtures\Author
             groups: [post]
-            xml_namespace: http://www.w3.org/2005/Atom
+            xml_element:
+                namespace: http://www.w3.org/2005/Atom

--- a/tests/JMS/Serializer/Tests/Metadata/Driver/yml/ObjectWithXmlNamespaces.yml
+++ b/tests/JMS/Serializer/Tests/Metadata/Driver/yml/ObjectWithXmlNamespaces.yml
@@ -7,18 +7,22 @@ JMS\Serializer\Tests\Fixtures\ObjectWithXmlNamespaces:
     properties:
         title:
             type: string
-            xml_namespace: http://purl.org/dc/elements/1.1/
+            xml_element:
+                namespace: http://purl.org/dc/elements/1.1/
         createdAt:
             type: DateTime
             xml_attribute: true
         etag:
             type: string
             xml_attribute: true
-            xml_namespace: http://schemas.google.com/g/2005
+            xml_element:
+                namespace: http://schemas.google.com/g/2005
         author:
             type: string
-            xml_namespace: http://www.w3.org/2005/Atom
+            xml_element:
+                namespace: http://www.w3.org/2005/Atom
         language:
             type: string
             xml_attribute: true
-            xml_namespace: http://purl.org/dc/elements/1.1/
+            xml_element:
+                namespace: http://purl.org/dc/elements/1.1/

--- a/tests/JMS/Serializer/Tests/Metadata/Driver/yml/SimpleClassObject.yml
+++ b/tests/JMS/Serializer/Tests/Metadata/Driver/yml/SimpleClassObject.yml
@@ -7,10 +7,13 @@ JMS\Serializer\Tests\Fixtures\SimpleClassObject:
         foo:
             type: string
             xml_attribute: true
-            xml_namespace: http://old.foo.example.org
+            xml_element:
+                namespace: http://old.foo.example.org
         bar:
             type: string
-            xml_namespace: http://foo.example.org
+            xml_element:
+                namespace: http://foo.example.org
         moo:
             type: string
-            xml_namespace: http://new.foo.example.org
+            xml_element:
+                namespace: http://new.foo.example.org

--- a/tests/JMS/Serializer/Tests/Metadata/Driver/yml/SimpleSubClassObject.yml
+++ b/tests/JMS/Serializer/Tests/Metadata/Driver/yml/SimpleSubClassObject.yml
@@ -5,10 +5,13 @@ JMS\Serializer\Tests\Fixtures\SimpleSubClassObject:
     properties:
         moo:
             type: string
-            xml_namespace: http://better.foo.example.org
+            xml_element:
+                namespace: http://better.foo.example.org
         baz:
             type: string
-            xml_namespace: http://foo.example.org
+            xml_element:
+                namespace: http://foo.example.org
         qux:
             type: string
-            xml_namespace: http://new.foo.example.org
+            xml_element:
+                namespace: http://new.foo.example.org


### PR DESCRIPTION
When I opened the PR #58 there was no `@XmlElement` annotation defined, but the `@XmlElement` annotation was introduced in #187, before #58 was merged.

Now the `@XmlElement` has two properties: `cdata` and `namespace` which have different notations in Yaml and Xml mappings.

I think this could be fixed in order to improve consistency. What do you think about?
## Yaml
### Current notation

``` yml
JMS\Serializer\Tests\Fixtures\BlogPost:
    properties:
        author:
            type: JMS\Serializer\Tests\Fixtures\Author
            groups: [post]
            xml_namespace: http://www.w3.org/2005/Atom
            xml_element:
                cdata: false
```
### Proposed notations
#### Option 1

``` yaml
JMS\Serializer\Tests\Fixtures\BlogPost:
    properties:
        author:
            type: JMS\Serializer\Tests\Fixtures\Author
            groups: [post]
            xml_namespace: http://www.w3.org/2005/Atom
            xml_cdata: false
```
#### Option 2

``` yml
JMS\Serializer\Tests\Fixtures\BlogPost:
    properties:
        author:
            type: JMS\Serializer\Tests\Fixtures\Author
            groups: [post]
            xml_element:
                namespace: http://www.w3.org/2005/Atom
                cdata: false
```
## XML
### Current notation

``` xml
<serializer>
    <class name="JMS\Serializer\Tests\Fixtures\BlogPost" xml-root-name="blog-post">
        <property name="author" groups="post" type="JMS\Serializer\Tests\Fixtures\Author" xml-namespace="http://www.w3.org/2005/Atom">
            <xml-element cdata="false"/>
        </property>
    </class>
</serializer>
```
### Proposed notations
#### Option 1

``` xml
<serializer>
    <class name="JMS\Serializer\Tests\Fixtures\BlogPost" xml-root-name="blog-post">
        <property name="author" groups="post" type="JMS\Serializer\Tests\Fixtures\Author" xml-namespace="http://www.w3.org/2005/Atom" xml-cdata="false"/>
    </class>
</serializer>
```
#### Option 2

``` xml
<serializer>
    <class name="JMS\Serializer\Tests\Fixtures\BlogPost" xml-root-name="blog-post">
        <property name="author" groups="post" type="JMS\Serializer\Tests\Fixtures\Author">
            <xml-element cdata="false" namespace="http://www.w3.org/2005/Atom"/>
        </property>
    </class>
</serializer>
```
