### PR TITLE
New param to `configureHandlers()` to also add default handlers.

### DIFF
--- a/src/JMS/Serializer/SerializerBuilder.php
+++ b/src/JMS/Serializer/SerializerBuilder.php
@@ -121,9 +121,9 @@ class SerializerBuilder
         return $this;
     }
 
-    public function configureHandlers(\Closure $closure)
+    public function configureHandlers(\Closure $closure, $addDefaults = false)
     {
-        $this->handlersConfigured = true;
+        $this->handlersConfigured = !$addDefaults;
         $closure($this->handlerRegistry);
 
         return $this;

--- a/tests/JMS/Serializer/Tests/SerializerBuilderTest.php
+++ b/tests/JMS/Serializer/Tests/SerializerBuilderTest.php
@@ -114,6 +114,39 @@ class SerializerBuilderTest extends \PHPUnit_Framework_TestCase
         );
     }
 
+    public function testDefaultHandlersAreSet()
+    {
+        // default behavior
+        $builderMock = $this->getMockBuilder('JMS\Serializer\SerializerBuilder')
+            ->setMethods(array('addDefaultHandlers'))
+            ->getMock();
+
+        $builderMock->expects($this->never())
+            ->method('addDefaultHandlers');
+
+        $builderMock->configureHandlers(
+            function (\JMS\Serializer\Handler\HandlerRegistry $registry) {}
+        );
+
+        $builderMock->build();
+
+        // adding defaults
+        $builderMock = $this->getMockBuilder('JMS\Serializer\SerializerBuilder')
+            ->setMethods(array('addDefaultHandlers'))
+            ->getMock();
+
+        $builderMock->expects($this->once())
+            ->method('addDefaultHandlers')
+            ->will($this->returnSelf());
+
+        $builderMock->configureHandlers(
+            function (\JMS\Serializer\Handler\HandlerRegistry $registry) {},
+            true
+        );
+
+        $builderMock->build();
+    }
+
     protected function setUp()
     {
         $this->builder = SerializerBuilder::create();


### PR DESCRIPTION
The second parameter `$addDefaults` can be set to true.
Then the call to `addDefaultHandlers` can be ommitted when building
the Serializer.

The default behavior is not changing.

Test case added.
