### PR TITLE
Added test for leading backslash in front of class name to TypeParserTest

### DIFF
--- a/tests/JMS/Serializer/Tests/Serializer/TypeParserTest.php
+++ b/tests/JMS/Serializer/Tests/Serializer/TypeParserTest.php
@@ -83,6 +83,15 @@ class TypeParserTest extends \PHPUnit_Framework_TestCase
         $this->parser->parse('Foo<aa,>');
     }
 
+    /**
+     * @expectedException \JMS\Parser\SyntaxErrorException
+     * @expectedExceptionMessage  Expected any of T_NAME or T_STRING, but got "\" of type T_NONE at position 4 (0-based).
+     */
+    public function testLeadingBackslash()
+    {
+        $this->parser->parse('Foo<\Bar>');
+    }
+
     protected function setUp()
     {
         $this->parser = new TypeParser();


### PR DESCRIPTION
testLeadingBackslash added to check if there's a leading backslash in
front of a class name.

Signed-off-by: Alexander Kluth contact@alexanderkluth.com
