### PR TITLE
Fix for deserializing xml with unprefixed children in the default namespace.

### DIFF
--- a/src/JMS/Serializer/XmlDeserializationVisitor.php
+++ b/src/JMS/Serializer/XmlDeserializationVisitor.php
@@ -258,7 +258,8 @@ class XmlDeserializationVisitor extends AbstractVisitor
 
         if ('' !== $namespace = (string) $metadata->xmlNamespace) {
             $registeredNamespaces = $data->getDocNamespaces();
-            if (false === $prefix = array_search($namespace, $registeredNamespaces)) {
+            $prefix = array_search($namespace, $registeredNamespaces);
+            if (false === $prefix || "" === $prefix) {
                 $prefix = uniqid('ns-');
                 $data->registerXPathNamespace($prefix, $namespace);
             }

--- a/tests/JMS/Serializer/Tests/Fixtures/ObjectWithDefaultNamespace.php
+++ b/tests/JMS/Serializer/Tests/Fixtures/ObjectWithDefaultNamespace.php
@@ -1,0 +1,53 @@
+<?php
+/**
+ * @author Mike Lively <mike.lively@sellingsource.com>
+ */
+
+namespace JMS\Serializer\Tests\Fixtures;
+
+use JMS\Serializer\Annotation\Type;
+use JMS\Serializer\Annotation\XmlRoot;
+use JMS\Serializer\Annotation\XmlNamespace;
+use JMS\Serializer\Annotation\XmlElement;
+use JMS\Serializer\Annotation\XmlAttribute;
+
+/**
+ * @XmlRoot("test-object", namespace="http://example.com/namespace")
+ * @XmlNamespace(uri="http://example.com/namespace")
+ * @XmlNamespace(uri="http://example.com/namespace/v2", prefix="v2")
+ */
+class ObjectWithDefaultNamespace
+{
+    /**
+     * @Type("string")
+     * @XmlElement(namespace="http://example.com/namespace");
+     */
+    private $name;
+
+    /**
+     * @Type("string")
+     * @XmlAttribute(namespace="http://example.com/namespace");
+     */
+    private $color;
+
+    /**
+     * @Type("string")
+     * @XmlElement(namespace="http://example.com/namespace");
+     */
+    private $description;
+
+    /**
+     * @Type("string")
+     * @XmlElement(namespace="http://example.com/namespace/v2");
+     */
+    private $status;
+
+    public function __construct($name, $color, $description, $status)
+    {
+        $this->name = $name;
+        $this->color = $color;
+        $this->description = $description;
+        $this->status = $status;
+    }
+
+} 

--- a/tests/JMS/Serializer/Tests/Serializer/XmlSerializationTest.php
+++ b/tests/JMS/Serializer/Tests/Serializer/XmlSerializationTest.php
@@ -25,6 +25,7 @@ use JMS\Serializer\SerializationContext;
 use JMS\Serializer\Serializer;
 use JMS\Serializer\Tests\Fixtures\InvalidUsageOfXmlValue;
 use JMS\Serializer\Exception\InvalidArgumentException;
+use JMS\Serializer\Tests\Fixtures\ObjectWithDefaultNamespace;
 use JMS\Serializer\Tests\Fixtures\PersonCollection;
 use JMS\Serializer\Tests\Fixtures\PersonLocation;
 use JMS\Serializer\Tests\Fixtures\Person;
@@ -206,6 +207,19 @@ class XmlSerializationTest extends BaseSerializationTest
         $this->assertAttributeSame('1edf9bf60a32d89afbb85b2be849e3ceed5f5b10', 'etag', $deserialized);
         $this->assertAttributeSame('en', 'language', $deserialized);
         $this->assertAttributeEquals('Foo Bar', 'author', $deserialized);
+
+    }
+
+    /**
+     * @group tmp
+     */
+    public function testDeserializingXmlWithDefaultNamespace()
+    {
+        $deserialized = $this->deserialize($this->getContent('object_with_default_xml_namespace'), 'JMS\Serializer\Tests\Fixtures\ObjectWithDefaultNamespace');
+        $this->assertEquals('Test Name', $this->getField($deserialized, 'name'));
+        $this->assertEquals('green', $this->getField($deserialized, 'color'));
+        $this->assertEquals('Test Description', $this->getField($deserialized, 'description'));
+        $this->assertEquals('New', $this->getField($deserialized, 'status'));
 
     }
 

--- a/tests/JMS/Serializer/Tests/Serializer/xml/object_with_default_xml_namespace.xml
+++ b/tests/JMS/Serializer/Tests/Serializer/xml/object_with_default_xml_namespace.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<test-object xmlns="http://example.com/namespace" xmlns:v2="http://example.com/namespace/v2" color="green">
+    <name>Test Name</name>
+    <description>Test Description</description>
+    <v2:status>New</v2:status>
+</test-object>


### PR DESCRIPTION
Given the following xml:

```
<?xml version="1.0" encoding="UTF-8"?>
<test-object xmlns="http://example.com/namespace" xmlns:v2="http://example.com/namespace/v2" color="green">
    <name>Test Name</name>
    <description>Test Description</description>
    <v2:status>New</v2:status>
</test-object>
```

attempts to deserialize the object will result in name and description being null. As near as I can tell, this is due to xpath in simplexml not being able to lookup unprefixed namespaces in element names. Basically xpath('./name') will return empty.

You can fix this by registering the namespace for the xpath with registerXPathNamespace. This is already being done for namespaces declared outside of the root node. I just added logic to also do this for the default namespace where the prefix yields "".

I did verify (with the included tests) that attributes do not exhibit this same issue therefore I did not make changes to that block in the visitor.