### PR TITLE
Implemented PathBasedExclusion

### DIFF
--- a/src/JMS/Serializer/Annotation/PathBasedExclusion.php
+++ b/src/JMS/Serializer/Annotation/PathBasedExclusion.php
@@ -1,0 +1,59 @@
+<?php
+
+/*
+ * Copyright 2014 Adam Pullen <adam@finalconcept.com.au>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * This annotation is used to exclude properties from object based on their path.
+ *
+ * Given the following object graph
+ * User
+ *   > groups
+ *     > permissions
+ *
+ * You can exclude permissions by using the PathBasedExclusion annotation on your
+ * class like so
+ *
+ * @PathBasedExclusion(["groups.permissions"])
+ * class User {
+ *  ...
+ * }
+ * 
+ * This annotation always works from the Root node. PathBasedExclusion annotations
+ * will be ignored on child classes. If you have a child class that also needs
+ * to exclude some properties you will need to add them to your root class
+ */
+
+namespace JMS\Serializer\Annotation;
+
+use JMS\Serializer\Exception\RuntimeException;
+
+/**
+ * @Annotation
+ * @Target("CLASS")
+ */
+final class PathBasedExclusion
+{
+
+    public $paths;
+
+    public function __construct(array $values)
+    {
+
+        if (!is_array($values['value'])) {
+            throw new RuntimeException('"value" must be an array of object paths.');
+        }
+        $this->paths = $values['value'];
+    }
+}

--- a/src/JMS/Serializer/Context.php
+++ b/src/JMS/Serializer/Context.php
@@ -59,6 +59,9 @@ abstract class Context
     /** @var \SplStack */
     private $metadataStack;
 
+    /** @var \SplStack */
+    private $propertyNameStack;
+
     public function __construct()
     {
         $this->attributes = new Map();
@@ -79,6 +82,7 @@ abstract class Context
         $this->navigator = $navigator;
         $this->metadataFactory = $factory;
         $this->metadataStack = new \SplStack();
+        $this->propertyNameStack = new \SplStack();
     }
 
     public function accept($data, array $type = null)
@@ -212,12 +216,13 @@ abstract class Context
     public function pushPropertyMetadata(PropertyMetadata $metadata)
     {
         $this->metadataStack->push($metadata);
+        $this->propertyNameStack->push($metadata->name);
     }
 
     public function popPropertyMetadata()
     {
         $metadata = $this->metadataStack->pop();
-
+        $this->propertyNameStack->pop();
         if (!$metadata instanceof PropertyMetadata) {
             throw new RuntimeException('Context metadataStack not working well');
         }
@@ -235,6 +240,25 @@ abstract class Context
     public function getMetadataStack()
     {
         return $this->metadataStack;
+    }
+
+    public function getPropertyStack()
+    {
+        return $this->propertyNameStack;
+    }
+
+    public function getPropPath()
+    {
+        $path = array();
+        foreach ($this->getPropertyStack() as $name) {
+            $path[] = $name;
+        }
+
+        if ( ! $path) {
+            return null;
+        }
+
+        return implode('.', array_reverse($path));
     }
 
     abstract public function getDepth();

--- a/src/JMS/Serializer/GraphNavigator.php
+++ b/src/JMS/Serializer/GraphNavigator.php
@@ -46,6 +46,7 @@ final class GraphNavigator
     private $metadataFactory;
     private $handlerRegistry;
     private $objectConstructor;
+    private $pathBasedExclusion = array();
 
     /**
      * Parses a direction string to one of the direction constants.
@@ -187,6 +188,20 @@ final class GraphNavigator
                     $this->leaveScope($context, $data);
 
                     return null;
+                }
+
+                
+                // PathBasedExclusion always works from the root class.
+                // If we have recursed into an other property then ignore any
+                // PathBasedExclusion annotations
+                if($context->getDepth() == 1){
+                    $this->pathBasedExclusion = $metadata->exclusionPaths;
+                }
+                if( in_array(strtolower($context->getPropPath()), $this->pathBasedExclusion)){
+
+                    $this->leaveScope($context, $data);
+                    return null;
+
                 }
 
                 $context->pushClassMetadata($metadata);

--- a/src/JMS/Serializer/Metadata/ClassMetadata.php
+++ b/src/JMS/Serializer/Metadata/ClassMetadata.php
@@ -56,6 +56,15 @@ class ClassMetadata extends MergeableClassMetadata
     public $discriminatorFieldName;
     public $discriminatorValue;
     public $discriminatorMap = array();
+    public $exclusionPaths = array();
+
+    public function setExclusionPaths($paths){
+        // Convert all paths to lower case to avoid issues with in_array
+        $this->exclusionPaths = array();
+        foreach($paths as $path){
+            array_push($this->exclusionPaths,strtolower($path));
+        }
+    }
 
     public function setDiscriminator($fieldName, array $map)
     {
@@ -190,6 +199,8 @@ class ClassMetadata extends MergeableClassMetadata
             $this->propertyMetadata[$this->discriminatorFieldName] = $discriminatorProperty;
         }
 
+        $this->exclusionPaths = $object->exclusionPaths;
+        
         $this->sortProperties();
     }
 
@@ -230,6 +241,7 @@ class ClassMetadata extends MergeableClassMetadata
             $this->discriminatorFieldName,
             $this->discriminatorValue,
             $this->discriminatorMap,
+        $this->exclusionPaths,
             parent::serialize(),
         ));
     }
@@ -251,6 +263,7 @@ class ClassMetadata extends MergeableClassMetadata
             $this->discriminatorFieldName,
             $this->discriminatorValue,
             $this->discriminatorMap,
+        $this->exclusionPaths,
             $parentStr
         ) = unserialize($str);
 

--- a/src/JMS/Serializer/Metadata/Driver/AnnotationDriver.php
+++ b/src/JMS/Serializer/Metadata/Driver/AnnotationDriver.php
@@ -18,6 +18,8 @@
 
 namespace JMS\Serializer\Metadata\Driver;
 
+use JMS\Serializer\Annotation\PathBasedExclusion;
+
 use JMS\Serializer\Annotation\Discriminator;
 use JMS\Serializer\GraphNavigator;
 use JMS\Serializer\Annotation\HandlerCallback;
@@ -99,6 +101,8 @@ class AnnotationDriver implements DriverInterface
                 } else {
                     $classMetadata->setDiscriminator($annot->field, $annot->map);
                 }
+            } elseif ($annot instanceof PathBasedExclusion) {
+                $classMetadata->setExclusionPaths($annot->paths);
             }
         }
 


### PR DESCRIPTION
This allows the user to annotate their base root class to exclude
complex paths.

For example given the following graph

``` php
User
 -> Company
   -> Users
     -> Groups
      -> Permissions
        -> Groups
   -> Groups
     -> Permissions
        -> Groups
 -> Groups
   -> Permissions
... and so on
```

The current state of the serializer does an excellent job of prevent recursion. However I am not interested in pulling all the data from the graph.

With this change you can tell the serializer to ignore object paths

``` php
use JMS\Serializer\Annotation as JMS;
/**
 * FinalConcept\TimeTracker\EntitiesBundle\Entity
 *
 * @ORM\Table(name="users")
 * @ORM\Entity(repositoryClass="FinalConcept\TimeTracker\EntitiesBundle\Repository\UserRepository")
 * @JMS\PathBasedExclusion({"company.users", "company.teams", "company.groups", "groups.users", "groups.permissions.groups", "teams.company", "teams.users"})
 */
class User implements UserInterface, \Serializable
{
//..
}.
```

which will give you a nice neat graph like so

``` php
User
  -> Company
  -> Groups
   -> Permissions
```

PathBasedExclusion is designed to work on the root object of the graph. Any PathBasedExclusion annotations found on objects lower down in the graph will be ignored.

Therefore if you want to continue ignoring properties from lower objects you need to add them to the root object
