### PR TITLE
Removed unnecessary use statement

### DIFF
--- a/src/JMS/Serializer/Handler/ArrayCollectionHandler.php
+++ b/src/JMS/Serializer/Handler/ArrayCollectionHandler.php
@@ -23,7 +23,6 @@ use JMS\Serializer\Context;
 use JMS\Serializer\GraphNavigator;
 use JMS\Serializer\VisitorInterface;
 use Doctrine\Common\Collections\Collection;
-use JMS\Serializer\Handler\SubscribingHandlerInterface;
 
 class ArrayCollectionHandler implements SubscribingHandlerInterface
 {


### PR DESCRIPTION
This use statement is not necessary because the interface is in the same namespace.