### PR TITLE
add the ability to mark a property as write only so it can be desrialized to but not be serialized from

### DIFF
--- a/src/JMS/Serializer/Annotation/WriteOnly.php
+++ b/src/JMS/Serializer/Annotation/WriteOnly.php
@@ -1,0 +1,31 @@
+<?php
+
+/*
+ * Copyright 2013 Johannes M. Schmitt <schmittjoh@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace JMS\Serializer\Annotation;
+
+/**
+ * @Annotation
+ * @Target({"CLASS","PROPERTY"})
+ */
+final class WriteOnly
+{
+    /**
+     * @var boolean
+     */
+    public $writeOnly = true;
+}

--- a/src/JMS/Serializer/GraphNavigator.php
+++ b/src/JMS/Serializer/GraphNavigator.php
@@ -219,7 +219,10 @@ final class GraphNavigator
                         continue;
                     }
 
-                    if ($context instanceof DeserializationContext && $propertyMetadata->readOnly) {
+                    if (
+                        ($context instanceof DeserializationContext && $propertyMetadata->readOnly)
+                        || ($context instanceof SerializationContext && $propertyMetadata->writeOnly)
+                    ) {
                         continue;
                     }
 

--- a/src/JMS/Serializer/Metadata/Driver/AnnotationDriver.php
+++ b/src/JMS/Serializer/Metadata/Driver/AnnotationDriver.php
@@ -19,6 +19,7 @@
 namespace JMS\Serializer\Metadata\Driver;
 
 use JMS\Serializer\Annotation\Discriminator;
+use JMS\Serializer\Annotation\WriteOnly;
 use JMS\Serializer\GraphNavigator;
 use JMS\Serializer\Annotation\HandlerCallback;
 use JMS\Serializer\Annotation\AccessorOrder;
@@ -77,6 +78,7 @@ class AnnotationDriver implements DriverInterface
         $excludeAll = false;
         $classAccessType = PropertyMetadata::ACCESS_TYPE_PROPERTY;
         $readOnlyClass = false;
+        $writeOnlyClass = false;
         foreach ($this->reader->getClassAnnotations($class) as $annot) {
             if ($annot instanceof ExclusionPolicy) {
                 $exclusionPolicy = $annot->policy;
@@ -91,6 +93,8 @@ class AnnotationDriver implements DriverInterface
                 $classAccessType = $annot->type;
             } elseif ($annot instanceof ReadOnly) {
                 $readOnlyClass = true;
+            }elseif ($annot instanceof WriteOnly) {
+                $writeOnlyClass = true;
             } elseif ($annot instanceof AccessorOrder) {
                 $classMetadata->setAccessorOrder($annot->order, $annot->custom);
             } elseif ($annot instanceof Discriminator) {
@@ -144,6 +148,7 @@ class AnnotationDriver implements DriverInterface
                 $isExclude = false;
                 $isExpose = $propertyMetadata instanceof VirtualPropertyMetadata;
                 $propertyMetadata->readOnly = $propertyMetadata->readOnly || $readOnlyClass;
+                $propertyMetadata->writeOnly = $propertyMetadata->writeOnly || $writeOnlyClass;
                 $accessType = $classAccessType;
                 $accessor = array(null, null);
 
@@ -188,7 +193,9 @@ class AnnotationDriver implements DriverInterface
                     } elseif ($annot instanceof AccessType) {
                         $accessType = $annot->type;
                     } elseif ($annot instanceof ReadOnly) {
-                       $propertyMetadata->readOnly = $annot->readOnly;
+                        $propertyMetadata->readOnly = $annot->readOnly;
+                    } elseif ($annot instanceof WriteOnly) {
+                        $propertyMetadata->writeOnly = $annot->writeOnly;
                     } elseif ($annot instanceof Accessor) {
                         $accessor = array($annot->getter, $annot->setter);
                     } elseif ($annot instanceof Groups) {

--- a/src/JMS/Serializer/Metadata/Driver/XmlDriver.php
+++ b/src/JMS/Serializer/Metadata/Driver/XmlDriver.php
@@ -68,6 +68,7 @@ class XmlDriver extends AbstractFileDriver
         }
 
         $readOnlyClass = 'true' === strtolower($elem->attributes()->{'read-only'});
+        $writeOnlyClass = 'true' === strtolower($elem->attributes()->{'write-only'});
 
         $discriminatorFieldName = (string) $elem->attributes()->{'discriminator-field-name'};
         $discriminatorMap = array();
@@ -222,11 +223,17 @@ class XmlDriver extends AbstractFileDriver
                         $pMetadata->maxDepth = (int) $pElem->attributes()->{'max-depth'};
                     }
 
-                    //we need read-only before setter and getter set, because that method depends on flag being set
+                    //we need read-only/write-only before setter and getter set, because that method depends on flag being set
                     if (null !== $readOnly = $pElem->attributes()->{'read-only'}) {
                         $pMetadata->readOnly = 'true' === strtolower($readOnly);
                     } else {
                         $pMetadata->readOnly = $pMetadata->readOnly || $readOnlyClass;
+                    }
+
+                    if (null !== $writeOnly = $pElem->attributes()->{'write-only'}) {
+                        $pMetadata->writeOnly = 'true' === strtolower($writeOnly);
+                    } else {
+                        $pMetadata->writeOnly = $pMetadata->writeOnly || $writeOnlyClass;
                     }
 
                     $getter = $pElem->attributes()->{'accessor-getter'};

--- a/src/JMS/Serializer/Metadata/Driver/YamlDriver.php
+++ b/src/JMS/Serializer/Metadata/Driver/YamlDriver.php
@@ -46,6 +46,7 @@ class YamlDriver extends AbstractFileDriver
         $excludeAll = isset($config['exclude']) ? (Boolean) $config['exclude'] : false;
         $classAccessType = isset($config['access_type']) ? $config['access_type'] : PropertyMetadata::ACCESS_TYPE_PROPERTY;
         $readOnlyClass =  isset($config['read_only']) ? (Boolean) $config['read_only'] : false;
+        $writeOnlyClass =  isset($config['write_only']) ? (Boolean) $config['write_only'] : false;
         $this->addClassProperties($metadata, $config);
 
         $propertiesMetadata = array();
@@ -165,11 +166,17 @@ class YamlDriver extends AbstractFileDriver
                         $pMetadata->xmlKeyValuePairs = (Boolean) $pConfig['xml_key_value_pairs'];
                     }
 
-                    //we need read_only before setter and getter set, because that method depends on flag being set
+                    //we need read_only/write_only before setter and getter set, because that method depends on flag being set
                     if (isset($pConfig['read_only'])) {
                           $pMetadata->readOnly = (Boolean) $pConfig['read_only'];
                     } else {
                         $pMetadata->readOnly = $pMetadata->readOnly || $readOnlyClass;
+                    }
+
+                    if (isset($pConfig['write_only'])) {
+                          $pMetadata->writeOnly = (Boolean) $pConfig['write_only'];
+                    } else {
+                        $pMetadata->writeOnly = $pMetadata->writeOnly || $writeOnlyClass;
                     }
 
                     $pMetadata->setAccessor(

--- a/src/JMS/Serializer/Metadata/PropertyMetadata.php
+++ b/src/JMS/Serializer/Metadata/PropertyMetadata.php
@@ -148,10 +148,10 @@ class PropertyMetadata extends BasePropertyMetadata
             $this->setter,
             $this->inline,
             $this->readOnly,
-            $this->writeOnly,
             $this->xmlAttributeMap,
             $this->maxDepth,
-            $parentStr
+            $parentStr,
+            $this->writeOnly
         ) = unserialize($str);
 
         parent::unserialize($parentStr);

--- a/src/JMS/Serializer/Metadata/PropertyMetadata.php
+++ b/src/JMS/Serializer/Metadata/PropertyMetadata.php
@@ -120,10 +120,10 @@ class PropertyMetadata extends BasePropertyMetadata
             $this->setter,
             $this->inline,
             $this->readOnly,
-            $this->writeOnly,
             $this->xmlAttributeMap,
             $this->maxDepth,
             parent::serialize(),
+            $this->writeOnly,
         ));
     }
 

--- a/src/JMS/Serializer/Metadata/PropertyMetadata.php
+++ b/src/JMS/Serializer/Metadata/PropertyMetadata.php
@@ -45,6 +45,7 @@ class PropertyMetadata extends BasePropertyMetadata
     public $setter;
     public $inline = false;
     public $readOnly = false;
+    public $writeOnly = false;
     public $xmlAttributeMap = false;
     public $maxDepth = null;
 
@@ -55,7 +56,7 @@ class PropertyMetadata extends BasePropertyMetadata
         if (self::ACCESS_TYPE_PUBLIC_METHOD === $type) {
             $class = $this->reflection->getDeclaringClass();
 
-            if (empty($getter)) {
+            if (empty($getter) && !$this->writeOnly) {
                 if ($class->hasMethod('get'.$this->name) && $class->getMethod('get'.$this->name)->isPublic()) {
                     $getter = 'get'.$this->name;
                 } elseif ($class->hasMethod('is'.$this->name) && $class->getMethod('is'.$this->name)->isPublic()) {
@@ -119,6 +120,7 @@ class PropertyMetadata extends BasePropertyMetadata
             $this->setter,
             $this->inline,
             $this->readOnly,
+            $this->writeOnly,
             $this->xmlAttributeMap,
             $this->maxDepth,
             parent::serialize(),
@@ -146,6 +148,7 @@ class PropertyMetadata extends BasePropertyMetadata
             $this->setter,
             $this->inline,
             $this->readOnly,
+            $this->writeOnly,
             $this->xmlAttributeMap,
             $this->maxDepth,
             $parentStr

--- a/src/JMS/Serializer/Metadata/StaticPropertyMetadata.php
+++ b/src/JMS/Serializer/Metadata/StaticPropertyMetadata.php
@@ -65,10 +65,10 @@ class StaticPropertyMetadata extends PropertyMetadata
             $this->setter,
             $this->inline,
             $this->readOnly,
-            $this->writeOnly,
             $this->class,
             $this->name,
-            $this->value
+            $this->value,
+            $this->writeOnly
         ));
     }
 

--- a/src/JMS/Serializer/Metadata/StaticPropertyMetadata.php
+++ b/src/JMS/Serializer/Metadata/StaticPropertyMetadata.php
@@ -93,10 +93,10 @@ class StaticPropertyMetadata extends PropertyMetadata
             $this->setter,
             $this->inline,
             $this->readOnly,
-            $this->writeOnly,
             $this->class,
             $this->name,
-            $this->value
+            $this->value,
+            $this->writeOnly
         ) = unserialize($str);
     }
 }

--- a/src/JMS/Serializer/Metadata/StaticPropertyMetadata.php
+++ b/src/JMS/Serializer/Metadata/StaticPropertyMetadata.php
@@ -65,6 +65,7 @@ class StaticPropertyMetadata extends PropertyMetadata
             $this->setter,
             $this->inline,
             $this->readOnly,
+            $this->writeOnly,
             $this->class,
             $this->name,
             $this->value
@@ -92,6 +93,7 @@ class StaticPropertyMetadata extends PropertyMetadata
             $this->setter,
             $this->inline,
             $this->readOnly,
+            $this->writeOnly,
             $this->class,
             $this->name,
             $this->value

--- a/src/JMS/Serializer/Metadata/VirtualPropertyMetadata.php
+++ b/src/JMS/Serializer/Metadata/VirtualPropertyMetadata.php
@@ -95,9 +95,9 @@ class VirtualPropertyMetadata extends PropertyMetadata
             $this->setter,
             $this->inline,
             $this->readOnly,
-            $this->writeOnly,
             $this->class,
-            $this->name
+            $this->name,
+            $this->writeOnly
         ) = unserialize($str);
     }
 }

--- a/src/JMS/Serializer/Metadata/VirtualPropertyMetadata.php
+++ b/src/JMS/Serializer/Metadata/VirtualPropertyMetadata.php
@@ -66,6 +66,7 @@ class VirtualPropertyMetadata extends PropertyMetadata
             $this->setter,
             $this->inline,
             $this->readOnly,
+            $this->writeOnly,
             $this->class,
             $this->name
         ));
@@ -94,6 +95,7 @@ class VirtualPropertyMetadata extends PropertyMetadata
             $this->setter,
             $this->inline,
             $this->readOnly,
+            $this->writeOnly,
             $this->class,
             $this->name
         ) = unserialize($str);

--- a/src/JMS/Serializer/Metadata/VirtualPropertyMetadata.php
+++ b/src/JMS/Serializer/Metadata/VirtualPropertyMetadata.php
@@ -66,9 +66,10 @@ class VirtualPropertyMetadata extends PropertyMetadata
             $this->setter,
             $this->inline,
             $this->readOnly,
-            $this->writeOnly,
             $this->class,
-            $this->name
+            $this->name,
+            $this->writeOnly
+
         ));
     }
 

--- a/tests/JMS/Serializer/Tests/Fixtures/AuthorWriteOnly.php
+++ b/tests/JMS/Serializer/Tests/Fixtures/AuthorWriteOnly.php
@@ -1,0 +1,58 @@
+<?php
+
+/*
+ * Copyright 2013 Johannes M. Schmitt <schmittjoh@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace JMS\Serializer\Tests\Fixtures;
+
+use JMS\Serializer\Annotation\SerializedName;
+use JMS\Serializer\Annotation\Type;
+use JMS\Serializer\Annotation\XmlRoot;
+use JMS\Serializer\Annotation\WriteOnly;
+use JMS\Serializer\Annotation\Accessor;
+
+/** @XmlRoot("author") */
+class AuthorWriteOnly
+{
+    /**
+     * @WriteOnly
+     * @SerializedName("id")
+     * @Type("integer")
+     */
+    private $id;
+
+    /**
+     * @Type("string")
+     * @SerializedName("full_name")
+     */
+    private $name;
+
+    public function __construct($id, $name)
+    {
+        $this->id = $id;
+        $this->name = $name;
+    }
+
+    public function getId()
+    {
+        return $this->id;
+    }
+
+    public function getName()
+    {
+        return $this->name;
+    }
+}

--- a/tests/JMS/Serializer/Tests/Fixtures/AuthorWriteOnly.php
+++ b/tests/JMS/Serializer/Tests/Fixtures/AuthorWriteOnly.php
@@ -37,6 +37,7 @@ class AuthorWriteOnly
     /**
      * @Type("string")
      * @SerializedName("full_name")
+     * @Accessor(setter="setName")
      */
     private $name;
 
@@ -54,5 +55,11 @@ class AuthorWriteOnly
     public function getName()
     {
         return $this->name;
+    }
+
+    public function setName($name)
+    {
+        $this->name = $name;
+        return $this;
     }
 }

--- a/tests/JMS/Serializer/Tests/Fixtures/AuthorWriteOnlyPerClass.php
+++ b/tests/JMS/Serializer/Tests/Fixtures/AuthorWriteOnlyPerClass.php
@@ -1,0 +1,62 @@
+<?php
+
+/*
+ * Copyright 2013 Johannes M. Schmitt <schmittjoh@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace JMS\Serializer\Tests\Fixtures;
+
+use JMS\Serializer\Annotation\SerializedName;
+use JMS\Serializer\Annotation\Type;
+use JMS\Serializer\Annotation\XmlRoot;
+use JMS\Serializer\Annotation\WriteOnly;
+use JMS\Serializer\Annotation\Accessor;
+
+/**
+ * @XmlRoot("author")
+ * @WriteOnly
+ */
+class AuthorWriteOnlyPerClass
+{
+    /**
+     * @WriteOnly
+     * @SerializedName("id")
+     * @Type("integer")
+     */
+    private $id;
+
+    /**
+     * @Type("string")
+     * @SerializedName("full_name")
+     * @WriteOnly(false)
+     */
+    private $name;
+
+    public function __construct($id, $name)
+    {
+        $this->id = $id;
+        $this->name = $name;
+    }
+
+    public function getId()
+    {
+        return $this->id;
+    }
+
+    public function getName()
+    {
+        return $this->name;
+    }
+}

--- a/tests/JMS/Serializer/Tests/Fixtures/AuthorWriteOnlyPerClass.php
+++ b/tests/JMS/Serializer/Tests/Fixtures/AuthorWriteOnlyPerClass.php
@@ -41,6 +41,7 @@ class AuthorWriteOnlyPerClass
      * @Type("string")
      * @SerializedName("full_name")
      * @WriteOnly(false)
+     * @Accessor(setter="setName")
      */
     private $name;
 
@@ -58,5 +59,11 @@ class AuthorWriteOnlyPerClass
     public function getName()
     {
         return $this->name;
+    }
+
+    public function setName($name)
+    {
+        $this->name = $name;
+        return $this;
     }
 }

--- a/tests/JMS/Serializer/Tests/Metadata/Driver/xml/AuthorWriteOnly.xml
+++ b/tests/JMS/Serializer/Tests/Metadata/Driver/xml/AuthorWriteOnly.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<serializer>
+    <class name="JMS\Serializer\Tests\Fixtures\AuthorReadOnly" xml-root-name="author">
+        <property name="id" write-only="true"/>
+        <property name="name" serialized-name="full_name" access-type="public_method" accessor-getter="getName" write-only="true"/>
+    </class>
+</serializer>

--- a/tests/JMS/Serializer/Tests/Metadata/Driver/xml/AuthorWriteOnlyPerClass.xml
+++ b/tests/JMS/Serializer/Tests/Metadata/Driver/xml/AuthorWriteOnlyPerClass.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<serializer>
+    <class name="JMS\Serializer\Tests\Fixtures\AuthorReadOnlyPerClass" xml-root-name="author" write-only="true">
+        <property name="id" write-only="true"/>
+        <property name="name" serialized-name="full_name" access-type="public_method" accessor-getter="getName" write-only="false" />
+    </class>
+</serializer>

--- a/tests/JMS/Serializer/Tests/Metadata/Driver/yml/AuthorWriteOnly.yml
+++ b/tests/JMS/Serializer/Tests/Metadata/Driver/yml/AuthorWriteOnly.yml
@@ -1,0 +1,10 @@
+JMS\Serializer\Tests\Fixtures\AuthorWriteOnly:
+    xml_root_name: author
+    properties:
+        id:
+            write_only: true
+        name:
+            serialized_name:  full_name
+            access_type:      public_method
+            accessor_getter:  getName
+            write_only:        true

--- a/tests/JMS/Serializer/Tests/Metadata/Driver/yml/AuthorWriteOnlyPerClass.yml
+++ b/tests/JMS/Serializer/Tests/Metadata/Driver/yml/AuthorWriteOnlyPerClass.yml
@@ -1,0 +1,11 @@
+JMS\Serializer\Tests\Fixtures\AuthorReadOnlyPerClass:
+    xml_root_name: author
+    write_only: true
+    properties:
+        id:
+            
+        name:
+            serialized_name:  full_name
+            access_type:      public_method
+            accessor_getter:  getName
+            write_only:        false

--- a/tests/JMS/Serializer/Tests/Serializer/BaseSerializationTest.php
+++ b/tests/JMS/Serializer/Tests/Serializer/BaseSerializationTest.php
@@ -23,6 +23,8 @@ use JMS\Serializer\DeserializationContext;
 use JMS\Serializer\GraphNavigator;
 use JMS\Serializer\Handler\PhpCollectionHandler;
 use JMS\Serializer\SerializationContext;
+use JMS\Serializer\Tests\Fixtures\AuthorWriteOnly;
+use JMS\Serializer\Tests\Fixtures\AuthorWriteOnlyPerClass;
 use JMS\Serializer\Tests\Fixtures\DateTimeArraysObject;
 use JMS\Serializer\Tests\Fixtures\Discriminator\Car;
 use JMS\Serializer\Tests\Fixtures\InlineChildEmpty;
@@ -419,6 +421,34 @@ abstract class BaseSerializationTest extends \PHPUnit_Framework_TestCase
             $this->assertNull($this->getField($deserialized, 'id'));
             $this->assertEquals('Ruud Kamphuis', $this->getField($deserialized, 'name'));
         }
+    }
+
+    public function testWriteOnly()
+    {
+        if (!$this->hasDeserializer()) {
+
+            $this->markTestSkipped();
+        }
+
+        $author = new AuthorWriteOnly(123, 'Ruud Kamphuis');
+        $this->assertEquals($author, $this->deserialize($this->getContent('writeonly'), get_class($author)));
+        $reserializedAuthor = $this->deserialize($this->serialize($author), get_class($author));
+        $this->assertNull($this->getField($reserializedAuthor, 'id'));
+        $this->assertEquals('Ruud Kamphuis', $this->getField($reserializedAuthor, 'name'));
+    }
+
+    public function testWriteOnlyClass()
+    {
+        if (!$this->hasDeserializer()) {
+
+            $this->markTestSkipped();
+        }
+
+        $author = new AuthorWriteOnlyPerClass(123, 'Ruud Kamphuis');
+        $this->assertEquals($author, $this->deserialize($this->getContent('writeonly'), get_class($author)));
+        $reserializedAuthor = $this->deserialize($this->serialize($author), get_class($author));
+        $this->assertNull($this->getField($reserializedAuthor, 'id'));
+        $this->assertEquals('Ruud Kamphuis', $this->getField($reserializedAuthor, 'name'));
     }
 
     public function testPrice()

--- a/tests/JMS/Serializer/Tests/Serializer/JsonSerializationTest.php
+++ b/tests/JMS/Serializer/Tests/Serializer/JsonSerializationTest.php
@@ -35,6 +35,7 @@ class JsonSerializationTest extends BaseSerializationTest
 
         if (!$outputs) {
             $outputs['readonly'] = '{"id":123,"full_name":"Ruud Kamphuis"}';
+            $outputs['writeonly'] = '{"id":123,"full_name":"Ruud Kamphuis"}';
             $outputs['string'] = '"foo"';
             $outputs['boolean_true'] = 'true';
             $outputs['boolean_false'] = 'false';

--- a/tests/JMS/Serializer/Tests/Serializer/xml/writeonly.xml
+++ b/tests/JMS/Serializer/Tests/Serializer/xml/writeonly.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<author>
+  <id>123</id>
+  <full_name><![CDATA[Ruud Kamphuis]]></full_name>
+</author>

--- a/tests/JMS/Serializer/Tests/Serializer/yml/writeonly.yml
+++ b/tests/JMS/Serializer/Tests/Serializer/yml/writeonly.yml
@@ -1,0 +1,2 @@
+id: 123
+full_name: 'Ruud Kamphuis'


### PR DESCRIPTION
im using the serializer to desrialize data from an http request but then i want to show this same object as a return from my application without some tf the fields that were deserialized to. so being able to mark them as writeonly would be really nice.