### PR TITLE
Missing attribute 'xml-value' in XML Reference

### DIFF
--- a/doc/reference/xml_reference.rst
+++ b/doc/reference/xml_reference.rst
@@ -18,6 +18,7 @@ XML Reference
                       since-version="1.0"
                       until-version="1.1"
                       xml-attribute="true"
+                      xml-value="true"
                       access-type="public_method"
                       accessor-getter="getSomeProperty"
                       accessor-setter="setSomeProperty"


### PR DESCRIPTION
As described for the annotations here: http://jmsyst.com/libs/serializer/master/reference/annotations#xmlvalue

Still, an XML Schema (.xsd) would be nice, now had to check the test-cases to find this out. Of course, time is scarce for everyone ;)