### PR TITLE
Deserialization 'Array to string conversion' better error

### DIFF
--- a/src/JMS/Serializer/Context.php
+++ b/src/JMS/Serializer/Context.php
@@ -45,7 +45,7 @@ abstract class Context
     /** @var GraphNavigator */
     private $navigator;
 
-    /** @var MetadataFactory */
+    /** @var MetadataFactoryInterface */
     private $metadataFactory;
 
     /** @var ExclusionStrategyInterface */

--- a/src/JMS/Serializer/GenericDeserializationVisitor.php
+++ b/src/JMS/Serializer/GenericDeserializationVisitor.php
@@ -18,6 +18,7 @@
 
 namespace JMS\Serializer;
 
+use JMS\Serializer\Exception\LogicException;
 use JMS\Serializer\Exception\RuntimeException;
 use JMS\Serializer\Metadata\PropertyMetadata;
 use JMS\Serializer\Metadata\ClassMetadata;
@@ -58,6 +59,9 @@ abstract class GenericDeserializationVisitor extends AbstractVisitor
 
     public function visitString($data, array $type, Context $context)
     {
+        if (is_array($data)) {
+            throw new LogicException('Expected string but got array. Do you have the wrong @Type mapping in class ' . get_class($this->currentObject) . '?');
+        }
         $data = (string) $data;
 
         if (null === $this->result) {

--- a/tests/JMS/Serializer/Tests/Serializer/Doctrine/IntegrationTest.php
+++ b/tests/JMS/Serializer/Tests/Serializer/Doctrine/IntegrationTest.php
@@ -58,21 +58,21 @@ class IntegrationTest extends \PHPUnit_Framework_TestCase
 
     protected function setUp()
     {
+        $that = $this;
         $this->registry = new SimpleManagerRegistry(
-            function($id) {
+            function($id) use ($that) {
                 switch ($id) {
                     case 'default_connection':
                         return $this->createConnection();
 
                     case 'default_manager':
-                        return $this->createEntityManager($this->registry->getConnection());
+                        return $this->createEntityManager($that->registry->getConnection());
 
                     default:
                         throw new \RuntimeException(sprintf('Unknown service id "%s".', $id));
                 }
             }
         );
-        $that = $this;
         $this->serializer = SerializerBuilder::create()
             ->setMetadataDriverFactory(new CallbackDriverFactory(
                 function(array $metadataDirs, Reader $annotationReader) use ($that) {

--- a/tests/JMS/Serializer/Tests/Serializer/Doctrine/IntegrationTest.php
+++ b/tests/JMS/Serializer/Tests/Serializer/Doctrine/IntegrationTest.php
@@ -85,7 +85,7 @@ class IntegrationTest extends \PHPUnit_Framework_TestCase
         ;
 
         $this->prepareDatabase();
-    }                                        PHP Fatal error:  Using $this when not in object context
+    }
 
     private function prepareDatabase()
     {

--- a/tests/JMS/Serializer/Tests/Serializer/Doctrine/IntegrationTest.php
+++ b/tests/JMS/Serializer/Tests/Serializer/Doctrine/IntegrationTest.php
@@ -63,10 +63,10 @@ class IntegrationTest extends \PHPUnit_Framework_TestCase
             function($id) use ($that) {
                 switch ($id) {
                     case 'default_connection':
-                        return $this->createConnection();
+                        return $that->createConnection();
 
                     case 'default_manager':
-                        return $this->createEntityManager($that->registry->getConnection());
+                        return $that->createEntityManager($that->registry->getConnection());
 
                     default:
                         throw new \RuntimeException(sprintf('Unknown service id "%s".', $id));

--- a/tests/JMS/Serializer/Tests/Serializer/Doctrine/IntegrationTest.php
+++ b/tests/JMS/Serializer/Tests/Serializer/Doctrine/IntegrationTest.php
@@ -72,20 +72,20 @@ class IntegrationTest extends \PHPUnit_Framework_TestCase
                 }
             }
         );
-
+        $that = $this;
         $this->serializer = SerializerBuilder::create()
             ->setMetadataDriverFactory(new CallbackDriverFactory(
-                function(array $metadataDirs, Reader $annotationReader) {
+                function(array $metadataDirs, Reader $annotationReader) use ($that) {
                     $defaultFactory = new DefaultDriverFactory();
 
-                    return new DoctrineTypeDriver($defaultFactory->createDriver($metadataDirs, $annotationReader), $this->registry);
+                    return new DoctrineTypeDriver($defaultFactory->createDriver($metadataDirs, $annotationReader), $that->registry);
                 }
             ))
             ->build()
         ;
 
         $this->prepareDatabase();
-    }
+    }                                        PHP Fatal error:  Using $this when not in object context
 
     private function prepareDatabase()
     {

--- a/tests/JMS/Serializer/Tests/Serializer/Doctrine/IntegrationTest.php
+++ b/tests/JMS/Serializer/Tests/Serializer/Doctrine/IntegrationTest.php
@@ -27,7 +27,7 @@ use JMS\Serializer\Tests\Fixtures\Doctrine\SingleTableInheritance\Teacher;
 class IntegrationTest extends \PHPUnit_Framework_TestCase
 {
     /** @var ManagerRegistry */
-    private $registry;
+    public $registry;
 
     /** @var Serializer */
     private $serializer;

--- a/tests/JMS/Serializer/Tests/Serializer/Doctrine/IntegrationTest.php
+++ b/tests/JMS/Serializer/Tests/Serializer/Doctrine/IntegrationTest.php
@@ -96,7 +96,7 @@ class IntegrationTest extends \PHPUnit_Framework_TestCase
         $tool->createSchema($em->getMetadataFactory()->getAllMetadata());
     }
 
-    private function createConnection()
+    public function createConnection()
     {
         $con = DriverManager::getConnection(array(
             'driver' => 'pdo_sqlite',
@@ -106,7 +106,7 @@ class IntegrationTest extends \PHPUnit_Framework_TestCase
         return $con;
     }
 
-    private function createEntityManager(Connection $con)
+    public function createEntityManager(Connection $con)
     {
         $cfg = new Configuration();
         $cfg->setMetadataDriverImpl(new AnnotationDriver(new AnnotationReader(), array(

--- a/tests/JMS/Serializer/Tests/Serializer/JsonSerializationTest.php
+++ b/tests/JMS/Serializer/Tests/Serializer/JsonSerializationTest.php
@@ -19,6 +19,7 @@
 namespace JMS\Serializer\Tests\Serializer;
 
 use JMS\Serializer\Context;
+use JMS\Serializer\Exception\LogicException;
 use JMS\Serializer\Exception\RuntimeException;
 use JMS\Serializer\EventDispatcher\Event;
 use JMS\Serializer\EventDispatcher\EventSubscriberInterface;
@@ -92,6 +93,7 @@ class JsonSerializationTest extends BaseSerializationTest
             $outputs['car'] = '{"km":5,"type":"car"}';
             $outputs['car_without_type'] = '{"km":5}';
             $outputs['tree'] = '{"tree":{"children":[{"children":[{"children":[],"foo":"bar"}],"foo":"bar"}],"foo":"bar"}}';
+            $outputs['type_string_array_conversion_error'] = '{"full_name":["Paul Atreides"]}';
         }
 
         if (!isset($outputs[$key])) {
@@ -202,6 +204,18 @@ class JsonSerializationTest extends BaseSerializationTest
     public function testSerializeArrayWithEmptyObject()
     {
         $this->assertEquals('{"0":{}}', $this->serialize(array(new \stdClass())));
+    }
+
+    /**
+     * @expectedException LogicException
+     * @expectedExceptionMessage Expected string but got array. Do you have the wrong @Type mapping in class JMS\Serializer\Tests\Fixtures\Author?
+     */
+    public function testDeserializeMoreAccurateErrorsTypeString() {
+        if ($this->hasDeserializer()) {
+            $this->deserialize($this->getContent('type_string_array_conversion_error'), 'JMS\Serializer\Tests\Fixtures\Author');
+        } else {
+            $this->markTestSkipped("Does not have deserializer");
+        }
     }
 
     protected function getFormat()


### PR DESCRIPTION
Sometimes I do mistake and have @Type("string") for in reality array data. When i run my tests, i get common php notice 'Array to string conversion' without any trace to current object etc (only stacktrace to ... vendor\jms\serializer\src\JMS\Serializer\GenericDeserializationVisitor.php).
I added LogicException with current objects, which hints me source of my error more accurately.