### PR TITLE
Xml Empty Data Exception

### DIFF
--- a/src/JMS/Serializer/XmlDeserializationVisitor.php
+++ b/src/JMS/Serializer/XmlDeserializationVisitor.php
@@ -59,8 +59,13 @@ class XmlDeserializationVisitor extends AbstractVisitor
         $previous = libxml_use_internal_errors(true);
         $previousEntityLoaderState = libxml_disable_entity_loader($this->disableExternalEntities);
 
+        if (!(string)$data) {
+            throw New InvalidArgumentException('Empty data not allowed.');
+        }
+
         $dom = new \DOMDocument();
         $dom->loadXML($data);
+        
         foreach ($dom->childNodes as $child) {
             if ($child->nodeType === XML_DOCUMENT_TYPE_NODE) {
                 $internalSubset = str_replace(array("\n", "\r"), '', $child->internalSubset);

--- a/tests/JMS/Serializer/Tests/Serializer/XmlSerializationTest.php
+++ b/tests/JMS/Serializer/Tests/Serializer/XmlSerializationTest.php
@@ -73,6 +73,15 @@ class XmlSerializationTest extends BaseSerializationTest
 
     /**
      * @expectedException JMS\Serializer\Exception\InvalidArgumentException
+     * @expectedExceptionMessage Empty data not allowed.
+     */
+    public function testEmptyDocumentException()
+    {
+        $this->deserialize('', 'stdClass');
+    }
+
+    /**
+     * @expectedException JMS\Serializer\Exception\InvalidArgumentException
      * @expectedExceptionMessage The document type "<!DOCTYPE author [<!ENTITY foo SYSTEM "php://filter/read=convert.base64-encode/resource=XmlSerializationTest.php">]>" is not allowed. If it is safe, you may add it to the whitelist configuration.
      */
     public function testExternalEntitiesAreDisabledByDefault()


### PR DESCRIPTION
Empty data generate an error because  on line:

https://github.com/skler/serializer/blob/d177ebdd35e7a1c6e525506d3e8926632f353a36/src/JMS/Serializer/XmlDeserializationVisitor.php#L86

libxml_get_last_error() returns false 