### PR TITLE
Fixed handling of un-typed collection references from Doctrine Mongo ODM

### DIFF
--- a/src/JMS/Serializer/Metadata/Driver/DoctrineTypeDriver.php
+++ b/src/JMS/Serializer/Metadata/Driver/DoctrineTypeDriver.php
@@ -48,6 +48,15 @@ class DoctrineTypeDriver extends AbstractDoctrineTypeDriver
         } elseif ($doctrineMetadata->hasAssociation($propertyName)) {
             $targetEntity = $doctrineMetadata->getAssociationTargetClass($propertyName);
 
+            // The Mongo ODM can't return a specific association target class for collection references with more than one
+            // possible target class, so we just treat it as a generic ArrayCollection.
+            if($targetEntity === null) {
+                if($doctrineMetadata->isCollectionValuedAssociation($propertyName)) {
+                    $propertyMetadata->setType('ArrayCollection');
+                }
+                return;
+            }
+
             if (null === $targetMetadata = $this->tryLoadingDoctrineMetadata($targetEntity)) {
                 return;
             }


### PR DESCRIPTION
The MongoDB ODM supports references where the type of the referenced entity is stored in the DBRef object in the database, so the type information is not available in metadata. When this happens, getAssociationTargetClass returns null and this fix tries to handle that.