### PR TITLE
Overwrite discriminator settings in metadata if not present in parent class

### DIFF
--- a/src/JMS/Serializer/Metadata/ClassMetadata.php
+++ b/src/JMS/Serializer/Metadata/ClassMetadata.php
@@ -190,6 +190,12 @@ class ClassMetadata extends MergeableClassMetadata
             $this->propertyMetadata[$this->discriminatorFieldName] = $discriminatorProperty;
         }
 
+        if ($object->discriminatorFieldName && !$this->discriminatorFieldName) {
+            $this->discriminatorFieldName = $object->discriminatorFieldName;
+            $this->discriminatorBaseClass = $object->discriminatorBaseClass;
+            $this->discriminatorMap       = $object->discriminatorMap;
+        }
+
         $this->sortProperties();
     }
 


### PR DESCRIPTION
Same problem as in #182.