### PR TITLE
Deserialize json bigint as strings

### DIFF
--- a/src/JMS/Serializer/JsonDeserializationVisitor.php
+++ b/src/JMS/Serializer/JsonDeserializationVisitor.php
@@ -24,7 +24,7 @@ class JsonDeserializationVisitor extends GenericDeserializationVisitor
 {
     protected function decode($str)
     {
-        $decoded = json_decode($str, true);
+        $decoded = json_decode($str, true, $depth = 512, JSON_BIGINT_AS_STRING);
 
         switch (json_last_error()) {
             case JSON_ERROR_NONE:

--- a/tests/JMS/Serializer/Tests/Serializer/JsonSerializationTest.php
+++ b/tests/JMS/Serializer/Tests/Serializer/JsonSerializationTest.php
@@ -39,6 +39,7 @@ class JsonSerializationTest extends BaseSerializationTest
             $outputs['boolean_true'] = 'true';
             $outputs['boolean_false'] = 'false';
             $outputs['integer'] = '1';
+            $outputs['big_integer'] = '1000007546090751';
             $outputs['float'] = '4.533';
             $outputs['float_trailing_zero'] = '1';
             $outputs['simple_object'] = '{"foo":"foo","moo":"bar","camel_case":"boo"}';
@@ -202,6 +203,13 @@ class JsonSerializationTest extends BaseSerializationTest
     public function testSerializeArrayWithEmptyObject()
     {
         $this->assertEquals('{"0":{}}', $this->serialize(array(new \stdClass())));
+    }
+
+    public function testDeserializeBigInteger()
+    {
+        if ($this->hasDeserializer()) {
+            $this->assertEquals("1000007546090751", $this->deserialize($this->getContent('big_integer'), 'string'));
+        }
     }
 
     protected function getFormat()


### PR DESCRIPTION
Currently im not able to deserialize json with big integers, 
when json contains
{ 'big-int': 1000007546090751}
its deserialized as '1.0000076544307E+15'

I added flag JSON_BIGINT_AS_STRING to json_decode. I could be somewhere defined as configuration but i dont see reason why not to use it globaly for lib?
