### PR TITLE
Bugfix: arrays returned as objects like {"0":... }

### DIFF
--- a/src/JMS/Serializer/JsonSerializationVisitor.php
+++ b/src/JMS/Serializer/JsonSerializationVisitor.php
@@ -71,7 +71,7 @@ class JsonSerializationVisitor extends GenericSerializationVisitor
         if (empty($rs)) {
             $rs = new \ArrayObject();
 
-            if (array() === $this->getRoot()) {
+            if (array() === $this->getRoot() && 0 === $context->getDepth()) {
                 $this->setRoot(clone $rs);
             }
         }


### PR DESCRIPTION
Sometimes an array gets returned as {"0":..., "1":...} instead of [..., ...]. Furthermore, this behaviour only appears at the root; when nesting arrays only the root is affected. I have seen multiple users being confronted to this bug. It is pretty annoying.
This is how I understand the code: In this part of the code, you assume that empty($rs) && array() === $this->getRoot() imply that the root is an empty array, that should then be returned as {} instead of []. But you don't actually check that you are at the root. That is the check I add.
