### PR TITLE
setter ignored in XmlDeserializationVisitor for xmlAttribute and xmlValue

### DIFF
--- a/src/JMS/Serializer/XmlDeserializationVisitor.php
+++ b/src/JMS/Serializer/XmlDeserializationVisitor.php
@@ -224,12 +224,12 @@ class XmlDeserializationVisitor extends AbstractVisitor
                 $nodes = $data->xpath('./@'.$attributeName);
                 if (!empty($nodes)) {
                     $v = (string) reset($nodes);
-                    $metadata->reflection->setValue($this->currentObject, $v);
+                    $this->setPropertyValue($metadata, $v);
                 }
 
             } elseif (isset($data[$name])) {
                 $v = $this->navigator->accept($data[$name], $metadata->type, $context);
-                $metadata->reflection->setValue($this->currentObject, $v);
+                $this->setPropertyValue($metadata, $v);
             }
 
             return;
@@ -237,7 +237,7 @@ class XmlDeserializationVisitor extends AbstractVisitor
 
         if ($metadata->xmlValue) {
             $v = $this->navigator->accept($data, $metadata->type, $context);
-            $metadata->reflection->setValue($this->currentObject, $v);
+            $this->setPropertyValue($metadata, $v);
 
             return;
         }
@@ -251,7 +251,7 @@ class XmlDeserializationVisitor extends AbstractVisitor
             $this->setCurrentMetadata($metadata);
             $v = $this->navigator->accept($enclosingElem, $metadata->type, $context);
             $this->revertCurrentMetadata();
-            $metadata->reflection->setValue($this->currentObject, $v);
+            $this->setPropertyValue($metadata, $v);
 
             return;
         }
@@ -277,13 +277,7 @@ class XmlDeserializationVisitor extends AbstractVisitor
 
         $v = $this->navigator->accept($node, $metadata->type, $context);
 
-        if (null === $metadata->setter) {
-            $metadata->reflection->setValue($this->currentObject, $v);
-
-            return;
-        }
-
-        $this->currentObject->{$metadata->setter}($v);
+        $this->setPropertyValue($metadata, $v);
     }
 
     public function endVisitingObject(ClassMetadata $metadata, $data, array $type, Context $context)
@@ -346,4 +340,20 @@ class XmlDeserializationVisitor extends AbstractVisitor
     {
         return $this->doctypeWhitelist;
     }
+
+    /**
+     * @param PropertyMetadata $metadata
+     * @param mixed $v
+     */
+    protected function setPropertyValue(PropertyMetadata $metadata, $v)
+    {
+        if (null === $metadata->setter) {
+            $metadata->reflection->setValue($this->currentObject, $v);
+
+            return;
+        }
+
+        $this->currentObject->{$metadata->setter}($v);
+    }
+
 }

--- a/tests/JMS/Serializer/Tests/Fixtures/AccessorSetter.php
+++ b/tests/JMS/Serializer/Tests/Fixtures/AccessorSetter.php
@@ -1,0 +1,97 @@
+<?php
+
+namespace JMS\Serializer\Tests\Fixtures;
+
+use JMS\Serializer\Annotation as Serializer;
+
+/**
+ * @Serializer\XmlRoot("AccessorSetter")
+ */
+class AccessorSetter 
+{
+    /**
+     * @var int
+     * @Serializer\Type("string")
+     * @Serializer\Accessor(getter="getAttributeString",setter="setAttribute")
+     * @Serializer\XmlAttribute
+     */
+    protected $attribute;
+
+    /**
+     * @var int
+     * @Serializer\Type("string")
+     * @Serializer\Accessor(getter="getElementString",setter="setElement")
+     * @Serializer\XmlElement(cdata=false)
+     * @Serializer\XmlValue
+     */
+    protected $element;
+
+
+    /**
+     * @return int
+     */
+    public function getAttributeTimestamp()
+    {
+        return $this->attribute;
+    }
+
+    /**
+     * @return string
+     */
+    public function getAttributeString()
+    {
+        return date('Y-m-d H:i:s', $this->attribute);
+    }
+
+    /**
+     * @param int|string|\DateTime $value
+     * @throws \InvalidArgumentException
+     */
+    public function setAttribute($value)
+    {
+        if (is_int($value)) {
+            $this->attribute = $value;
+        } else if (is_string($value)) {
+            $this->attribute = strtotime($value);
+        } else if ($value instanceof \DateTime) {
+            $this->attribute = $value->getTimestamp();
+        } else {
+            throw new \InvalidArgumentException();
+        }
+    }
+
+
+    /**
+     * @return int
+     */
+    public function getElementTimestamp()
+    {
+        return $this->element;
+    }
+
+    /**
+     * @return string
+     */
+    public function getElementString()
+    {
+        return date('Y-m-d H:i:s', $this->element);
+    }
+
+    /**
+     * @param int|string|\DateTime $value
+     * @throws \InvalidArgumentException
+     */
+    public function setElement($value)
+    {
+        if (is_int($value)) {
+            $this->element = $value;
+        } else if (is_string($value)) {
+            $this->element = strtotime($value);
+        } else if ($value instanceof \DateTime) {
+            $this->element = $value->getTimestamp();
+        } else {
+            throw new \InvalidArgumentException();
+        }
+    }
+
+} 

--- a/tests/JMS/Serializer/Tests/Serializer/XmlSerializationTest.php
+++ b/tests/JMS/Serializer/Tests/Serializer/XmlSerializationTest.php
@@ -251,6 +251,18 @@ class XmlSerializationTest extends BaseSerializationTest
         $this->assertEquals($this->getContent('simple_subclass_object'), $this->serialize($childObject));
     }
 
+    public function testAccessorSetterDeserialization()
+    {
+        /** @var \JMS\Serializer\Tests\Fixtures\AccessorSetter $object */
+        $object = $this->deserialize('<?xml version="1.0"?>
+            <AccessorSetter attribute="2014-07-21T14:37:28Z">2015-07-21T14:37:28Z</AccessorSetter>',
+            'JMS\Serializer\Tests\Fixtures\AccessorSetter'
+        );
+
+        $this->assertEquals(1405953448, $object->getAttributeTimestamp());
+        $this->assertEquals(1437489448, $object->getElementTimestamp());
+    }
+
     private function xpathFirstToString(\SimpleXMLElement $xml, $xpath)
     {
         $nodes = $xml->xpath($xpath);


### PR DESCRIPTION
If you mark a property with XmlAttribute and Accessor getter/setter, during serialization the getter method will be called, but during deserialization setter method is not called. Setter is also not called in case property has XmlValue annotation.

Example:

``` php
class Assertion
{
    /**
     * @var int
     * @JMS\Type("string")
     * @JMS\Accessor(getter="getIssueInstantString", setter="setIssueInstant")
     * @JMS\SerializedName("IssueInstant")
     * @JMS\XmlAttribute
     */
    protected $issueInstant;

    /**
     * @return string
     */
    public function getIssueInstantString()
    {
        return Helper::time2string($this->issueInstant);
    }

    /**
     * @return string
     */
    public function getIssueInstantTimestamp()
    {
        return $this->issueInstant;
    }

    /**
     * @param string|int|\DateTime $issueInstant
     * @throws \InvalidArgumentException
     * @return $this|Assertion
     */
    public function setIssueInstant($issueInstant)
    {
        if (is_string($issueInstant)) {
            $this->issueInstant = Helper::parseSAMLTime($issueInstant);
        } else if ($issueInstant instanceof \DateTime) {
            $this->issueInstant = $issueInstant->getTimestamp();
        } else if (is_int($issueInstant)) {
            $this->issueInstant = $issueInstant;
        } else {
            throw new \InvalidArgumentException();
        }
        return $this;
    }

}
```

XML for deserialization

``` xml
<?xml version="1.0" encoding="UTF-8"?>
<Assertion IssueInstant="2014-07-21T14:37:28Z">
</Assertion>
```

Test

``` php
class AssertionTest extends \PHPUnit_Framework_TestCase
{
    public function testDeserialization()
    {
        $xml = <<<EOT
<?xml version="1.0" encoding="UTF-8"?>
<Assertion IssueInstant="2014-07-21T14:37:28Z">
</Assertion>
EOT;
        AnnotationRegistry::registerLoader('class_exists');
        $serializer = \JMS\Serializer\SerializerBuilder::create()->build();
        $assertion = $serializer ->deserialize($xml, 'Assertion', 'xml');

        // actual value is "2014-07-21T14:37:28Z" directly set by reflection, rather then setter method called
        $this->assertEquals(1405953448, $assertion->getIssueInstantTimestamp());
}
```

Suggested fix:
Class `JMS\Serializer\XmlDeserializationVisitor`
Method: `visitProperty(...)`
When value `$v` is obtained do

``` php
        if (null === $metadata->setter) {
            $metadata->reflection->setValue($this->currentObject, $v);
            return;
        }
        $this->currentObject->{$metadata->setter}($v);
```

instead of just

``` php
$metadata->reflection->setValue($this->currentObject, $v);
```

like it's done in the fallback on the end of that method.

Eventually, extract those few lines into separate method and prevent duplication of code.
