### PR TITLE
Optional setting to deserialize bigint as strings

### DIFF
--- a/src/JMS/Serializer/JsonDeserializationVisitor.php
+++ b/src/JMS/Serializer/JsonDeserializationVisitor.php
@@ -19,12 +19,25 @@
 namespace JMS\Serializer;
 
 use JMS\Serializer\Exception\RuntimeException;
+use JMS\Serializer\Naming\PropertyNamingStrategyInterface;
 
 class JsonDeserializationVisitor extends GenericDeserializationVisitor
 {
+    protected $jsonBigIntAsString;
+
+    public function __construct(PropertyNamingStrategyInterface $namingStrategy, $jsonBigIntAsString)
+    {
+        parent::__construct($namingStrategy);
+        $this->jsonBigIntAsString = $jsonBigIntAsString;
+    }
+
     protected function decode($str)
     {
-        $decoded = json_decode($str, true);
+        if ($this->jsonBigIntAsString) {
+            $decoded = json_decode($str, true, $depth = 512, JSON_BIGINT_AS_STRING);
+        } else {
+            $decoded = json_decode($str, true);
+        }
 
         switch (json_last_error()) {
             case JSON_ERROR_NONE:

--- a/src/JMS/Serializer/JsonDeserializationVisitor.php
+++ b/src/JMS/Serializer/JsonDeserializationVisitor.php
@@ -23,7 +23,7 @@ use JMS\Serializer\Naming\PropertyNamingStrategyInterface;
 
 class JsonDeserializationVisitor extends GenericDeserializationVisitor
 {
-    protected $jsonBigIntAsString;
+    private $jsonBigIntAsString;
 
     public function __construct(PropertyNamingStrategyInterface $namingStrategy, $jsonBigIntAsString = false)
     {

--- a/src/JMS/Serializer/JsonDeserializationVisitor.php
+++ b/src/JMS/Serializer/JsonDeserializationVisitor.php
@@ -25,7 +25,7 @@ class JsonDeserializationVisitor extends GenericDeserializationVisitor
 {
     protected $jsonBigIntAsString;
 
-    public function __construct(PropertyNamingStrategyInterface $namingStrategy, $jsonBigIntAsString)
+    public function __construct(PropertyNamingStrategyInterface $namingStrategy, $jsonBigIntAsString = false)
     {
         parent::__construct($namingStrategy);
         $this->jsonBigIntAsString = $jsonBigIntAsString;

--- a/src/JMS/Serializer/SerializerBuilder.php
+++ b/src/JMS/Serializer/SerializerBuilder.php
@@ -68,6 +68,7 @@ class SerializerBuilder
     private $visitorsAdded = false;
     private $propertyNamingStrategy;
     private $debug = false;
+    private $jsonBigIntAsString = false;
     private $cacheDir;
     private $annotationReader;
     private $includeInterfaceMetadata = false;
@@ -97,6 +98,13 @@ class SerializerBuilder
     public function setDebug($bool)
     {
         $this->debug = (boolean) $bool;
+
+        return $this;
+    }
+
+    public function setUseJsonBigIntAsString($bool)
+    {
+        $this->jsonBigIntAsString = (boolean) $bool;
 
         return $this;
     }
@@ -201,7 +209,7 @@ class SerializerBuilder
         $this->visitorsAdded = true;
         $this->deserializationVisitors->setAll(array(
             'xml' => new XmlDeserializationVisitor($this->propertyNamingStrategy),
-            'json' => new JsonDeserializationVisitor($this->propertyNamingStrategy),
+            'json' => new JsonDeserializationVisitor($this->propertyNamingStrategy, $this->jsonBigIntAsString),
         ));
 
         return $this;

--- a/tests/JMS/Serializer/Tests/Serializer/BaseSerializationTest.php
+++ b/tests/JMS/Serializer/Tests/Serializer/BaseSerializationTest.php
@@ -950,7 +950,7 @@ abstract class BaseSerializationTest extends \PHPUnit_Framework_TestCase
             'yml'  => new YamlSerializationVisitor($namingStrategy),
         ));
         $this->deserializationVisitors = new Map(array(
-            'json' => new JsonDeserializationVisitor($namingStrategy),
+            'json' => new JsonDeserializationVisitor($namingStrategy, true),
             'xml'  => new XmlDeserializationVisitor($namingStrategy),
         ));
 

--- a/tests/JMS/Serializer/Tests/Serializer/JsonSerializationTest.php
+++ b/tests/JMS/Serializer/Tests/Serializer/JsonSerializationTest.php
@@ -39,6 +39,7 @@ class JsonSerializationTest extends BaseSerializationTest
             $outputs['boolean_true'] = 'true';
             $outputs['boolean_false'] = 'false';
             $outputs['integer'] = '1';
+            $outputs['big_integer'] = '1000007546090751';
             $outputs['float'] = '4.533';
             $outputs['float_trailing_zero'] = '1';
             $outputs['simple_object'] = '{"foo":"foo","moo":"bar","camel_case":"boo"}';
@@ -202,6 +203,13 @@ class JsonSerializationTest extends BaseSerializationTest
     public function testSerializeArrayWithEmptyObject()
     {
         $this->assertEquals('{"0":{}}', $this->serialize(array(new \stdClass())));
+    }
+
+    public function testDeserializeBigInteger()
+    {
+        if ($this->hasDeserializer()) {
+            $this->assertEquals("1000007546090751", $this->deserialize($this->getContent('big_integer'), 'string'));
+        }
     }
 
     protected function getFormat()


### PR DESCRIPTION
Currently im not able to deserialize json with big integers, 
when json contains
{ 'big-int': 1000007546090751}
its deserialized as '1.0000076544307E+15'