### PR TITLE
Default `$serializeNull` to false

### DIFF
--- a/src/JMS/Serializer/Context.php
+++ b/src/JMS/Serializer/Context.php
@@ -52,7 +52,7 @@ abstract class Context
     private $exclusionStrategy;
 
     /** @var boolean */
-    private $serializeNull;
+    private $serializeNull = false;
 
     private $initialized = false;
 


### PR DESCRIPTION
`JMS\Serializer\Context::serializeNull` is a boolean, so should default to false, not null.