### PR TITLE
Only parse direction once per direction

### DIFF
--- a/src/JMS/Serializer/Metadata/Driver/YamlDriver.php
+++ b/src/JMS/Serializer/Metadata/Driver/YamlDriver.php
@@ -195,8 +195,8 @@ class YamlDriver extends AbstractFileDriver
 
         if (isset($config['handler_callbacks'])) {
             foreach ($config['handler_callbacks'] as $direction => $formats) {
+                $direction = GraphNavigator::parseDirection($direction);
                 foreach ($formats as $format => $methodName) {
-                    $direction = GraphNavigator::parseDirection($direction);
                     $metadata->addHandlerCallback($direction, $format, $methodName);
                 }
             }


### PR DESCRIPTION
Solves an InvalidArgumentException when defining two serializers for one
direction:
```yml
// ..
    handler_callbacks:
        serialization:
            json: serializeToJson
            json_ld: serializeToJsonLd
```