### PR TITLE
Ability to replace and set data on current object/root element through the visitor.

### DIFF
--- a/src/JMS/Serializer/GenericSerializationVisitor.php
+++ b/src/JMS/Serializer/GenericSerializationVisitor.php
@@ -169,6 +169,63 @@ abstract class GenericSerializationVisitor extends AbstractVisitor
         $this->data[$key] = $value;
     }
 
+    /**
+     * Allows replacing an existing data on the current object/root element.
+     *
+     * @param $key
+     * @param $value
+     *
+     * @throws Exception\InvalidArgumentException
+     */
+    public function replaceData($key, $value)
+    {
+        if (!isset($this->data[$key])) {
+            throw new InvalidArgumentException(sprintf('There is no data for "%s".', $key));
+        }
+
+        $this->data[$key] = $value;
+    }
+
+    /**
+     * Allows setting data on the current object/root element. Adds if doesn't exist, replaces otherwise.
+     *
+     * @param $key
+     * @param $data
+     */
+    public function setData($key, $data)
+    {
+        $this->data[$key] = $data;
+    }
+
+    /**
+     * Allows retrieving data from current object/root element.
+     *
+     * @param $key
+     *
+     * @throws Exception\InvalidArgumentException
+     * @return mixed
+     */
+    public function getData($key)
+    {
+        if ($this->data[$key]) {
+            return $this->data[$key];
+        } else {
+            throw new InvalidArgumentException(sprintf('There is no data for "%s".', $key));
+        }
+    }
+
+    /**
+     * Check if data is set on current object/root element
+     *
+     * @param $key
+     *
+     * @return bool
+     */
+    public function hasData($key)
+    {
+        return isset($this->data[$key]);
+    }
+
     public function getRoot()
     {
         return $this->root;

--- a/tests/JMS/Serializer/Tests/Serializer/JsonSerializationTest.php
+++ b/tests/JMS/Serializer/Tests/Serializer/JsonSerializationTest.php
@@ -114,7 +114,7 @@ class JsonSerializationTest extends BaseSerializationTest
         $list->add(new Author('foo'));
         $list->add(new Author('bar'));
 
-        $this->assertEquals('[{"full_name":"foo","_links":{"details":"http:\/\/foo.bar\/details\/foo","comments":"http:\/\/foo.bar\/details\/foo\/comments"}},{"full_name":"bar","_links":{"details":"http:\/\/foo.bar\/details\/bar","comments":"http:\/\/foo.bar\/details\/bar\/comments"}}]', $this->serialize($list));
+        $this->assertEquals('[{"full_name":"FOO","_links":{"details":"http:\/\/foo.bar\/details\/foo","comments":"http:\/\/foo.bar\/details\/foo\/comments"}},{"full_name":"BAR","_links":{"details":"http:\/\/foo.bar\/details\/bar","comments":"http:\/\/foo.bar\/details\/bar\/comments"}}]', $this->serialize($list));
     }
 
     public function getPrimitiveTypes()
@@ -222,10 +222,17 @@ class LinkAddingSubscriber implements EventSubscriberInterface
         ));
     }
 
+    public function onPostSerializeTwo(Event $event)
+    {
+        $author = $event->getObject();
+        $event->getVisitor()->replaceData('full_name', strtoupper($event->getVisitor()->getData('full_name')));
+    }
+
     public static function getSubscribedEvents()
     {
         return array(
             array('event' => 'serializer.post_serialize', 'method' => 'onPostSerialize', 'format' => 'json', 'class' => 'JMS\Serializer\Tests\Fixtures\Author'),
+            array('event' => 'serializer.post_serialize', 'method' => 'onPostSerializeTwo', 'format' => 'json', 'class' => 'JMS\Serializer\Tests\Fixtures\Author'),
         );
     }
 }


### PR DESCRIPTION
Sometimes there is a need to modify data during `serializer.post_serialize`, right before returning the data in the final format, i.e., passing values through a filter to humanize normalized values, etc.

Currently it only allows adding extra values, not replacing existing ones. This PR adds that ability.

Its a very simple patch and I can't imagine this breaking anything. but if this introduce any potential problems that I'm not aware of, please let me know.
