### PR TITLE
Fix serialization of array with empty object into JSON

### DIFF
--- a/src/JMS/Serializer/JsonSerializationVisitor.php
+++ b/src/JMS/Serializer/JsonSerializationVisitor.php
@@ -24,6 +24,8 @@ class JsonSerializationVisitor extends GenericSerializationVisitor
 {
     private $options = 0;
 
+    private $rootIsArray = false;
+
     public function getResult()
     {
         $result = @json_encode($this->getRoot(), $this->options);
@@ -52,6 +54,10 @@ class JsonSerializationVisitor extends GenericSerializationVisitor
 
     public function visitArray($data, array $type, Context $context)
     {
+        if (null === $this->getRoot()) {
+            $this->rootIsArray = true;
+        }
+
         $result = parent::visitArray($data, $type, $context);
 
         if (null !== $this->getRoot() && isset($type['params'][1]) && 0 === count($result)) {
@@ -71,7 +77,7 @@ class JsonSerializationVisitor extends GenericSerializationVisitor
         if (empty($rs)) {
             $rs = new \ArrayObject();
 
-            if (array() === $this->getRoot()) {
+            if (array() === $this->getRoot() && !$this->rootIsArray) {
                 $this->setRoot(clone $rs);
             }
         }

--- a/tests/JMS/Serializer/Tests/Serializer/JsonSerializationTest.php
+++ b/tests/JMS/Serializer/Tests/Serializer/JsonSerializationTest.php
@@ -201,7 +201,8 @@ class JsonSerializationTest extends BaseSerializationTest
 
     public function testSerializeArrayWithEmptyObject()
     {
-        $this->assertEquals('{"0":{}}', $this->serialize(array(new \stdClass())));
+        $this->assertEquals('[{}]', $this->serialize(array(new \stdClass())));
+        $this->assertEquals('{"a":[{}]}', $this->serialize(array('a' => array(new \stdClass()))));
     }
 
     protected function getFormat()


### PR DESCRIPTION
Do not replace empty root with `ArrayObject` in `JsonSerializationVisitor::endVisitingObject()` when serialization was started as `array`.

Related issues:  #323, #277, #267, #242