### PR TITLE
GraphNavigatorInterface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ For instructions on how to upgrade from one version to another, please see the d
 ---------
 - [BC Break] Passes DeserializationContext to ObjectConstructor instances as additional argument
 - adds a handler for Propel related classes
+- make `GraphNavigator` class replaceable by introducing `GraphNavigatorInterface`
 
 0.13 (2013-07-29)
 -----------------

--- a/src/JMS/Serializer/Context.php
+++ b/src/JMS/Serializer/Context.php
@@ -67,7 +67,7 @@ abstract class Context
     /**
      * @param string $format
      */
-    public function initialize($format, VisitorInterface $visitor, GraphNavigator $navigator, MetadataFactoryInterface $factory)
+    public function initialize($format, VisitorInterface $visitor, GraphNavigatorInterface $navigator, MetadataFactoryInterface $factory)
     {
         if ($this->initialized) {
             throw new \LogicException('This context was already initialized, and cannot be re-used.');

--- a/src/JMS/Serializer/Context.php
+++ b/src/JMS/Serializer/Context.php
@@ -42,7 +42,7 @@ abstract class Context
     /** @var VisitorInterface */
     private $visitor;
 
-    /** @var GraphNavigator */
+    /** @var GraphNavigatorInterface */
     private $navigator;
 
     /** @var MetadataFactory */

--- a/src/JMS/Serializer/GenericDeserializationVisitor.php
+++ b/src/JMS/Serializer/GenericDeserializationVisitor.php
@@ -34,7 +34,7 @@ abstract class GenericDeserializationVisitor extends AbstractVisitor
     private $objectStack;
     private $currentObject;
 
-    public function setNavigator(GraphNavigator $navigator)
+    public function setNavigator(GraphNavigatorInterface $navigator)
     {
         $this->navigator = $navigator;
         $this->result = null;

--- a/src/JMS/Serializer/GenericSerializationVisitor.php
+++ b/src/JMS/Serializer/GenericSerializationVisitor.php
@@ -29,7 +29,7 @@ abstract class GenericSerializationVisitor extends AbstractVisitor
     private $dataStack;
     private $data;
 
-    public function setNavigator(GraphNavigator $navigator)
+    public function setNavigator(GraphNavigatorInterface $navigator)
     {
         $this->navigator = $navigator;
         $this->root = null;

--- a/src/JMS/Serializer/GraphNavigator.php
+++ b/src/JMS/Serializer/GraphNavigator.php
@@ -37,7 +37,7 @@ use JMS\Serializer\Exception\InvalidArgumentException;
  *
  * @author Johannes M. Schmitt <schmittjoh@gmail.com>
  */
-final class GraphNavigator
+final class GraphNavigator implements GraphNavigatorInterface
 {
     const DIRECTION_SERIALIZATION = 1;
     const DIRECTION_DESERIALIZATION = 2;

--- a/src/JMS/Serializer/GraphNavigatorInterface.php
+++ b/src/JMS/Serializer/GraphNavigatorInterface.php
@@ -1,0 +1,39 @@
+<?php
+
+/*
+ * Copyright 2013 Johannes M. Schmitt <schmittjoh@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace JMS\Serializer;
+
+
+/**
+ * GraphNavigator interface
+ *
+ * @author Xavier Lacot <xavier@lacot.org>
+ */
+interface GraphNavigatorInterface
+{
+    /**
+     * Called for each node of the graph that is being traversed.
+     *
+     * @param mixed $data the data depends on the direction, and type of visitor
+     * @param null|array $type array has the format ["name" => string, "params" => array]
+     * @param boolean $isRoot whether or not we are accepting the root
+     *
+     * @return mixed the return value depends on the direction, and type of visitor
+     */
+    public function accept($data, array $type = null, Context $context);
+}

--- a/src/JMS/Serializer/SerializationContext.php
+++ b/src/JMS/Serializer/SerializationContext.php
@@ -38,7 +38,7 @@ class SerializationContext extends Context
     /**
      * @param string $format
      */
-    public function initialize($format, VisitorInterface $visitor, GraphNavigator $navigator, MetadataFactoryInterface $factory)
+    public function initialize($format, VisitorInterface $visitor, GraphNavigatorInterface $navigator, MetadataFactoryInterface $factory)
     {
         parent::initialize($format, $visitor, $navigator, $factory);
 

--- a/src/JMS/Serializer/VisitorInterface.php
+++ b/src/JMS/Serializer/VisitorInterface.php
@@ -126,7 +126,7 @@ interface VisitorInterface
      *
      * @return void
      */
-    public function setNavigator(GraphNavigator $navigator);
+    public function setNavigator(GraphNavigatorInterface $navigator);
 
     /**
      * @deprecated use Context::getNavigator/Context::accept instead

--- a/src/JMS/Serializer/XmlDeserializationVisitor.php
+++ b/src/JMS/Serializer/XmlDeserializationVisitor.php
@@ -41,7 +41,7 @@ class XmlDeserializationVisitor extends AbstractVisitor
         $this->disableExternalEntities = false;
     }
 
-    public function setNavigator(GraphNavigator $navigator)
+    public function setNavigator(GraphNavigatorInterface $navigator)
     {
         $this->navigator = $navigator;
         $this->objectStack = new \SplStack;

--- a/src/JMS/Serializer/XmlSerializationVisitor.php
+++ b/src/JMS/Serializer/XmlSerializationVisitor.php
@@ -67,7 +67,7 @@ class XmlSerializationVisitor extends AbstractVisitor
         $this->defaultEncoding = $encoding;
     }
 
-    public function setNavigator(GraphNavigator $navigator)
+    public function setNavigator(GraphNavigatorInterface $navigator)
     {
         $this->navigator = $navigator;
         $this->document = null;
@@ -199,7 +199,7 @@ class XmlSerializationVisitor extends AbstractVisitor
             }
             $this->document->appendChild($this->currentNode);
         }
-        
+
         $this->addNamespaceAttributes($metadata, $this->currentNode);
 
         $this->hasValue = false;
@@ -421,7 +421,7 @@ class XmlSerializationVisitor extends AbstractVisitor
             $this->nullWasVisited = true;
         }
     }
-    
+
     /**
      * Adds namespace attributes to the XML root element
      *

--- a/src/JMS/Serializer/YamlSerializationVisitor.php
+++ b/src/JMS/Serializer/YamlSerializationVisitor.php
@@ -46,7 +46,7 @@ class YamlSerializationVisitor extends AbstractVisitor
         $this->writer = new Writer();
     }
 
-    public function setNavigator(GraphNavigator $navigator)
+    public function setNavigator(GraphNavigatorInterface $navigator)
     {
         $this->navigator = $navigator;
         $this->writer->reset();


### PR DESCRIPTION
Several visitor classes depend on the `JMS\Serializer\GraphNavigator` class, which is a `final` class. Switching the signatures of these visitors so that they to depend on a `GraphNavigatorInterface` instead of the class itself, allows more flexibility, and makes the `GraphNavigator` component replaceable.

Closes https://github.com/schmittjoh/JMSSerializerBundle/issues/238
