### PR TITLE
Support for MongoDB ODM

### DIFF
--- a/src/JMS/Serializer/Metadata/Driver/DoctrineTypeDriver.php
+++ b/src/JMS/Serializer/Metadata/Driver/DoctrineTypeDriver.php
@@ -30,13 +30,24 @@ class DoctrineTypeDriver extends AbstractDoctrineTypeDriver
 {
     protected function setDiscriminator(DoctrineClassMetadata $doctrineMetadata, ClassMetadata $classMetadata)
     {
-        if (empty($classMetadata->discriminatorMap) && ! $classMetadata->discriminatorDisabled
-            && ! empty($doctrineMetadata->discriminatorMap) && $doctrineMetadata->isRootEntity()
-        ) {
-            $classMetadata->setDiscriminator(
-                $doctrineMetadata->discriminatorColumn['name'],
-                $doctrineMetadata->discriminatorMap
-            );
+        if (method_exists($doctrineMetadata, 'mapField')) {
+            if (empty($classMetadata->discriminatorMap) && ! $classMetadata->discriminatorDisabled
+                && ! empty($doctrineMetadata->discriminatorMap) && $doctrineMetadata->isMappedSuperclass
+            ) {
+                $classMetadata->setDiscriminator(
+                    $doctrineMetadata->discriminatorField['name'],
+                    $doctrineMetadata->discriminatorMap
+                );
+            }
+        } else {
+            if (empty($classMetadata->discriminatorMap) && ! $classMetadata->discriminatorDisabled
+                && ! empty($doctrineMetadata->discriminatorMap) && $doctrineMetadata->isRootEntity()
+            ) {
+                $classMetadata->setDiscriminator(
+                    $doctrineMetadata->discriminatorColumn['name'],
+                    $doctrineMetadata->discriminatorMap
+                );
+            }
         }
     }
 


### PR DESCRIPTION
Method "isRootEntity" does not exist outside of the ORM implementation.  MappedSuperClass should allow for the differentiation.
Also changed from discriminatorColumn to discriminatorField when MongoDB
