### PR TITLE
Change Proxy class used to Doctrine\Common\Persistence\Proxy

### DIFF
--- a/tests/JMS/Serializer/Tests/Fixtures/SimpleObjectProxy.php
+++ b/tests/JMS/Serializer/Tests/Fixtures/SimpleObjectProxy.php
@@ -18,7 +18,7 @@
 
 namespace JMS\Serializer\Tests\Fixtures;
 
-use Doctrine\ORM\Proxy\Proxy;
+use Doctrine\Common\Persistence\Proxy;
 
 class SimpleObjectProxy extends SimpleObject implements Proxy
 {


### PR DESCRIPTION
Tests are currently failing with recent doctrine orm as proxy classes needs to implement several other methods