### PR TITLE
add prefix for default namespace

### DIFF
--- a/src/JMS/Serializer/XmlDeserializationVisitor.php
+++ b/src/JMS/Serializer/XmlDeserializationVisitor.php
@@ -258,7 +258,7 @@ class XmlDeserializationVisitor extends AbstractVisitor
 
         if ('' !== $namespace = (string) $metadata->xmlNamespace) {
             $registeredNamespaces = $data->getDocNamespaces();
-            if (false === $prefix = array_search($namespace, $registeredNamespaces)) {
+            if (!$prefix = array_search($namespace, $registeredNamespaces)) {
                 $prefix = uniqid('ns-');
                 $data->registerXPathNamespace($prefix, $namespace);
             }


### PR DESCRIPTION
if you meet an element with default namespace, you still need to register a prefix for it to use xpath.

the reason behind it is that most of today environments use libs based on xpath1.0 which doesn't have "default namespace" entity in its specification while xpath2.0 does.

i'm proposing to use this options as it will both work for xpath1.0 and 2.0 while search without prefix will only work in xpath2.0