### PR TITLE
fixed wrong result generation in visitArray if values are skipped

### DIFF
--- a/src/JMS/Serializer/GenericSerializationVisitor.php
+++ b/src/JMS/Serializer/GenericSerializationVisitor.php
@@ -98,14 +98,24 @@ abstract class GenericSerializationVisitor extends AbstractVisitor
             $rs = array();
         }
 
+        $i = 0;
+        $isHash = false;
         foreach ($data as $k => $v) {
+            if ($k !== $i++) {
+                $isHash = true;
+            }
+            
             $v = $this->navigator->accept($v, $this->getElementType($type), $context);
 
             if (null === $v && (!is_string($k) || !$context->shouldSerializeNull())) {
                 continue;
             }
 
-            $rs[$k] = $v;
+            if ($isHash) {
+                $rs[$k] = $v;
+            } else {
+                $rs[] = $v;
+            }
         }
 
         return $rs;

--- a/src/JMS/Serializer/GenericSerializationVisitor.php
+++ b/src/JMS/Serializer/GenericSerializationVisitor.php
@@ -24,8 +24,10 @@ use JMS\Serializer\Metadata\PropertyMetadata;
 
 abstract class GenericSerializationVisitor extends AbstractVisitor
 {
+    /** @var GraphNavigator */
     private $navigator;
     private $root;
+    /** @var \SplStack */
     private $dataStack;
     private $data;
 
@@ -88,6 +90,9 @@ abstract class GenericSerializationVisitor extends AbstractVisitor
     /**
      * @param array $data
      * @param array $type
+     * @param Context $context
+     *
+     * @return array
      */
     public function visitArray($data, array $type, Context $context)
     {

--- a/tests/JMS/Serializer/Tests/Serializer/JsonSerializationTest.php
+++ b/tests/JMS/Serializer/Tests/Serializer/JsonSerializationTest.php
@@ -204,6 +204,14 @@ class JsonSerializationTest extends BaseSerializationTest
         $this->assertEquals('{"0":{}}', $this->serialize(array(new \stdClass())));
     }
 
+    public function testSerializeArrayPreserveSequentialWhenSkipNull()
+    {
+        $this->assertEquals('[1]', $this->serialize(array(null, 1)));
+        $this->assertEquals('[1]', $this->serialize(array(null, 1 => 1)));
+        $this->assertEquals('{"2":1}', $this->serialize(array(null, 2 => 1)));
+        $this->assertEquals('{"a":1}', $this->serialize(array(null, "a" => 1)));
+    }
+
     protected function getFormat()
     {
         return 'json';


### PR DESCRIPTION
If the navigator return ```null``` and it should be skipped then the ```rs``` array loses his sequential indexes so you will get an object instead of an array in JSON.