### PR TITLE
Fix createFromFormat false with format c

### DIFF
--- a/src/JMS/Serializer/Handler/DateHandler.php
+++ b/src/JMS/Serializer/Handler/DateHandler.php
@@ -106,7 +106,12 @@ class DateHandler implements SubscribingHandlerInterface
     {
         $timezone = isset($type['params'][1]) ? new \DateTimeZone($type['params'][1]) : $this->defaultTimezone;
         $format = $this->getFormat($type);
-        $datetime = \DateTime::createFromFormat($format, (string) $data, $timezone);
+        if ($format == 'c')
+        {
+            $datetime = new \DateTime((string) $data, $timezone);
+        } else {
+            $datetime = \DateTime::createFromFormat($format, (string) $data, $timezone);
+        }
         if (false === $datetime) {
             throw new RuntimeException(sprintf('Invalid datetime "%s", expected format %s.', $data, $format));
         }


### PR DESCRIPTION
Due to an error in php which returns false when using createFromFormat with format c probably related to the issue https://bugs.php.net/bug.php?id=51950 when the format is c the string is passed into the constructor.
