### PR TITLE
Throw exception with clear message in case of int and bool as type

### DIFF
--- a/src/JMS/Serializer/GraphNavigator.php
+++ b/src/JMS/Serializer/GraphNavigator.php
@@ -136,6 +136,12 @@ final class GraphNavigator
 
                 throw new RuntimeException($msg);
 
+            case 'int':
+                throw new RuntimeException('Use integer as type instead of int.');
+
+            case 'bool':
+                throw new RuntimeException('Use boolean as type instead of bool.');
+
             default:
                 // TODO: The rest of this method needs some refactoring.
                 if ($context instanceof SerializationContext) {

--- a/tests/JMS/Serializer/Tests/Serializer/GraphNavigatorTest.php
+++ b/tests/JMS/Serializer/Tests/Serializer/GraphNavigatorTest.php
@@ -48,6 +48,33 @@ class GraphNavigatorTest extends \PHPUnit_Framework_TestCase
         $this->navigator->accept(STDIN, null, $this->context);
     }
 
+    /**
+     * @expectedException JMS\Serializer\Exception\RuntimeException
+     * @expectedExceptionMessage Use integer as type instead of int.
+     */
+    public function testTypeIntThrowsException()
+    {
+        $this->context->expects($this->any())
+            ->method('getDirection')
+            ->will($this->returnValue(GraphNavigator::DIRECTION_SERIALIZATION));
+
+        $this->navigator->accept(10, ['name' => 'int'], $this->context);
+    }
+
+    /**
+     * @expectedException JMS\Serializer\Exception\RuntimeException
+     * @expectedExceptionMessage Use boolean as type instead of bool.
+     */
+    public function testTypeBoolThrowsException()
+    {
+        $this->context->expects($this->any())
+            ->method('getDirection')
+            ->will($this->returnValue(GraphNavigator::DIRECTION_SERIALIZATION));
+
+        $this->navigator->accept(true, ['name' => 'bool'], $this->context);
+    }
+
+
     public function testNavigatorPassesInstanceOnSerialization()
     {
         $object = new SerializableClass;


### PR DESCRIPTION
I'm always using int and bool instead of integer and boolean on types and then get a very generic exception message, this makes easier to find the problem.