### PR TITLE
return integer instead of string when the column is datetime and the format is timestamp

### DIFF
--- a/src/JMS/Serializer/Handler/DateHandler.php
+++ b/src/JMS/Serializer/Handler/DateHandler.php
@@ -69,6 +69,7 @@ class DateHandler implements SubscribingHandlerInterface
         if ($visitor instanceof XmlSerializationVisitor && false === $this->xmlCData) {
             return $visitor->visitSimpleString($date->format($this->getFormat($type)), $type, $context);
         }
+        $format = $this->getFormat($type);
         if("U"==$format){
             return $visitor->visitInteger($date->format($format), $type, $context);
         }else {

--- a/src/JMS/Serializer/Handler/DateHandler.php
+++ b/src/JMS/Serializer/Handler/DateHandler.php
@@ -69,7 +69,11 @@ class DateHandler implements SubscribingHandlerInterface
         if ($visitor instanceof XmlSerializationVisitor && false === $this->xmlCData) {
             return $visitor->visitSimpleString($date->format($this->getFormat($type)), $type, $context);
         }
-        return $visitor->visitString($date->format($this->getFormat($type)), $type, $context);
+        if("U"==$format){
+            return $visitor->visitInteger($date->format($format), $type, $context);
+        }else {
+            return $visitor->visitString($date->format($format), $type, $context);
+        }
     }
 
     public function serializeDateInterval(VisitorInterface $visitor, \DateInterval $date, array $type, Context $context)


### PR DESCRIPTION
It's useful for api development. 