### PR TITLE
Fix inheritance of discriminators on Doctrine entities

### DIFF
--- a/src/JMS/Serializer/Metadata/ClassMetadata.php
+++ b/src/JMS/Serializer/Metadata/ClassMetadata.php
@@ -158,6 +158,13 @@ class ClassMetadata extends MergeableClassMetadata
                 $this->discriminatorBaseClass,
                 $this->discriminatorBaseClass
             ));
+        } elseif ( ! $this->discriminatorFieldName && $object->discriminatorFieldName) {
+            $this->discriminatorFieldName = $object->discriminatorFieldName;
+            $this->discriminatorMap = $object->discriminatorMap;
+        }
+
+        if ($object->discriminatorDisabled !== null) {
+            $this->discriminatorDisabled = $object->discriminatorDisabled;
         }
 
         if ($this->discriminatorMap && ! $this->reflection->isAbstract()) {

--- a/tests/JMS/Serializer/Tests/Fixtures/Doctrine/SingleTableInheritance/AbstractModel.php
+++ b/tests/JMS/Serializer/Tests/Fixtures/Doctrine/SingleTableInheritance/AbstractModel.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace JMS\Serializer\Tests\Fixtures\Doctrine\SingleTableInheritance;
+
+/**
+ * Abstract base class without Entity annotation
+ */
+abstract class AbstractModel
+{
+}

--- a/tests/JMS/Serializer/Tests/Fixtures/Doctrine/SingleTableInheritance/Clazz.php
+++ b/tests/JMS/Serializer/Tests/Fixtures/Doctrine/SingleTableInheritance/Clazz.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace JMS\Serializer\Tests\Fixture\Doctrine\SingleTableInheritance;
+namespace JMS\Serializer\Tests\Fixtures\Doctrine\SingleTableInheritance;
 
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\ORM\Mapping as ORM;
@@ -9,7 +9,7 @@ use JMS\Serializer\Tests\Fixtures\Doctrine\SingleTableInheritance\Teacher;
 /**
  * @ORM\Entity
  */
-class Clazz
+class Clazz extends AbstractModel
 {
     /** @ORM\Id @ORM\GeneratedValue(strategy = "AUTO") @ORM\Column(type = "integer") */
     private $id;

--- a/tests/JMS/Serializer/Tests/Fixtures/Doctrine/SingleTableInheritance/Organization.php
+++ b/tests/JMS/Serializer/Tests/Fixtures/Doctrine/SingleTableInheritance/Organization.php
@@ -9,11 +9,10 @@ use Doctrine\ORM\Mapping as ORM;
  * @ORM\InheritanceType("SINGLE_TABLE")
  * @ORM\DiscriminatorColumn(name="type", type="string")
  * @ORM\DiscriminatorMap({
- *     "student" = "JMS\Serializer\Tests\Fixtures\Doctrine\SingleTableInheritance\Student",
- *     "teacher" = "JMS\Serializer\Tests\Fixtures\Doctrine\SingleTableInheritance\Teacher",
+ *     "school" = "JMS\Serializer\Tests\Fixtures\Doctrine\SingleTableInheritance\School"
  * })
  */
-abstract class Person extends AbstractModel
+abstract class Organization
 {
     /** @ORM\Id @ORM\GeneratedValue(strategy = "AUTO") @ORM\Column(type = "integer") */
     private $id;

--- a/tests/JMS/Serializer/Tests/Fixtures/Doctrine/SingleTableInheritance/School.php
+++ b/tests/JMS/Serializer/Tests/Fixtures/Doctrine/SingleTableInheritance/School.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace JMS\Serializer\Tests\Fixtures\Doctrine\SingleTableInheritance;
+
+use Doctrine\ORM\Mapping as ORM;
+
+/**
+ * @ORM\Entity
+ */
+class School extends Organization
+{
+}

--- a/tests/JMS/Serializer/Tests/Serializer/Doctrine/IntegrationTest.php
+++ b/tests/JMS/Serializer/Tests/Serializer/Doctrine/IntegrationTest.php
@@ -18,11 +18,12 @@ use JMS\Serializer\Serializer;
 use JMS\Serializer\SerializerBuilder;
 use Doctrine\ORM\EntityManager;
 use Doctrine\ORM\ORMException;
-use JMS\Serializer\Tests\Fixture\Doctrine\SingleTableInheritance\Clazz;
+use JMS\Serializer\Tests\Fixtures\Doctrine\SingleTableInheritance\Clazz;
 use JMS\Serializer\Tests\Fixtures\Doctrine\SingleTableInheritance\Excursion;
 use JMS\Serializer\Tests\Fixtures\Doctrine\SingleTableInheritance\Person;
 use JMS\Serializer\Tests\Fixtures\Doctrine\SingleTableInheritance\Student;
 use JMS\Serializer\Tests\Fixtures\Doctrine\SingleTableInheritance\Teacher;
+use JMS\Serializer\Tests\Fixtures\Doctrine\SingleTableInheritance\School;
 
 class IntegrationTest extends \PHPUnit_Framework_TestCase
 {
@@ -31,6 +32,20 @@ class IntegrationTest extends \PHPUnit_Framework_TestCase
 
     /** @var Serializer */
     private $serializer;
+
+    public function testDiscriminatorIsInferredForEntityBaseClass()
+    {
+        $school = new School();
+        $json = $this->serializer->serialize($school, 'json');
+        $this->assertEquals('{"type":"school"}', $json);
+    }
+
+    public function testDiscriminatorIsInferredForGenericBaseClass()
+    {
+        $student = new Student();
+        $json = $this->serializer->serialize($student, 'json');
+        $this->assertEquals('{"type":"student"}', $json);
+    }
 
     public function testDiscriminatorIsInferredFromDoctrine()
     {


### PR DESCRIPTION
The discriminator configuration in the class metadata of Doctrine entities breaks in cases where the base-entity extends another non-entity class. This PR adds a testcases for that problem as well as a fix.

Fixes the following issues:

  - #166 - _Discriminator related metadata overwritten by subsequent MetadataDriver in DriverChain_
  - #182 - _Deserialization fails when discriminator base class extends another class_
  - #296 - _Overwrite discriminator settings in metadata if not present in parent class_
  - #309 - _add / discriminator for classes in the middle of hierarchy_

Working
-------

Entity inherits from abstract entity.

```
abstract class Organization                         @ORM\Entity  @ORM\InheritanceType("SINGLE_TABLE")  @ORM\DiscriminatorMap(...)
 `- class School extends Organization               @ORM\Entity
```

```php
<?php
  $school = new School();
  $json = $this->serializer->serialize($school, 'json');
?>

--- Expected
+++ Actual
@@ @@
-'{"type":"school"}'
+'{"type":"school"}'
```

Broken
------

Entity inherits from abstract entity inherits from abstract non-entity.

```
abstract class AbstractModel                        (none)
 |- abstract class Person extends AbstractModel     @ORM\Entity  @ORM\InheritanceType("SINGLE_TABLE")  @ORM\DiscriminatorMap(...)
 |   |- class Student extends Person                @ORM\Entity
 |   `- class Teacher extends Person                @ORM\Entity
 `- class Clazz extends AbstractModel               @ORM\Entity
```

```php
<?php
  $student = new Student();
  $json = $this->serializer->serialize($student, 'json');
?>

--- Expected
+++ Actual
@@ @@
-'{"type":"student"}'
+'{}'
```
