### PR TITLE
Fix DoctrineObjectConstructor returning nulls instead of objects

### DIFF
--- a/src/JMS/Serializer/Construction/DoctrineObjectConstructor.php
+++ b/src/JMS/Serializer/Construction/DoctrineObjectConstructor.php
@@ -82,8 +82,14 @@ class DoctrineObjectConstructor implements ObjectConstructorInterface
             $identifierList[$name] = $data[$name];
         }
 
-        // Entity update, load it from database
+        // Entity update, try to load it from database
         $object = $objectManager->find($metadata->name, $identifierList);
+        
+        if ( ! is_object($object))
+        {
+        	// Entity with that identifier didn't exist, create a new Entity
+        	return $this->fallbackConstructor->construct($visitor, $metadata, $data, $type, $context);
+        }
 
         $objectManager->initializeObject($object);
 


### PR DESCRIPTION
Makes DoctrineObjectConstructor use the fallback constructor to create
a new object if the identifier computed from the metadata is not
currently stored in the database.  This previously just returned a null
value.
