### PR TITLE
Allow DateTime to be null

### DIFF
--- a/src/JMS/Serializer/Handler/DateHandler.php
+++ b/src/JMS/Serializer/Handler/DateHandler.php
@@ -95,7 +95,7 @@ class DateHandler implements SubscribingHandlerInterface
 
     public function deserializeDateTimeFromJson(JsonDeserializationVisitor $visitor, $data, array $type)
     {
-        if (null === $data) {
+        if (null == $data) {
             return null;
         }
 


### PR DESCRIPTION
JMS check if the field value is null before trying to deserialize a field. 

JMS use the === operator to determine if the field must be trated like a datetime or not, but in my app the data is send whit an API in JSON and the null field is in fact a empty string. However JMS is considering my field is a real datetime (beacause in php "" === null is false) and try to parse it and faill. 

I don't see any good raison to keep === instead == so there is my PR, but maybe i'm wrong ?
