### PR TITLE
better json serialized of a formtype

### DIFF
--- a/src/JMS/Serializer/Handler/FormErrorHandler.php
+++ b/src/JMS/Serializer/Handler/FormErrorHandler.php
@@ -146,13 +146,13 @@ class FormErrorHandler implements SubscribingHandlerInterface
         }
 
         if ($children) {
-            $form['children'] = $children;
+            $form[$data->getName() ?: 'children'] = $children;
         }
 
         if ($isRoot) {
             $visitor->setRoot($form);
         }
 
-        return $form;
+        return $form ? $form : $data->getData();
     }
 }


### PR DESCRIPTION
When I serialize a form to json if the root elements are bad named, ever say "children" and not the getName() value configured in the FormType difinition and when serialized a form with data this data don't serialied

**Before**:
empty  and filled form:

``` Json
{
  "children": {
    "name": [],
    "description": [],
    "typeId": [],
    "active": []
  }
}
```

**After**:
empty form:

``` Json
{
  "card": {
    "name": null,
    "description": null,
    "typeId": null,
    "active": "1"
  }
}
```

filled form:

``` Json
{
  "card": {
    "name": "the name",
    "description": "the desc",
    "typeId": 1,
    "active": "1"
  }
}
```
