### PR TITLE
Show exclusionPolicy setting in Metadata when given

### DIFF
--- a/src/JMS/Serializer/Metadata/ClassMetadata.php
+++ b/src/JMS/Serializer/Metadata/ClassMetadata.php
@@ -44,6 +44,7 @@ class ClassMetadata extends MergeableClassMetadata
     /** @var \ReflectionMethod[] */
     public $postDeserializeMethods = array();
 
+    public $exclusionPolicy;
     public $xmlRootName;
     public $xmlRootNamespace;
     public $xmlNamespaces = array();
@@ -219,6 +220,7 @@ class ClassMetadata extends MergeableClassMetadata
             $this->preSerializeMethods,
             $this->postSerializeMethods,
             $this->postDeserializeMethods,
+            $this->exclusionPolicy,
             $this->xmlRootName,
             $this->xmlRootNamespace,
             $this->xmlNamespaces,
@@ -240,6 +242,7 @@ class ClassMetadata extends MergeableClassMetadata
             $this->preSerializeMethods,
             $this->postSerializeMethods,
             $this->postDeserializeMethods,
+            $this->exclusionPolicy,
             $this->xmlRootName,
             $this->xmlRootNamespace,
             $this->xmlNamespaces,

--- a/src/JMS/Serializer/Metadata/Driver/AnnotationDriver.php
+++ b/src/JMS/Serializer/Metadata/Driver/AnnotationDriver.php
@@ -80,6 +80,7 @@ class AnnotationDriver implements DriverInterface
         foreach ($this->reader->getClassAnnotations($class) as $annot) {
             if ($annot instanceof ExclusionPolicy) {
                 $exclusionPolicy = $annot->policy;
+                $classMetadata->exclusionPolicy = $exclusionPolicy;
             } elseif ($annot instanceof XmlRoot) {
                 $classMetadata->xmlRootName = $annot->name;
                 $classMetadata->xmlRootNamespace = $annot->namespace;

--- a/src/JMS/Serializer/Metadata/Driver/XmlDriver.php
+++ b/src/JMS/Serializer/Metadata/Driver/XmlDriver.php
@@ -48,7 +48,14 @@ class XmlDriver extends AbstractFileDriver
 
         $metadata->fileResources[] = $path;
         $metadata->fileResources[] = $class->getFileName();
-        $exclusionPolicy = strtoupper($elem->attributes()->{'exclusion-policy'}) ?: 'NONE';
+
+        if (null !== $exclusionPolicy = $elem->attributes()->{'exclusion-policy'}) {
+            $exclusionPolicy = strtoupper($exclusionPolicy);
+            $metadata->exclusionPolicy = $exclusionPolicy;
+        } else {
+            $exclusionPolicy = 'NONE';
+        }
+
         $excludeAll = null !== ($exclude = $elem->attributes()->exclude) ? 'true' === strtolower($exclude) : false;
         $classAccessType = (string) ($elem->attributes()->{'access-type'} ?: PropertyMetadata::ACCESS_TYPE_PROPERTY);
 

--- a/src/JMS/Serializer/Metadata/Driver/YamlDriver.php
+++ b/src/JMS/Serializer/Metadata/Driver/YamlDriver.php
@@ -42,7 +42,14 @@ class YamlDriver extends AbstractFileDriver
         $metadata = new ClassMetadata($name);
         $metadata->fileResources[] = $file;
         $metadata->fileResources[] = $class->getFileName();
-        $exclusionPolicy = isset($config['exclusion_policy']) ? strtoupper($config['exclusion_policy']) : 'NONE';
+
+        if (isset($config['exclusion_policy'])) {
+            $exclusionPolicy = strtoupper($config['exclusion_policy']);
+            $metadata->exclusionPolicy = $exclusionPolicy;
+        } else {
+            $exclusionPolicy = 'NONE';
+        }
+
         $excludeAll = isset($config['exclude']) ? (Boolean) $config['exclude'] : false;
         $classAccessType = isset($config['access_type']) ? $config['access_type'] : PropertyMetadata::ACCESS_TYPE_PROPERTY;
         $readOnlyClass = isset($config['read_only']) ? (Boolean) $config['read_only'] : false;

--- a/tests/JMS/Serializer/Tests/Metadata/Driver/BaseDriverTest.php
+++ b/tests/JMS/Serializer/Tests/Metadata/Driver/BaseDriverTest.php
@@ -321,6 +321,14 @@ abstract class BaseDriverTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($p, $m->propertyMetadata['qux']);
     }
 
+    public function testExclusionPolicy()
+    {
+        $m = $this->getDriver()->loadMetadataForClass(new \ReflectionClass('JMS\Serializer\Tests\Fixtures\Person'));
+        $this->assertNull($m->exclusionPolicy);
+
+        $m = $this->getDriver()->loadMetadataForClass(new \ReflectionClass('JMS\Serializer\Tests\Fixtures\AllExcludedObject'));
+        $this->assertEquals('ALL', $m->exclusionPolicy);
+    }
 
     /**
      * @return DriverInterface

--- a/tests/JMS/Serializer/Tests/Metadata/Driver/php/AllExcludedObject.php
+++ b/tests/JMS/Serializer/Tests/Metadata/Driver/php/AllExcludedObject.php
@@ -1,0 +1,8 @@
+<?php
+
+use JMS\Serializer\Metadata\ClassMetadata;
+
+$metadata = new ClassMetadata('JMS\Serializer\Tests\Fixtures\AllExcludedObject');
+$metadata->exclusionPolicy = 'ALL';
+
+return $metadata;

--- a/tests/JMS/Serializer/Tests/Metadata/Driver/xml/AllExcludedObject.xml
+++ b/tests/JMS/Serializer/Tests/Metadata/Driver/xml/AllExcludedObject.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<serializer>
+<class name="JMS\Serializer\Tests\Fixtures\AllExcludedObject" exclusion-policy="ALL">
+    <property name="bar" expose="true" />
+</class>
+</serializer>

--- a/tests/JMS/Serializer/Tests/Metadata/Driver/yml/AllExcludedObject.yml
+++ b/tests/JMS/Serializer/Tests/Metadata/Driver/yml/AllExcludedObject.yml
@@ -1,0 +1,5 @@
+JMS\Serializer\Tests\Fixtures\AllExcludedObject:
+    exclusion_policy: ALL
+    properties:
+        bar:
+            expose: true


### PR DESCRIPTION
This PR adds the exclusionPolicy property to the ClassMetaData when it's given. 

This allows me to do something like this:
```php
class SkipClassesWithoutExclusionPolicy implements ExclusionStrategyInterface
{
    /**
     * {@inheritDoc}
     */
    public function shouldSkipClass(ClassMetadata $metadata, Context $navigatorContext)
    {
        return null === $metadata->exclusionPolicy;
    }

    /**
     * {@inheritDoc}
     */
    public function shouldSkipProperty(PropertyMetadata $property, Context $navigatorContext)
    {
        return false;
    }
}
```

It will return `null` by default. When a `exclusionPolicy` is set it will return the policy (string) instead.