### PR TITLE
Support for magic virtual properties

### DIFF
--- a/src/JMS/Serializer/Metadata/Driver/YamlDriver.php
+++ b/src/JMS/Serializer/Metadata/Driver/YamlDriver.php
@@ -51,8 +51,12 @@ class YamlDriver extends AbstractFileDriver
         $propertiesMetadata = array();
         if (array_key_exists('virtual_properties', $config)) {
             foreach ($config['virtual_properties'] as $methodName => $propertySettings) {
-                if ( ! $class->hasMethod($methodName)) {
-                    throw new RuntimeException('The method '.$methodName.' not found in class '.$class->name);
+                if (!$propertySettings['is_magic'] && !$class->hasMethod( $methodName ) ) {
+                    throw new RuntimeException('The method '.$methodName.' not found in class ' . $class->name);
+                }
+
+                if($propertySettings['is_magic'] && !$class->hasMethod('__call')) {
+                    throw new RuntimeException('Virtual properties set as magic and the method '.$methodName.' not found in class ' . $class->name);
                 }
 
                 $virtualPropertyMetadata = new VirtualPropertyMetadata($name, $methodName);


### PR DESCRIPTION
A flag could be set to use the __call method for virtual properties.

This is a working example of how it can be done.

If it's accepted I could completed it for the other driver and unit test.