### PR TITLE
Added support for mapped "system" fields in PHPCR-ODM

### DIFF
--- a/src/JMS/Serializer/Metadata/Driver/DoctrinePHPCRTypeDriver.php
+++ b/src/JMS/Serializer/Metadata/Driver/DoctrinePHPCRTypeDriver.php
@@ -27,6 +27,10 @@ use JMS\Serializer\Metadata\PropertyMetadata;
  */
 class DoctrinePHPCRTypeDriver extends AbstractDoctrineTypeDriver
 {
+    private $phpcrFieldMapping = array(
+        'long' => 'integer',
+    );
+
     /**
      * @param DoctrineClassMetadata $doctrineMetadata
      * @param PropertyMetadata $propertyMetadata
@@ -80,5 +84,14 @@ class DoctrinePHPCRTypeDriver extends AbstractDoctrineTypeDriver
             case $doctrineMetadata->identifier:
                 $propertyMetadata->setType('string');
         }
+    }
+
+    protected function normalizeFieldType($type)
+    {
+        if (isset($this->phpcrFieldMapping[$type])) {
+            return $this->phpcrFieldMapping[$type];
+        }
+
+        return parent::normalizeFieldType($type);
     }
 }

--- a/src/JMS/Serializer/Metadata/Driver/DoctrinePHPCRTypeDriver.php
+++ b/src/JMS/Serializer/Metadata/Driver/DoctrinePHPCRTypeDriver.php
@@ -48,7 +48,10 @@ class DoctrinePHPCRTypeDriver extends AbstractDoctrineTypeDriver
             }
 
             $propertyMetadata->setType($fieldType);
-        } elseif ($doctrineMetadata->hasAssociation($propertyName)) {
+            return;
+        }
+        
+        if ($doctrineMetadata->hasAssociation($propertyName)) {
             try {
                 $targetEntity = $doctrineMetadata->getAssociationTargetClass($propertyName);
             } catch (\Exception $e) {
@@ -64,6 +67,18 @@ class DoctrinePHPCRTypeDriver extends AbstractDoctrineTypeDriver
             }
 
             $propertyMetadata->setType($targetEntity);
+            return;
+        }
+
+        switch ($propertyName) {
+            case $doctrineMetadata->nodename:
+            case $doctrineMetadata->localeMapping:
+            case $doctrineMetadata->depthMapping:
+            case $doctrineMetadata->versionNameField:
+            case $doctrineMetadata->versionCreatedField:
+            case $doctrineMetadata->uuidFieldName:
+            case $doctrineMetadata->identifier:
+                $propertyMetadata->setType('string');
         }
     }
 }

--- a/tests/JMS/Serializer/Tests/Fixtures/DoctrinePHPCR/BlogPost.php
+++ b/tests/JMS/Serializer/Tests/Fixtures/DoctrinePHPCR/BlogPost.php
@@ -81,6 +81,21 @@ class BlogPost
      */
     private $author;
 
+    /**
+     * @PHPCRODM\Nodename()
+     */
+    private $nodename;
+
+    /**
+     * @PHPCRODM\Uuid()
+     */
+    private $uuid;
+
+    /**
+     * @PHPCRODM\Locale()
+     */
+    private $locale;
+
     public function __construct($title, Author $author, \DateTime $createdAt)
     {
         $this->title = $title;
@@ -88,6 +103,7 @@ class BlogPost
         $this->published = false;
         $this->comments = new ArrayCollection();
         $this->createdAt = $createdAt;
+        $this->locale = 'de_at';
     }
 
     public function setPublished()

--- a/tests/JMS/Serializer/Tests/Metadata/Driver/DoctrinePHPCRDriverTest.php
+++ b/tests/JMS/Serializer/Tests/Metadata/Driver/DoctrinePHPCRDriverTest.php
@@ -93,6 +93,28 @@ class DoctrinePHPCRDriverTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($plainMetadata, $doctrineMetadata);
     }
 
+    public function provideSystemField()
+    {
+        return array(
+            array('nodename', 'string'),
+            array('uuid', 'string'),
+            array('locale', 'string'),
+        );
+    }
+
+    /**
+     * @dataProvider provideSystemField
+     */
+    public function testSystemField($field, $type)
+    {
+        $metadata = $this->getMetadata();
+
+        $this->assertEquals(
+            array('name' => $type, 'params' => array()),
+            $metadata->propertyMetadata[$field]->type
+        );
+    }
+
     protected function getDocumentManager()
     {
         $config = new Configuration();


### PR DESCRIPTION
This PR adds support for mapping missing scalar fields available in the PHPCR-ODM metadata: `nodename`, `uuid`, `locale`, `depth`, `versionName`, `versionCreated` and `identifier`.

/cc @lsmith77 