### PR TITLE
MaxDepth is handled incorrectly with Collections

### DIFF
--- a/src/JMS/Serializer/Handler/ArrayCollectionHandler.php
+++ b/src/JMS/Serializer/Handler/ArrayCollectionHandler.php
@@ -62,10 +62,17 @@ class ArrayCollectionHandler implements SubscribingHandlerInterface
 
     public function serializeCollection(VisitorInterface $visitor, Collection $collection, array $type, Context $context)
     {
+        //  Pop ourselves out of the context not to be counted as a depth level
+        $context->stopVisiting($collection);
+
         // We change the base type, and pass through possible parameters.
         $type['name'] = 'array';
+        $result = $visitor->visitArray($collection->toArray(), $type, $context);
 
-        return $visitor->visitArray($collection->toArray(), $type, $context);
+        //  Push ourselves back in, so we can be popped after leaving the handler
+        $context->startVisiting($collection);
+
+        return $result;
     }
 
     public function deserializeCollection(VisitorInterface $visitor, $data, array $type, Context $context)

--- a/src/JMS/Serializer/Handler/PhpCollectionHandler.php
+++ b/src/JMS/Serializer/Handler/PhpCollectionHandler.php
@@ -58,9 +58,17 @@ class PhpCollectionHandler implements SubscribingHandlerInterface
 
     public function serializeMap(VisitorInterface $visitor, Map $map, array $type, Context $context)
     {
-        $type['name'] = 'array';
+        //  Pop ourselves out of the context not to be counted as a depth level
+        $context->stopVisiting($map);
 
-        return $visitor->visitArray(iterator_to_array($map), $type, $context);
+        // We change the base type, and pass through possible parameters.
+        $type['name'] = 'array';
+        $result = $visitor->visitArray(iterator_to_array($map), $type, $context);
+
+        //  Push ourselves back in, so we can be popped after leaving the handler
+        $context->startVisiting($map);
+
+        return $result;
     }
 
     public function deserializeMap(VisitorInterface $visitor, $data, array $type, Context $context)
@@ -72,10 +80,17 @@ class PhpCollectionHandler implements SubscribingHandlerInterface
 
     public function serializeSequence(VisitorInterface $visitor, Sequence $sequence, array $type, Context $context)
     {
+        //  Pop ourselves out of the context not to be counted as a depth level
+        $context->stopVisiting($sequence);
+
         // We change the base type, and pass through possible parameters.
         $type['name'] = 'array';
+        $result = $visitor->visitArray($sequence->all(), $type, $context);
 
-        return $visitor->visitArray($sequence->all(), $type, $context);
+        //  Push ourselves back in, so we can be popped after leaving the handler
+        $context->startVisiting($sequence);
+
+        return $result;
     }
 
     public function deserializeSequence(VisitorInterface $visitor, $data, array $type, Context $context)

--- a/src/JMS/Serializer/Handler/PropelCollectionHandler.php
+++ b/src/JMS/Serializer/Handler/PropelCollectionHandler.php
@@ -61,10 +61,17 @@ class PropelCollectionHandler implements SubscribingHandlerInterface
 
     public function serializeCollection(VisitorInterface $visitor, PropelCollection $collection, array $type, Context $context)
     {
+        //  Pop ourselves out of the context not to be counted as a depth level
+        $context->stopVisiting($collection);
+
         // We change the base type, and pass through possible parameters.
         $type['name'] = 'array';
+        $result = $visitor->visitArray($collection->getData(), $type, $context);
 
-        return $visitor->visitArray($collection->getData(), $type, $context);
+        //  Push ourselves back in, so we can be popped after leaving the handler
+        $context->startVisiting($collection);
+
+        return $result;
     }
 
     public function deserializeCollection(VisitorInterface $visitor, $data, array $type, Context $context)


### PR DESCRIPTION
This fixes handling collections for the purpose of depth calculations. Since arrays are not counted as a depth level, neither should Collections.
The other side effect of this change is that @MaxDepth on an entity inside a collection will be handled correctly as well (before, each Collection contributed +1 to depth, but did not leave PropertyMetadata, therefore was not subtracted when calculating relative depth).