### PR TITLE
Add toArray and fromArray methods to the serializer

### DIFF
--- a/src/JMS/Serializer/Serializer.php
+++ b/src/JMS/Serializer/Serializer.php
@@ -121,6 +121,49 @@ class Serializer implements SerializerInterface
         return $visitorResult;
     }
 
+    public function toArray($data, SerializationContext $context = null)
+    {
+        if (null === $context) {
+            $context = new SerializationContext();
+        }
+
+        $context->initialize(
+            'json',
+            $visitor = $this->serializationVisitors->get('json')->get(),
+            $this->navigator,
+            $this->factory
+        );
+
+        $visitor->setNavigator($this->navigator);
+        $this->navigator->accept($visitor->prepare($data), null, $context);
+
+        return (array) $visitor->getRoot();
+    }
+
+    public function fromArray($data, $type, DeserializationContext $context = null)
+    {
+        if (null === $context) {
+            $context = new DeserializationContext();
+        }
+
+        $context->initialize(
+            'json',
+            $visitor = $this->deserializationVisitors->get('json')->get(),
+            $this->navigator,
+            $this->factory
+        );
+
+        $visitor->setNavigator($this->navigator);
+        $navigatorResult = $this->navigator->accept($data, $this->typeParser->parse($type), $context);
+
+        // This is a special case if the root is handled by a callback on the object iself.
+        if ((null === $visitorResult = $visitor->getResult()) && null !== $navigatorResult) {
+            return $navigatorResult;
+        }
+
+        return $visitorResult;
+    }
+
     /**
      * @return MetadataFactoryInterface
      */

--- a/src/JMS/Serializer/Serializer.php
+++ b/src/JMS/Serializer/Serializer.php
@@ -140,7 +140,7 @@ class Serializer implements SerializerInterface
         return (array) $visitor->getRoot();
     }
 
-    public function fromArray($data, $type, DeserializationContext $context = null)
+    public function fromArray(array $data, $type, DeserializationContext $context = null)
     {
         if (null === $context) {
             $context = new DeserializationContext();

--- a/tests/JMS/Serializer/Tests/Serializer/ArrayTest.php
+++ b/tests/JMS/Serializer/Tests/Serializer/ArrayTest.php
@@ -64,6 +64,26 @@ class ArrayTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($expected, $result);
     }
 
+    /**
+     * @dataProvider scalarValues
+     */
+    public function testToArrayWithScalar($input)
+    {
+        $result = $this->serializer->toArray($input);
+
+        $this->assertEquals(array($input), $result);
+    }
+
+    public function scalarValues()
+    {
+        return array(
+            array(42),
+            array(3.14159),
+            array('helloworld'),
+            array(true),
+        );
+    }
+
     public function testFromArray()
     {
         $data = array(

--- a/tests/JMS/Serializer/Tests/Serializer/ArrayTest.php
+++ b/tests/JMS/Serializer/Tests/Serializer/ArrayTest.php
@@ -1,0 +1,87 @@
+<?php
+
+/*
+ * Copyright 2013 Johannes M. Schmitt <schmittjoh@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace JMS\Serializer\Tests\Serializer;
+
+use JMS\Serializer\Handler\HandlerRegistry;
+use JMS\Serializer\Tests\Fixtures\Order;
+use JMS\Serializer\Tests\Fixtures\Price;
+use PhpCollection\Map;
+use JMS\Serializer\Naming\SerializedNameAnnotationStrategy;
+use Metadata\MetadataFactory;
+use JMS\Serializer\Metadata\Driver\AnnotationDriver;
+use Doctrine\Common\Annotations\AnnotationReader;
+use JMS\Serializer\Construction\UnserializeObjectConstructor;
+use JMS\Serializer\JsonSerializationVisitor;
+use JMS\Serializer\JsonDeserializationVisitor;
+use JMS\Serializer\Serializer;
+use JMS\Serializer\Naming\CamelCaseNamingStrategy;
+
+class ArrayTest extends \PHPUnit_Framework_TestCase
+{
+    protected $serializer;
+
+    public function setUp()
+    {
+        $namingStrategy = new SerializedNameAnnotationStrategy(new CamelCaseNamingStrategy());
+
+        $this->serializer = new Serializer(
+            new MetadataFactory(new AnnotationDriver(new AnnotationReader())),
+            new HandlerRegistry(),
+            new UnserializeObjectConstructor(),
+            new Map(array('json' => new JsonSerializationVisitor($namingStrategy))),
+            new Map(array('json' => new JsonDeserializationVisitor($namingStrategy)))
+        );
+    }
+
+    public function testToArray()
+    {
+        $order = new Order(new Price(5));
+
+        $expected = array(
+            'cost' => array(
+                'price' => 5
+            )
+        );
+
+        $result = $this->serializer->toArray($order);
+
+        $this->assertEquals($expected, $result);
+    }
+
+    public function testFromArray()
+    {
+        $data = array(
+            'cost' => array(
+                'price' => 2.5
+            )
+        );
+
+        $expected = new Order(new Price(2.5));
+        $result = $this->serializer->fromArray($data, 'JMS\Serializer\Tests\Fixtures\Order');
+
+        $this->assertEquals($expected, $result);
+    }
+
+    public function testToArrayReturnsArrayObjectAsArray()
+    {
+        $result = $this->serializer->toArray(new \ArrayObject());
+
+        $this->assertEquals(array(), $result);
+    }
+}


### PR DESCRIPTION
This PR implements the solution suggested by @schmittjoh to add additional methods for dealing with array input/output instead of adding a new format for arrays.

https://github.com/schmittjoh/serializer/pull/20#issuecomment-94781669

TODO
- [x] Add some test cases