### PR TITLE
Added public `hasData` function to check if a data key already have been added.

### DIFF
--- a/src/JMS/Serializer/GenericSerializationVisitor.php
+++ b/src/JMS/Serializer/GenericSerializationVisitor.php
@@ -162,7 +162,7 @@ abstract class GenericSerializationVisitor extends AbstractVisitor
      */
     public function addData($key, $value)
     {
-        if ($this->hasData($key)) {
+        if (isset($this->data[$key])) {
             throw new InvalidArgumentException(sprintf('There is already data for "%s".', $key));
         }
 

--- a/src/JMS/Serializer/GenericSerializationVisitor.php
+++ b/src/JMS/Serializer/GenericSerializationVisitor.php
@@ -162,7 +162,7 @@ abstract class GenericSerializationVisitor extends AbstractVisitor
      */
     public function addData($key, $value)
     {
-        if ( $this->hasData($key) ) {
+        if ($this->hasData($key)) {
             throw new InvalidArgumentException(sprintf('There is already data for "%s".', $key));
         }
 

--- a/src/JMS/Serializer/GenericSerializationVisitor.php
+++ b/src/JMS/Serializer/GenericSerializationVisitor.php
@@ -162,11 +162,22 @@ abstract class GenericSerializationVisitor extends AbstractVisitor
      */
     public function addData($key, $value)
     {
-        if (isset($this->data[$key])) {
+        if ( $this->hasData($key) ) {
             throw new InvalidArgumentException(sprintf('There is already data for "%s".', $key));
         }
 
         $this->data[$key] = $value;
+    }
+    
+    /**
+     * Checks if some data key exists.
+     *
+     * @param string $key
+     * @return boolean
+     */
+    public function hasData($key)
+    {
+        return isset($this->data[$key]);
     }
 
     public function getRoot()


### PR DESCRIPTION
This pull request is related with schmittjoh/serializer#197 but it's less aggressive.

In order to reduce try/catch blocks I think it's important to expose data in some way, at least to know if a key already exists.

This will reduce many try/catch blocks or "added flags".