### PR TITLE
Implement discriminator default

### DIFF
--- a/src/JMS/Serializer/Annotation/Discriminator.php
+++ b/src/JMS/Serializer/Annotation/Discriminator.php
@@ -32,4 +32,7 @@ class Discriminator
 
     /** @var boolean */
     public $disabled = false;
+
+    /** @var string */
+    public $default = null;
 }

--- a/src/JMS/Serializer/GraphNavigator.php
+++ b/src/JMS/Serializer/GraphNavigator.php
@@ -268,16 +268,20 @@ final class GraphNavigator
                 ));
         }
 
-        if ( ! isset($metadata->discriminatorMap[$typeValue])) {
-            throw new \LogicException(sprintf(
-                'The type value "%s" does not exist in the discriminator map of class "%s". Available types: %s',
-                $typeValue,
-                $metadata->name,
-                implode(', ', array_keys($metadata->discriminatorMap))
-            ));
+        if ( isset($metadata->discriminatorMap[$typeValue]) ) {
+            return $this->metadataFactory->getMetadataForClass($metadata->discriminatorMap[$typeValue]);
         }
 
-        return $this->metadataFactory->getMetadataForClass($metadata->discriminatorMap[$typeValue]);
+        if ( ! is_null($metadata->discriminatorDefault) ) {
+            return $this->metadataFactory->getMetadataForClass($metadata->discriminatorDefault);
+        }
+
+        throw new \LogicException(sprintf(
+            'The type value "%s" does not exist in the discriminator map of class "%s". Available types: %s',
+            $typeValue,
+            $metadata->name,
+            implode(', ', array_keys($metadata->discriminatorMap))
+        ));
     }
 
     private function leaveScope(Context $context, $data)

--- a/src/JMS/Serializer/Metadata/ClassMetadata.php
+++ b/src/JMS/Serializer/Metadata/ClassMetadata.php
@@ -56,8 +56,9 @@ class ClassMetadata extends MergeableClassMetadata
     public $discriminatorFieldName;
     public $discriminatorValue;
     public $discriminatorMap = array();
+    public $discriminatorDefault;
 
-    public function setDiscriminator($fieldName, array $map)
+    public function setDiscriminator($fieldName, array $map, $default)
     {
         if (empty($fieldName)) {
             throw new \InvalidArgumentException('The $fieldName cannot be empty.');
@@ -70,6 +71,7 @@ class ClassMetadata extends MergeableClassMetadata
         $this->discriminatorBaseClass = $this->name;
         $this->discriminatorFieldName = $fieldName;
         $this->discriminatorMap = $map;
+        $this->discriminatorDefault = $default;
     }
 
     /**
@@ -230,6 +232,7 @@ class ClassMetadata extends MergeableClassMetadata
             $this->discriminatorFieldName,
             $this->discriminatorValue,
             $this->discriminatorMap,
+            $this->discriminatorDefault,
             parent::serialize(),
         ));
     }
@@ -251,6 +254,7 @@ class ClassMetadata extends MergeableClassMetadata
             $this->discriminatorFieldName,
             $this->discriminatorValue,
             $this->discriminatorMap,
+            $this->discriminatorDefault,
             $parentStr
         ) = unserialize($str);
 

--- a/src/JMS/Serializer/Metadata/Driver/AnnotationDriver.php
+++ b/src/JMS/Serializer/Metadata/Driver/AnnotationDriver.php
@@ -97,7 +97,7 @@ class AnnotationDriver implements DriverInterface
                 if ($annot->disabled) {
                     $classMetadata->discriminatorDisabled = true;
                 } else {
-                    $classMetadata->setDiscriminator($annot->field, $annot->map);
+                    $classMetadata->setDiscriminator($annot->field, $annot->map, $annot->default);
                 }
             }
         }

--- a/src/JMS/Serializer/Metadata/Driver/DoctrineTypeDriver.php
+++ b/src/JMS/Serializer/Metadata/Driver/DoctrineTypeDriver.php
@@ -35,7 +35,8 @@ class DoctrineTypeDriver extends AbstractDoctrineTypeDriver
         ) {
             $classMetadata->setDiscriminator(
                 $doctrineMetadata->discriminatorColumn['name'],
-                $doctrineMetadata->discriminatorMap
+                $doctrineMetadata->discriminatorMap,
+                null
             );
         }
     }

--- a/src/JMS/Serializer/Metadata/Driver/XmlDriver.php
+++ b/src/JMS/Serializer/Metadata/Driver/XmlDriver.php
@@ -70,6 +70,12 @@ class XmlDriver extends AbstractFileDriver
         $readOnlyClass = 'true' === strtolower($elem->attributes()->{'read-only'});
 
         $discriminatorFieldName = (string) $elem->attributes()->{'discriminator-field-name'};
+
+        $discriminatorDefault = (string) $elem->attributes()->{'discriminator-default'};
+        if ($discriminatorDefault === '') {
+            $discriminatorDefault = null;
+        }
+
         $discriminatorMap = array();
         foreach ($elem->xpath('./discriminator-class') as $entry) {
             if ( ! isset($entry->attributes()->value)) {
@@ -82,7 +88,7 @@ class XmlDriver extends AbstractFileDriver
         if ('true' === (string) $elem->attributes()->{'discriminator-disabled'}) {
             $metadata->discriminatorDisabled = true;
         } elseif ( ! empty($discriminatorFieldName) || ! empty($discriminatorMap)) {
-            $metadata->setDiscriminator($discriminatorFieldName, $discriminatorMap);
+            $metadata->setDiscriminator($discriminatorFieldName, $discriminatorMap, $discriminatorDefault);
         }
 
         foreach ($elem->xpath('./xml-namespace') as $xmlNamespace) {

--- a/src/JMS/Serializer/Metadata/Driver/YamlDriver.php
+++ b/src/JMS/Serializer/Metadata/Driver/YamlDriver.php
@@ -262,7 +262,16 @@ class YamlDriver extends AbstractFileDriver
                     throw new RuntimeException('The "map" attribute must be set, and be an array for discriminators.');
                 }
 
-                $metadata->setDiscriminator($config['discriminator']['field_name'], $config['discriminator']['map']);
+                $discriminatorDefault = null;
+                if (isset($config['discriminator']['default'])) {
+                    $discriminatorDefault = $config['discriminator']['default'];
+                }
+
+                $metadata->setDiscriminator(
+                    $config['discriminator']['field_name'],
+                    $config['discriminator']['map'],
+                    $discriminatorDefault
+                );
             }
         }
     }

--- a/tests/JMS/Serializer/Tests/Fixtures/Discriminator/Vehicle.php
+++ b/tests/JMS/Serializer/Tests/Fixtures/Discriminator/Vehicle.php
@@ -21,10 +21,14 @@ namespace JMS\Serializer\Tests\Fixtures\Discriminator;
 use JMS\Serializer\Annotation as Serializer;
 
 /**
- * @Serializer\Discriminator(field = "type", map = {
- *    "car": "JMS\Serializer\Tests\Fixtures\Discriminator\Car",
- *    "moped": "JMS\Serializer\Tests\Fixtures\Discriminator\Moped",
- * })
+ * @Serializer\Discriminator(
+ *  field = "type",
+ *  map = {
+ *      "car": "JMS\Serializer\Tests\Fixtures\Discriminator\Car",
+ *      "moped": "JMS\Serializer\Tests\Fixtures\Discriminator\Moped",
+ *  },
+ *  default = "JMS\Serializer\Tests\Fixtures\Discriminator\Car"
+ * )
  */
 abstract class Vehicle
 {

--- a/tests/JMS/Serializer/Tests/Metadata/Driver/BaseDriverTest.php
+++ b/tests/JMS/Serializer/Tests/Metadata/Driver/BaseDriverTest.php
@@ -155,6 +155,7 @@ abstract class BaseDriverTest extends \PHPUnit_Framework_TestCase
             ),
             $m->discriminatorMap
         );
+        $this->assertEquals('JMS\Serializer\Tests\Fixtures\Discriminator\Car', $m->discriminatorDefault);
     }
 
     public function testLoadDiscriminatorSubClass()

--- a/tests/JMS/Serializer/Tests/Metadata/Driver/php/Discriminator.Vehicle.php
+++ b/tests/JMS/Serializer/Tests/Metadata/Driver/php/Discriminator.Vehicle.php
@@ -4,10 +4,14 @@ use JMS\Serializer\Metadata\ClassMetadata;
 use JMS\Serializer\Metadata\PropertyMetadata;
 
 $metadata = new ClassMetadata('JMS\Serializer\Tests\Fixtures\Discriminator\Vehicle');
-$metadata->setDiscriminator('type', array(
-    'car' => 'JMS\Serializer\Tests\Fixtures\Discriminator\Car',
-    'moped' => 'JMS\Serializer\Tests\Fixtures\Discriminator\Moped',
-));
+$metadata->setDiscriminator(
+    'type',
+    array(
+        'car' => 'JMS\Serializer\Tests\Fixtures\Discriminator\Car',
+        'moped' => 'JMS\Serializer\Tests\Fixtures\Discriminator\Moped',
+    ),
+    'JMS\Serializer\Tests\Fixtures\Discriminator\Car'
+);
 
 $km = new PropertyMetadata('JMS\Serializer\Tests\Fixtures\Discriminator\Vehicle', 'km');
 $km->setType('integer');

--- a/tests/JMS/Serializer/Tests/Metadata/Driver/xml/Discriminator.Vehicle.xml
+++ b/tests/JMS/Serializer/Tests/Metadata/Driver/xml/Discriminator.Vehicle.xml
@@ -1,6 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <serializer>
-    <class name="JMS\Serializer\Tests\Fixtures\Discriminator\Vehicle" discriminator-field-name="type">
+    <class name="JMS\Serializer\Tests\Fixtures\Discriminator\Vehicle"
+           discriminator-field-name="type"
+           discriminator-default="JMS\Serializer\Tests\Fixtures\Discriminator\Car"
+    >
         <discriminator-class value="car">JMS\Serializer\Tests\Fixtures\Discriminator\Car</discriminator-class>
         <discriminator-class value="moped">JMS\Serializer\Tests\Fixtures\Discriminator\Moped</discriminator-class>
         <property name="km" type="integer" />

--- a/tests/JMS/Serializer/Tests/Metadata/Driver/yml/Discriminator.Vehicle.yml
+++ b/tests/JMS/Serializer/Tests/Metadata/Driver/yml/Discriminator.Vehicle.yml
@@ -4,6 +4,7 @@ JMS\Serializer\Tests\Fixtures\Discriminator\Vehicle:
         map:
             car: JMS\Serializer\Tests\Fixtures\Discriminator\Car
             moped: JMS\Serializer\Tests\Fixtures\Discriminator\Moped
+        default: JMS\Serializer\Tests\Fixtures\Discriminator\Car
 
     properties:
         km:

--- a/tests/JMS/Serializer/Tests/Serializer/XmlSerializationTest.php
+++ b/tests/JMS/Serializer/Tests/Serializer/XmlSerializationTest.php
@@ -89,7 +89,7 @@ class XmlSerializationTest extends BaseSerializationTest
 
     /**
      * @expectedException JMS\Serializer\Exception\InvalidArgumentException
-     * @expectedExceptionMessage The document type "<!DOCTYPE author [<!ENTITY foo SYSTEM "php://filter/read=convert.base64-encode/resource=XmlSerializationTest.php">]>" is not allowed. If it is safe, you may add it to the whitelist configuration.
+     * @expectedExceptionMessage The document type "<!ENTITY foo SYSTEM "php://filter/read=convert.base64-encode/resource=XmlSerializationTest.php">" is not allowed. If it is safe, you may add it to the whitelist configuration.
      */
     public function testExternalEntitiesAreDisabledByDefault()
     {
@@ -115,7 +115,7 @@ class XmlSerializationTest extends BaseSerializationTest
     {
         $this->deserializationVisitors->get('xml')->get()->setDoctypeWhitelist(array(
             '<!DOCTYPE authorized SYSTEM "http://authorized_url.dtd">',
-            '<!DOCTYPE author [<!ENTITY foo SYSTEM "php://filter/read=convert.base64-encode/resource='.basename(__FILE__).'">]>'));
+            '<!ENTITY foo SYSTEM "php://filter/read=convert.base64-encode/resource='.basename(__FILE__).'">'));
 
         $this->serializer->deserialize('<?xml version="1.0"?>
             <!DOCTYPE authorized SYSTEM "http://authorized_url.dtd">


### PR DESCRIPTION
In case of polymorph DTOs we wanted a fallback option. So that new subclasses on server side don't break our legacy clients. To do this we added a default handler in the discriminator which is used as class type if the type identifier is unknown.    

If there is any interest in having this feature merged, I would further elaborate on the testing.