### PR TITLE
Switch the Twig integration to use non-deprecated APIs

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,12 +19,15 @@
         "doctrine/annotations": "1.*",
         "doctrine/instantiator": "~1.0.3"
     },
+    "conflict": {
+        "twig/twig": "<1.12"
+    },
     "suggest": {
         "symfony/yaml": "Required if you'd like to serialize data to YAML format."
     },
     "minimum-stability": "dev",
     "require-dev": {
-        "twig/twig": ">=1.8,<2.0-dev",
+        "twig/twig": "~1.12|~2.0",
         "doctrine/orm": "~2.1",
         "doctrine/phpcr-odm": "~1.0.1",
         "jackalope/jackalope-doctrine-dbal": "1.0.*",

--- a/src/JMS/Serializer/Twig/SerializerExtension.php
+++ b/src/JMS/Serializer/Twig/SerializerExtension.php
@@ -43,25 +43,15 @@ class SerializerExtension extends \Twig_Extension
     public function getFilters()
     {
         return array(
-            'serialize'      => new \Twig_Filter_Method($this, 'serialize'),
+            new \Twig_SimpleFilter('serialize', array($this, 'serialize')),
         );
     }
 
     public function getFunctions()
     {
         return array(
-            'serialization_context' => new \Twig_Function_Method($this, 'createContext'),
+            new \Twig_SimpleFunction('serialization_context', '\JMS\Serializer\SerializationContext::createContext'),
         );
-    }
-
-    /**
-     * Creates the serialization context
-     *
-     * @return SerializationContext
-     */
-    public function createContext()
-    {
-        return SerializationContext::create();
     }
 
     /**


### PR DESCRIPTION
This makes the library compatible with Twig 2.0, and avoids deprecation warnings in 1.21+

Note that I changed the way the ``serialization_context`` function is compiled. there is no way to wrap this static function into a method of the extension. This will save a method call each time this function is used.