### PR TITLE
The Twig_Filter_Method class is deprecated since version 1.12 and wil…

### DIFF
--- a/src/JMS/Serializer/Twig/SerializerExtension.php
+++ b/src/JMS/Serializer/Twig/SerializerExtension.php
@@ -43,14 +43,14 @@ class SerializerExtension extends \Twig_Extension
     public function getFilters()
     {
         return array(
-            'serialize'      => new \Twig_Filter_Method($this, 'serialize'),
+            'serialize'      => new \Twig_SimpleFilter('serialize', array($this, 'serialize')),
         );
     }
 
     public function getFunctions()
     {
         return array(
-            'serialization_context' => new \Twig_Function_Method($this, 'createContext'),
+            'serialization_context' => new \Twig_SimpleFunction('serialization_context', array($this, 'createContext')),
         );
     }
 


### PR DESCRIPTION
The Twig_Filter_Method class is deprecated since version 1.12 and will be removed in 2.0. Use Twig_SimpleFilter instead.