### PR TITLE
Fix issue where error is thrown for non callable

### DIFF
--- a/src/JMS/Serializer/Twig/SerializerExtension.php
+++ b/src/JMS/Serializer/Twig/SerializerExtension.php
@@ -50,8 +50,18 @@ class SerializerExtension extends \Twig_Extension
     public function getFunctions()
     {
         return array(
-            new \Twig_SimpleFunction('serialization_context', '\JMS\Serializer\SerializationContext::createContext'),
+            new \Twig_SimpleFunction('serialization_context', array($this, 'createContext')),
         );
+    }
+
+     /**
+     * Creates the serialization context
+     *
+     * @return SerializationContext
+     */
+    public function createContext()
+    {
+        return SerializationContext::create();
     }
 
     /**


### PR DESCRIPTION
Running HHVM and seeing this below issue with the new changes for twig. This reverts some code to make it callable again.

Fatal Error: Argument 2 passed to Twig_Function::__construct() must be an instance of callable