### PR TITLE
Fix detecting doctype for whitelisting.

### DIFF
--- a/src/JMS/Serializer/XmlDeserializationVisitor.php
+++ b/src/JMS/Serializer/XmlDeserializationVisitor.php
@@ -356,7 +356,7 @@ class XmlDeserializationVisitor extends AbstractVisitor
      */
     private function getDomDocumentTypeEntitySubset(\DOMDocumentType $child, $data)
     {
-        if (null !== $child->internalSubset) {
+        if (null !== $child->internalSubset && stripos($child->internalSubset, "<!doctype") !== false) {
             return str_replace(array("\n", "\r"), '', $child->internalSubset);
         }
         


### PR DESCRIPTION
This "fix" restores the original behavior of doctype whitelisting (also - makes the unit tests pass).

The doctype whitelisting works on the whole "<!DOCTYPE" declaration. But in recent PHP versions the internalSubtype returns (correctly) only, well, the INTERNAL subtype declaration for a doctype.

Existing code tried to compensate this and worked for doctypes without internal entity declarations.

This PR restores the original behavior also for doctypes with internal entity declarations.

This is connected to #427 (although the original issue was closed).