### PR TITLE
Fix JSON deserialization of inline objects

### DIFF
--- a/src/JMS/Serializer/GenericDeserializationVisitor.php
+++ b/src/JMS/Serializer/GenericDeserializationVisitor.php
@@ -161,16 +161,17 @@ abstract class GenericDeserializationVisitor extends AbstractVisitor
     public function visitProperty(PropertyMetadata $metadata, $data, Context $context)
     {
         $name = $this->namingStrategy->translateName($metadata);
-
-        if (null === $data || ! array_key_exists($name, $data)) {
+        if (null === $data || (!array_key_exists($name, $data) && !$metadata->inline)) {
             return;
         }
+
+        $value = $metadata->inline ? $data : $data[$name];
 
         if ( ! $metadata->type) {
             throw new RuntimeException(sprintf('You must define a type for %s::$%s.', $metadata->reflection->class, $metadata->name));
         }
 
-        $v = $data[$name] !== null ? $this->navigator->accept($data[$name], $metadata->type, $context) : null;
+        $v = $value !== null ? $this->navigator->accept($value, $metadata->type, $context) : null;
 
         if (null === $metadata->setter) {
             $metadata->reflection->setValue($this->currentObject, $v);

--- a/tests/JMS/Serializer/Tests/Serializer/BaseSerializationTest.php
+++ b/tests/JMS/Serializer/Tests/Serializer/BaseSerializationTest.php
@@ -246,11 +246,11 @@ abstract class BaseSerializationTest extends \PHPUnit_Framework_TestCase
             $this->markTestSkipped('XML can\'t be tested for empty array');
         }
 
-        $data = array('array' => []);
+        $data = array('array' => array());
         $this->assertEquals($this->getContent('array_empty'), $this->serialize($data));
 
         if ($this->hasDeserializer()) {
-            $this->assertEquals($data, $this->deserialize($this->getContent('array_empty')), 'array');
+            $this->assertEquals($data, $this->deserialize($this->getContent('array_empty'), 'array'));
         }
     }
 


### PR DESCRIPTION
I've been using JMS Serializer and run into some problems while deserializing some objects from JSON. I have two dimensional table in my application, it has rows and cells with simple string values. Table represented by a class which has `$rows` property, it's an array of `Row` instances. Class `Row` has a single property `values` which is an array of strings.

I want to serialize my object into two dimensional JSON array. I'm using `inline` property for `Row` class to expose values in JSON.

```
Table:
[
     ["a", "b", "c"], <- Row
]
```

Without inline property I'm getting not exactly what I want:

```
Table:
[
     {"values": ["a", "b", "c"]}, <- Row
]
```

I didn't manage to find out if there is any test for `GenericDeserializationVisitor` so I can add a test case for my fix. I will really appreciate if you suggest what is the best way to test my change.

Thanks in advance!

### Steps to reproduce

I'm using this mapping:

```xml
<?xml version="1.0" encoding="UTF-8" ?>
<serializer>
    <class name="Test" xml-root-name="table">
        <property name="x" inline="true">
            <type><![CDATA[array<string>]]></type>
        </property>
    </class>
</serializer>
```

Then I'm serializing an object to json:

```php
$test = new Test();
$test->x = ['a', 'b', 'c'];

echo $serializer->serialize($test, 'json');
```

I'm getting this json:

```json
["a", "b", "c"]
```

Then I'm trying to deserialize it back to the object:

```php
$test = $serializer->serialize($data, Test::class, 'json');

var_dump($text->x);
```

I'm getting an empty array.