### PR TITLE
Fix multiple handler callbacks in YamlDriver

### DIFF
--- a/src/JMS/Serializer/Metadata/Driver/YamlDriver.php
+++ b/src/JMS/Serializer/Metadata/Driver/YamlDriver.php
@@ -203,9 +203,9 @@ class YamlDriver extends AbstractFileDriver
         }
 
         if (isset($config['handler_callbacks'])) {
-            foreach ($config['handler_callbacks'] as $direction => $formats) {
+            foreach ($config['handler_callbacks'] as $directionName => $formats) {
+                $direction = GraphNavigator::parseDirection($directionName);
                 foreach ($formats as $format => $methodName) {
-                    $direction = GraphNavigator::parseDirection($direction);
                     $metadata->addHandlerCallback($direction, $format, $methodName);
                 }
             }

--- a/tests/JMS/Serializer/Tests/Fixtures/ObjectWithHandlerCallbacks.php
+++ b/tests/JMS/Serializer/Tests/Fixtures/ObjectWithHandlerCallbacks.php
@@ -1,0 +1,46 @@
+<?php
+
+/*
+ * Copyright 2013 Johannes M. Schmitt <schmittjoh@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace JMS\Serializer\Tests\Fixtures;
+
+use JMS\Serializer\Annotation\HandlerCallback;
+use JMS\Serializer\Annotation\Type;
+
+class ObjectWithHandlerCallbacks
+{
+    /**
+     * @Type("string")
+     */
+    public $name;
+
+    /**
+     * @HandlerCallback(direction="serialization", format="json")
+     */
+    public function toJson()
+    {
+        return $this->name;
+    }
+
+    /**
+     * @HandlerCallback(direction="serialization", format="xml")
+     */
+    public function toXml()
+    {
+        return $this->name;
+    }
+}

--- a/tests/JMS/Serializer/Tests/Metadata/Driver/BaseDriverTest.php
+++ b/tests/JMS/Serializer/Tests/Metadata/Driver/BaseDriverTest.php
@@ -18,6 +18,7 @@
 
 namespace JMS\Serializer\Tests\Metadata\Driver;
 
+use JMS\Serializer\GraphNavigator;
 use JMS\Serializer\Metadata\ClassMetadata;
 use JMS\Serializer\Metadata\PropertyMetadata;
 use JMS\Serializer\Metadata\VirtualPropertyMetadata;
@@ -321,6 +322,13 @@ abstract class BaseDriverTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($p, $m->propertyMetadata['qux']);
     }
 
+    public function testHandlerCallbacks()
+    {
+        $m = $this->getDriver()->loadMetadataForClass(new \ReflectionClass('JMS\Serializer\Tests\Fixtures\ObjectWithHandlerCallbacks'));
+
+        $this->assertEquals('toJson', $m->handlerCallbacks[GraphNavigator::DIRECTION_SERIALIZATION]['json']);
+        $this->assertEquals('toXml', $m->handlerCallbacks[GraphNavigator::DIRECTION_SERIALIZATION]['xml']);
+    }
 
     /**
      * @return DriverInterface

--- a/tests/JMS/Serializer/Tests/Metadata/Driver/php/ObjectWithHandlerCallbacks.php
+++ b/tests/JMS/Serializer/Tests/Metadata/Driver/php/ObjectWithHandlerCallbacks.php
@@ -1,0 +1,16 @@
+<?php
+
+use JMS\Serializer\GraphNavigator;
+use JMS\Serializer\Metadata\ClassMetadata;
+use JMS\Serializer\Metadata\PropertyMetadata;
+
+$metadata = new ClassMetadata('JMS\Serializer\Tests\Fixtures\ObjectWithHandlerCallbacks');
+
+$pMetadata = new PropertyMetadata('JMS\Serializer\Tests\Fixtures\ObjectWithHandlerCallbacks', 'name');
+$pMetadata->type = 'string';
+$metadata->addPropertyMetadata($pMetadata);
+
+$metadata->addHandlerCallback(GraphNavigator::DIRECTION_SERIALIZATION, 'json', 'toJson');
+$metadata->addHandlerCallback(GraphNavigator::DIRECTION_SERIALIZATION, 'xml', 'toXml');
+
+return $metadata;

--- a/tests/JMS/Serializer/Tests/Metadata/Driver/xml/ObjectWithHandlerCallbacks.xml
+++ b/tests/JMS/Serializer/Tests/Metadata/Driver/xml/ObjectWithHandlerCallbacks.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<serializer>
+    <class name="JMS\Serializer\Tests\Fixtures\ObjectWithHandlerCallbacks">
+        <property name="name" type="string"/>
+        <callback-method name="toJson" type="handler" direction="serialization" format="json" />
+        <callback-method name="toXml" type="handler" direction="serialization" format="xml" />
+    </class>
+</serializer>

--- a/tests/JMS/Serializer/Tests/Metadata/Driver/yml/ObjectWithHandlerCallbacks.yml
+++ b/tests/JMS/Serializer/Tests/Metadata/Driver/yml/ObjectWithHandlerCallbacks.yml
@@ -1,0 +1,8 @@
+JMS\Serializer\Tests\Fixtures\ObjectWithHandlerCallbacks:
+    properties:
+        name:
+            type: string
+    handler_callbacks:
+        serialization:
+            xml: toXml
+            json: toJson


### PR DESCRIPTION
Using handler callbacks for multiple formats caused errors in `YamlDriver` because the `direction` key was parsed multiple times. Now `direction` key is only parsed once (per direction).

A basic test case for handler callbacks is included for all configuration formats.