### PR TITLE
Fix test annotations and addition of new Feature

### DIFF
--- a/src/JMS/Serializer/Context.php
+++ b/src/JMS/Serializer/Context.php
@@ -59,6 +59,9 @@ abstract class Context
     /** @var \SplStack */
     private $metadataStack;
 
+    /** @var boolean */
+    private $formatOutput = true;
+
     public function __construct()
     {
         $this->attributes = new Map();
@@ -243,4 +246,24 @@ abstract class Context
      * @return integer
      */
     abstract public function getDirection();
+
+    /**
+     * @author Ayrton Ricardo<ayrton@voxtecnologia.com.br>
+     * @param boolean $formatOutput
+     * @return Context
+     */
+    public function setFormatOutput($formatOutput)
+    {
+        $this->formatOutput = (boolean)$formatOutput;
+
+        return $this;
+    }
+
+    /**
+     * @return boolean
+     */
+    public function isFormatOutput()
+    {
+        return $this->formatOutput;
+    }
 }

--- a/src/JMS/Serializer/XmlSerializationVisitor.php
+++ b/src/JMS/Serializer/XmlSerializationVisitor.php
@@ -184,7 +184,7 @@ class XmlSerializationVisitor extends AbstractVisitor
     public function startVisitingObject(ClassMetadata $metadata, $data, array $type, Context $context)
     {
         if (null === $this->document) {
-            $this->document = $this->createDocument(null, null, false);
+            $this->document = $this->createDocument(null, null, false, $context->isFormatOutput());
             if ($metadata->xmlRootName) {
                 $rootName = $metadata->xmlRootName;
                 $rootNamespace = $metadata->xmlRootNamespace;
@@ -199,7 +199,7 @@ class XmlSerializationVisitor extends AbstractVisitor
             }
             $this->document->appendChild($this->currentNode);
         }
-        
+
         $this->addNamespaceAttributes($metadata, $this->currentNode);
 
         $this->hasValue = false;
@@ -361,10 +361,10 @@ class XmlSerializationVisitor extends AbstractVisitor
         return $this->currentMetadata = $this->metadataStack->pop();
     }
 
-    public function createDocument($version = null, $encoding = null, $addRoot = true)
+    public function createDocument($version = null, $encoding = null, $addRoot = true, $formatOutput = true)
     {
         $doc = new \DOMDocument($version ?: $this->defaultVersion, $encoding ?: $this->defaultEncoding);
-        $doc->formatOutput = true;
+        $doc->formatOutput = $formatOutput;
 
         if ($addRoot) {
             if ($this->defaultRootNamespace) {

--- a/tests/JMS/Serializer/Tests/Serializer/BaseSerializationTest.php
+++ b/tests/JMS/Serializer/Tests/Serializer/BaseSerializationTest.php
@@ -250,7 +250,7 @@ abstract class BaseSerializationTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($this->getContent('array_empty'), $this->serialize($data));
 
         if ($this->hasDeserializer()) {
-            $this->assertEquals($data, $this->deserialize($this->getContent('array_empty')), 'array');
+            $this->assertEquals($data, $this->deserialize($this->getContent('array_empty'), 'array'));
         }
     }
 

--- a/tests/JMS/Serializer/Tests/Serializer/XmlSerializationTest.php
+++ b/tests/JMS/Serializer/Tests/Serializer/XmlSerializationTest.php
@@ -89,7 +89,7 @@ class XmlSerializationTest extends BaseSerializationTest
 
     /**
      * @expectedException JMS\Serializer\Exception\InvalidArgumentException
-     * @expectedExceptionMessage The document type "<!DOCTYPE author [<!ENTITY foo SYSTEM "php://filter/read=convert.base64-encode/resource=XmlSerializationTest.php">]>" is not allowed. If it is safe, you may add it to the whitelist configuration.
+     * @expectedExceptionMessage The document type "<!ENTITY foo SYSTEM "php://filter/read=convert.base64-encode/resource=XmlSerializationTest.php">" is not allowed. If it is safe, you may add it to the whitelist configuration.
      */
     public function testExternalEntitiesAreDisabledByDefault()
     {
@@ -259,6 +259,8 @@ class XmlSerializationTest extends BaseSerializationTest
 
     /**
      * @param string $key
+     * @throw InvalidArgumentException
+     * @return string
      */
     protected function getContent($key)
     {
@@ -272,5 +274,22 @@ class XmlSerializationTest extends BaseSerializationTest
     protected function getFormat()
     {
         return 'xml';
+    }
+
+    /**
+     * @author Ayrton Ricardo<ayrton@voxtecnologia.com.br>
+     */
+    public function testWithoutFormattingOutputByContext()
+    {
+        $object = new SimpleClassObject;
+        $object->foo = 'foo';
+        $object->bar = 'bar';
+        $object->moo = 'moo';
+
+        $context = \JMS\Serializer\SerializationContext::create()
+            ->setSerializeNull(true)
+            ->setFormatOutput(false);
+
+        $this->assertEquals($this->getContent('simple_class_object_minified'), $this->serialize($object, $context));
     }
 }

--- a/tests/JMS/Serializer/Tests/Serializer/xml/simple_class_object_minified.xml
+++ b/tests/JMS/Serializer/Tests/Serializer/xml/simple_class_object_minified.xml
@@ -1,0 +1,2 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<result xmlns:old_foo="http://old.foo.example.org" xmlns:foo="http://foo.example.org" xmlns:new_foo="http://new.foo.example.org" old_foo:foo="foo"><foo:bar><![CDATA[bar]]></foo:bar><new_foo:moo><![CDATA[moo]]></new_foo:moo></result>


### PR DESCRIPTION
- Fix annotation on XmlSerializationTest::testExternalEntitiesAreDisabledByDefault.
- Fix wrong parameters in BaseSerializationTest::testArrayEmpty.
- Option on context to disable formatting output xml(default true). 
    Example of usage (XmlSerializationTest::testWithoutFormattingOutputByContext).

- Implementation of test.