### PR TITLE
Fix wrong overriding of the virtual property

### DIFF
--- a/src/JMS/Serializer/Metadata/Driver/AnnotationDriver.php
+++ b/src/JMS/Serializer/Metadata/Driver/AnnotationDriver.php
@@ -140,6 +140,8 @@ class AnnotationDriver implements DriverInterface
                 $propertiesAnnotations[] = $this->reader->getPropertyAnnotations($property);
             }
 
+            // Avoiding overriding property on same name (basically, virtual property)
+            $alreadyRegister = [];
             foreach ($propertiesMetadata as $propertyKey => $propertyMetadata) {
                 $isExclude = false;
                 $isExpose = $propertyMetadata instanceof VirtualPropertyMetadata;
@@ -213,8 +215,10 @@ class AnnotationDriver implements DriverInterface
 
                 $propertyMetadata->setAccessor($accessType, $accessor[0], $accessor[1]);
 
-                if ((ExclusionPolicy::NONE === $exclusionPolicy && ! $isExclude)
-                    || (ExclusionPolicy::ALL === $exclusionPolicy && $isExpose)) {
+                if (((ExclusionPolicy::NONE === $exclusionPolicy && ! $isExclude)
+                    || (ExclusionPolicy::ALL === $exclusionPolicy && $isExpose))
+                    && !in_array($propertyMetadata->name, $alreadyRegister)) {
+                    $alreadyRegister[] = $propertyMetadata->name;
                     $classMetadata->addPropertyMetadata($propertyMetadata);
                 }
             }

--- a/tests/JMS/Serializer/Tests/Fixtures/VitualPropertyIsPriority.php
+++ b/tests/JMS/Serializer/Tests/Fixtures/VitualPropertyIsPriority.php
@@ -1,0 +1,96 @@
+<?php
+
+/*
+ * Copyright 2013 Johannes M. Schmitt <schmittjoh@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace JMS\Serializer\Tests\Fixtures;
+
+use JMS\Serializer\Annotation\Groups;
+use JMS\Serializer\Annotation\VirtualProperty;
+use JMS\Serializer\Annotation\SerializedName;
+
+class VitualPropertyIsPriority
+{
+    /**
+     * @var integer
+     */
+    private $id;
+
+    /**
+     * @var string
+     */
+    private $locale;
+
+    /**
+     * @var string
+     * @Groups({"testing_group"})
+     */
+    private $title;
+
+    /**
+     * @return int
+     *
+     * @VirtualProperty
+     * @SerializedName("id")
+     * @Groups({"testing_group"})
+     */
+    public function getId()
+    {
+        return $this->id;
+    }
+
+    /**
+     * @return string
+     */
+    public function getLocale()
+    {
+        return $this->locale;
+    }
+
+    /**
+     * @param string $locale
+     * @return VitualPropertyIsPriority
+     *
+     * @VirtualProperty
+     * @SerializedName("id")
+     * @Groups({"testing_group"})
+     */
+    public function setLocale($locale)
+    {
+        $this->locale = $locale;
+
+        return $this;
+    }
+
+    /**
+     * @return string
+     */
+    public function getTitle()
+    {
+        return $this->title;
+    }
+
+    /**
+     * @param string $title
+     * @return VitualPropertyIsPriority
+     */
+    public function setTitle($title)
+    {
+        $this->title = $title;
+
+        return $this;
+    }
+}

--- a/tests/JMS/Serializer/Tests/Metadata/Driver/AnnotationDriverTest.php
+++ b/tests/JMS/Serializer/Tests/Metadata/Driver/AnnotationDriverTest.php
@@ -20,11 +20,25 @@ namespace JMS\Serializer\Tests\Metadata\Driver;
 
 use Doctrine\Common\Annotations\AnnotationReader;
 use JMS\Serializer\Metadata\Driver\AnnotationDriver;
+use JMS\Serializer\Metadata\VirtualPropertyMetadata;
 
 class AnnotationDriverTest extends BaseDriverTest
 {
     protected function getDriver()
     {
         return new AnnotationDriver(new AnnotationReader());
+    }
+
+    public function testVirtualPropertyHasPriority()
+    {
+        $m = $this->getDriver()->loadMetadataForClass(new \ReflectionClass('JMS\Serializer\Tests\Fixtures\VitualPropertyIsPriority'));
+
+        $this->assertNotNull($m);
+
+        $p = new VirtualPropertyMetadata($m->name, 'id');
+        $p->groups = array('testing_group');
+        $p->getter = 'getId';
+        $p->serializedName = 'id';
+        $this->assertEquals($p, $m->propertyMetadata['id']);
     }
 }


### PR DESCRIPTION
Currently, when there is a private property inside the class and you don't access to it, you can't defined a virtual property (the test I added fails on the master branch) that will replace the mapping of the property. This is a problem when you uses groups or choose different policies.

The real problem is from this class: https://github.com/schmittjoh/metadata/blob/master/src%2FMetadata%2FClassMetadata.php#L53 and an eventual fix would be that:

``` php
    public function addPropertyMetadata(PropertyMetadata $metadata)
    {
        if (!isset($this->propertyMetadata[$metadata->name])) {
            $this->propertyMetadata[$metadata->name] = $metadata;
        }
    }
```

The problem is that it would be a huge BC Break because it doesn't allow anymore to override a metadata (that could maybe be useful ? I really don't know).

So I added a little fix in this PR, as the problem is present only on annotation mapping, I added the fix only in the `AnnotationDriver`. It's not awesome but it work and it's efficient.
