### PR TITLE
Force double type to have decimal

### DIFF
--- a/src/JMS/Serializer/GenericSerializationVisitor.php
+++ b/src/JMS/Serializer/GenericSerializationVisitor.php
@@ -82,7 +82,7 @@ abstract class GenericSerializationVisitor extends AbstractVisitor
             $this->root = $data;
         }
 
-        return (float) $data;
+        return sprintf('%f', $data);
     }
 
     /**


### PR DESCRIPTION
When the value is an integer, casting type to float alone doesn't show fractional part of number. Use sprintf to force it. This is to avoid confusing of mobile client to figure where the value is integer or float when receiving output.