### PR TITLE
Fix: Use appropriate sections in Travis configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,8 +16,10 @@ matrix:
   allow_failures:
     - php: 7.0
 
-before_script:
+before_install:
     - composer self-update
+
+before_script:
     - composer install --dev
 
 script: vendor/bin/phpunit --coverage-clover clover


### PR DESCRIPTION
This PR

* [x] updates composer itself in the `before_install` section
* [x] installs dependencies with composer in the `install` section