### PR TITLE
Fix: Send builds to container-based infrastructure

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 language: php
 
+sudo: false
+
 matrix:
   allow_failures:
     - php: hhvm


### PR DESCRIPTION
This PR

* [x] sends builds to container-based infrastructure

:information_desk_person: Ain't nobody got time for waiting, no?