### PR TITLE
Fix: Add build status badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-Serializer [![Scrutinizer Quality Score](https://scrutinizer-ci.com/g/schmittjoh/serializer/badges/quality-score.png?s=189df68e00c75d3fe155bc0da0b53b53709a9895)](https://scrutinizer-ci.com/g/schmittjoh/serializer/)
+Serializer [![Build Status](https://travis-ci.org/schmittjoh/serializer.svg?branch=master)](https://travis-ci.org/schmittjoh/serializer) [![Scrutinizer Quality Score](https://scrutinizer-ci.com/g/schmittjoh/serializer/badges/quality-score.png?s=189df68e00c75d3fe155bc0da0b53b53709a9895)](https://scrutinizer-ci.com/g/schmittjoh/serializer/)
 ==========
 
 Learn more about it in its [documentation](http://jmsyst.com/libs/serializer).


### PR DESCRIPTION
This PR

* [x] adds a Travis build status badge to `README.md`

:person_with_pouting_face: By the way, current `master` is failing, effectively breaking builds for all branches based off of it (unless, of course, they intend to fix the build), see 

* https://travis-ci.org/schmittjoh/serializer/branches

