### PR TITLE
Fix: No short array syntax on PHP5.3

### DIFF
--- a/tests/JMS/Serializer/Tests/Serializer/BaseSerializationTest.php
+++ b/tests/JMS/Serializer/Tests/Serializer/BaseSerializationTest.php
@@ -246,7 +246,7 @@ abstract class BaseSerializationTest extends \PHPUnit_Framework_TestCase
             $this->markTestSkipped('XML can\'t be tested for empty array');
         }
 
-        $data = array('array' => []);
+        $data = array('array' => array());
         $this->assertEquals($this->getContent('array_empty'), $this->serialize($data));
 
         if ($this->hasDeserializer()) {


### PR DESCRIPTION
This PR

* [x] converts a short array to a long array using as it breaks the build on PHP5.3

See https://travis-ci.org/schmittjoh/serializer/jobs/92420623#L265.

Related to #511.

Used

```
$ php-cs-fixer fix --verbose --fixers=long_array_syntax tests
```

for that.