### PR TITLE
Add support for simple handler inheritance

### DIFF
--- a/src/JMS/Serializer/Handler/HandlerRegistry.php
+++ b/src/JMS/Serializer/Handler/HandlerRegistry.php
@@ -79,10 +79,10 @@ class HandlerRegistry implements HandlerRegistryInterface
 
     public function getHandler($direction, $typeName, $format)
     {
-        if ( ! isset($this->handlers[$direction][$typeName][$format])) {
-            return null;
-        }
-
-        return $this->handlers[$direction][$typeName][$format];
+        do {
+            if (isset($this->handlers[$direction][$typeName][$format])) {
+                return $this->handlers[$direction][$typeName][$format];
+            }
+        } while ($typeName = get_parent_class($typeName));
     }
 }

--- a/src/JMS/Serializer/Handler/LazyHandlerRegistry.php
+++ b/src/JMS/Serializer/Handler/LazyHandlerRegistry.php
@@ -39,6 +39,16 @@ class LazyHandlerRegistry extends HandlerRegistry
 
     public function getHandler($direction, $typeName, $format)
     {
+        do {
+            $handler = $this->resolveHandler($direction, $typeName, $format);
+            if(null !== $handler) {
+                return $handler;
+            }
+        } while ($typeName = get_parent_class($typeName));
+    }
+
+    private function resolveHandler($direction, $typeName, $format)
+    {
         if (isset($this->initializedHandlers[$direction][$typeName][$format])) {
             return $this->initializedHandlers[$direction][$typeName][$format];
         }


### PR DESCRIPTION
This PR adds support for simple handler inheritance.

For example if you create an handler to normalize ``\Exception`` instances, and if you try to serialize a ``\LogicException`` instance, your first handler will be executed unless you have a more specific handler to normalize ``\LogicException``.