### PR TITLE
Fix for #559 to enable @discriminator fields to not be serialized as CDATA

### DIFF
--- a/doc/reference/annotations.rst
+++ b/doc/reference/annotations.rst
@@ -245,6 +245,20 @@ to the least super type::
     class Car extends Vehicle { }
     class Moped extends Vehicle { }
 
+By default, an XML serialization would use CDATA for discriminator field, for example::
+
+    <type><![CDATA[car]]></type>
+  
+You can indicate you don't require CDATA with an additional `cdata=false` in the annotation. So, annotating like this::
+
+    /**
+     * @Discriminator(field = "type", map = {"car": "Car", "moped": "Moped"}, cdata=false)
+     */
+
+Would produce XML like this::
+
+    <type>car</type>
+
 @Type
 ~~~~~
 This annotation can be defined on a property to specify the type of that property.

--- a/doc/reference/xml_reference.rst
+++ b/doc/reference/xml_reference.rst
@@ -7,7 +7,7 @@ XML Reference
     <serializer>
         <class name="Fully\Qualified\ClassName" exclusion-policy="ALL" xml-root-name="foo-bar" exclude="true"
             accessor-order="custom" custom-accessor-order="propertyName1,propertyName2,...,propertyNameN"
-            access-type="public_method" discriminator-field-name="type"  read-only="false">
+            access-type="public_method" discriminator-field-name="type" discriminator-cdata="true" read-only="false">
             <xml-namespace prefix="atom" uri="http://www.w3.org/2005/Atom"/>
             <discriminator-class value="some-value">ClassName</discriminator-class>
             <property name="some-property"

--- a/doc/reference/yml_reference.rst
+++ b/doc/reference/yml_reference.rst
@@ -13,6 +13,7 @@ YAML Reference
         accessor_order: custom
         custom_accessor_order: [propertyName1, propertyName2, ..., propertyNameN]
         discriminator:
+            cdata: true
             field_name: type
             map:
                 some-value: ClassName

--- a/src/JMS/Serializer/Annotation/Discriminator.php
+++ b/src/JMS/Serializer/Annotation/Discriminator.php
@@ -32,4 +32,7 @@ class Discriminator
 
     /** @var boolean */
     public $disabled = false;
+
+    /** @var boolean */
+    public $cdata = true;
 }

--- a/src/JMS/Serializer/Metadata/ClassMetadata.php
+++ b/src/JMS/Serializer/Metadata/ClassMetadata.php
@@ -233,6 +233,7 @@ class ClassMetadata extends MergeableClassMetadata
             $this->discriminatorFieldName,
             $this->discriminatorValue,
             $this->discriminatorMap,
+            $this->discriminatorCdata,
             parent::serialize(),
         ));
     }
@@ -254,6 +255,7 @@ class ClassMetadata extends MergeableClassMetadata
             $this->discriminatorFieldName,
             $this->discriminatorValue,
             $this->discriminatorMap,
+            $this->discriminatorCdata,
             $parentStr
         ) = unserialize($str);
 

--- a/src/JMS/Serializer/Metadata/ClassMetadata.php
+++ b/src/JMS/Serializer/Metadata/ClassMetadata.php
@@ -56,8 +56,9 @@ class ClassMetadata extends MergeableClassMetadata
     public $discriminatorFieldName;
     public $discriminatorValue;
     public $discriminatorMap = array();
+    public $discriminatorCdata = true;
 
-    public function setDiscriminator($fieldName, array $map)
+    public function setDiscriminator($fieldName, array $map, $cdata = true)
     {
         if (empty($fieldName)) {
             throw new \InvalidArgumentException('The $fieldName cannot be empty.');
@@ -70,6 +71,7 @@ class ClassMetadata extends MergeableClassMetadata
         $this->discriminatorBaseClass = $this->name;
         $this->discriminatorFieldName = $fieldName;
         $this->discriminatorMap = $map;
+        $this->discriminatorCdata = $cdata;
     }
 
     /**
@@ -187,6 +189,7 @@ class ClassMetadata extends MergeableClassMetadata
                 $typeValue
             );
             $discriminatorProperty->serializedName = $this->discriminatorFieldName;
+            $discriminatorProperty->xmlElementCData = $this->discriminatorCdata;
             $this->propertyMetadata[$this->discriminatorFieldName] = $discriminatorProperty;
         }
 

--- a/src/JMS/Serializer/Metadata/Driver/AnnotationDriver.php
+++ b/src/JMS/Serializer/Metadata/Driver/AnnotationDriver.php
@@ -97,7 +97,7 @@ class AnnotationDriver implements DriverInterface
                 if ($annot->disabled) {
                     $classMetadata->discriminatorDisabled = true;
                 } else {
-                    $classMetadata->setDiscriminator($annot->field, $annot->map);
+                    $classMetadata->setDiscriminator($annot->field, $annot->map, $annot->cdata);
                 }
             }
         }

--- a/src/JMS/Serializer/Metadata/Driver/XmlDriver.php
+++ b/src/JMS/Serializer/Metadata/Driver/XmlDriver.php
@@ -79,10 +79,14 @@ class XmlDriver extends AbstractFileDriver
             $discriminatorMap[(string) $entry->attributes()->value] = (string) $entry;
         }
 
+        if (null !== $discriminatorCdata = strtolower($elem->attributes()->{'discriminator-cdata'})) {
+            $discriminatorCdata='true';
+        }
+
         if ('true' === (string) $elem->attributes()->{'discriminator-disabled'}) {
             $metadata->discriminatorDisabled = true;
         } elseif ( ! empty($discriminatorFieldName) || ! empty($discriminatorMap)) {
-            $metadata->setDiscriminator($discriminatorFieldName, $discriminatorMap);
+            $metadata->setDiscriminator($discriminatorFieldName, $discriminatorMap, $discriminatorCdata==='true');
         }
 
         foreach ($elem->xpath('./xml-namespace') as $xmlNamespace) {

--- a/src/JMS/Serializer/Metadata/Driver/YamlDriver.php
+++ b/src/JMS/Serializer/Metadata/Driver/YamlDriver.php
@@ -262,7 +262,8 @@ class YamlDriver extends AbstractFileDriver
                     throw new RuntimeException('The "map" attribute must be set, and be an array for discriminators.');
                 }
 
-                $metadata->setDiscriminator($config['discriminator']['field_name'], $config['discriminator']['map']);
+                $cdata= isset($config['discriminator']['cdata']) ? $config['discriminator']['cdata'] : true;
+                $metadata->setDiscriminator($config['discriminator']['field_name'], $config['discriminator']['map'],  $cdata);
             }
         }
     }


### PR DESCRIPTION
This adds options to the @discriminator annotation (and its YML and XML configuration equivalents) which allow the use of CDATA in the discriminator field to be disabled. By default, it is will be on to preserve existing behaviour. 

So, now you can do this

```
/** 
 * @JMS\Discriminator(field = "type", cdata=false, map = {
 *   "foo": "MyBundle\Entity\FooEntity",
 *   "bar": "MyBundle\Entity\BarEntity"
 * })
 */
```

Serializing a FooEntity as XML would include a type like this::

`<type>foo</type>`

If the `cdata=true`, or if it is omitted, the original behaviour will use CDATA for those elements

`<type><![CDATA[foo]]></type>`

Feedback on this push request appreciated - in particular, this needs a unit test. How about if I add a new set of polymorphic types, e.g. Animal/Dog/Cat which _don't_ use CDATA, some xml fixtures for them, and additional test methods in BaseSerializationTest?
