### PR TITLE
Assert type in string visitor

### DIFF
--- a/src/JMS/Serializer/GenericDeserializationVisitor.php
+++ b/src/JMS/Serializer/GenericDeserializationVisitor.php
@@ -58,6 +58,10 @@ abstract class GenericDeserializationVisitor extends AbstractVisitor
 
     public function visitString($data, array $type, Context $context)
     {
+        if (is_array($data)) {
+            throw new RuntimeException(sprintf('Expected a string, but got an array: %s', json_encode($data)));
+        }
+
         $data = (string) $data;
 
         if (null === $this->result) {

--- a/tests/JMS/Serializer/Tests/Serializer/JsonSerializationTest.php
+++ b/tests/JMS/Serializer/Tests/Serializer/JsonSerializationTest.php
@@ -209,6 +209,15 @@ class JsonSerializationTest extends BaseSerializationTest
         $this->assertEquals('{"0":{}}', $this->serialize(array(new \stdClass())));
     }
 
+    /**
+     * @expectedException RuntimeException
+     * @expectedExceptionMessage Expected a string, but got an array: [1,3,4]
+     */
+    public function testDeserializingArrayToString()
+    {
+        $this->deserialize('[1, 3, 4]', 'string');
+    }
+
     protected function getFormat()
     {
         return 'json';


### PR DESCRIPTION
At the moment, calling `$serializer->deserialize('[1, 3, 4]', 'string', 'foo');` using a `GenericDeserializationVisitor` (e.g. JSON) throws a PHP notice. After applying this fix, a proper exception is thrown. The other primitive visitors do not seem to have the same problem, as they just default to `0`/`false` without throwing notices.
