### PR TITLE
Introducing NormalizerInterface

### DIFF
--- a/src/JMS/Serializer/NormalizerInterface.php
+++ b/src/JMS/Serializer/NormalizerInterface.php
@@ -1,0 +1,49 @@
+<?php
+
+/*
+ * Copyright 2013 Johannes M. Schmitt <schmittjoh@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace JMS\Serializer;
+
+/**
+ * Interface NormalizerInterface
+ * @author Daniel Bojdo <daniel@bojdo.eu>
+ */
+interface NormalizerInterface
+{
+    /**
+     * Converts objects to an array structure.
+     *
+     * This is useful when the data needs to be passed on to other methods which expect array data.
+     *
+     * @param mixed $data anything that converts to an array, typically an object or an array of objects
+     * @param SerializationContext $context
+     *
+     * @return array
+     */
+    public function toArray($data, SerializationContext $context = null);
+
+    /**
+     * Restores objects from an array structure.
+     *
+     * @param array $data
+     * @param string $type
+     * @param DeserializationContext $context
+     *
+     * @return mixed this returns whatever the passed type is, typically an object or an array of objects
+     */
+    public function fromArray(array $data, $type, DeserializationContext $context = null);
+}

--- a/src/JMS/Serializer/NormalizerInterface.php
+++ b/src/JMS/Serializer/NormalizerInterface.php
@@ -30,7 +30,7 @@ interface NormalizerInterface
      * This is useful when the data needs to be passed on to other methods which expect array data.
      *
      * @param mixed $data anything that converts to an array, typically an object or an array of objects
-     * @param SerializationContext $context
+     * @param SerializationContext|null $context
      *
      * @return array
      */
@@ -41,7 +41,7 @@ interface NormalizerInterface
      *
      * @param array $data
      * @param string $type
-     * @param DeserializationContext $context
+     * @param DeserializationContext|null $context
      *
      * @return mixed this returns whatever the passed type is, typically an object or an array of objects
      */

--- a/src/JMS/Serializer/Serializer.php
+++ b/src/JMS/Serializer/Serializer.php
@@ -105,13 +105,7 @@ class Serializer implements SerializerInterface, NormalizerInterface
     }
 
     /**
-     * Converts objects to an array structure.
-     *
-     * This is useful when the data needs to be passed on to other methods which expect array data.
-     *
-     * @param mixed $data anything that converts to an array, typically an object or an array of objects
-     *
-     * @return array
+     * {@InheritDoc}
      */
     public function toArray($data, SerializationContext $context = null)
     {
@@ -139,12 +133,7 @@ class Serializer implements SerializerInterface, NormalizerInterface
     }
 
     /**
-     * Restores objects from an array structure.
-     *
-     * @param array $data
-     * @param string $type
-     *
-     * @return mixed this returns whatever the passed type is, typically an object or an array of objects
+     * {@InheritDoc}
      */
     public function fromArray(array $data, $type, DeserializationContext $context = null)
     {

--- a/src/JMS/Serializer/Serializer.php
+++ b/src/JMS/Serializer/Serializer.php
@@ -31,7 +31,7 @@ use PhpCollection\MapInterface;
  *
  * @author Johannes M. Schmitt <schmittjoh@gmail.com>
  */
-class Serializer implements SerializerInterface
+class Serializer implements SerializerInterface, NormalizerInterface
 {
     private $factory;
     private $handlerRegistry;


### PR DESCRIPTION
Reintegrates https://github.com/schmittjoh/serializer/pull/538.
Rebased to take updated tests, remove doc duplication.

The `NormalizerInterface` has the 2 methods `fromArray` and `toArray`.
It could be used instead of the full Serializer class when we need to use only `toArray`.