### PR TITLE
Fix xml-attribute-map for the xml driver

### DIFF
--- a/src/JMS/Serializer/Metadata/Driver/XmlDriver.php
+++ b/src/JMS/Serializer/Metadata/Driver/XmlDriver.php
@@ -215,7 +215,7 @@ class XmlDriver extends AbstractFileDriver
                     }
 
                     if (isset($pElem->attributes()->{'xml-attribute-map'})) {
-                        $pMetadata->xmlAttribute = 'true' === (string) $pElem->attributes()->{'xml-attribute-map'};
+                        $pMetadata->xmlAttributeMap = 'true' === (string) $pElem->attributes()->{'xml-attribute-map'};
                     }
 
                     if (isset($pElem->attributes()->{'xml-value'})) {


### PR DESCRIPTION
There is a simple test XML reference for class Foo:
```xml
<?xml version="1.0" encoding="UTF-8"?>
<serializer>
    <class name="Foo">
        <property name="array" type="array" xml-attribute-map="true" />
    </class>
</serializer>
```

```php
class Foo
{
    private $array = [
        'name' => 'firstname',
        'value' => 'lastname'
    ];
}
```

When I try serialize this class I'm expecting to get the result as shown below but instead getting an error that the property **array** cannot be serialized because it contains not allowed characters.
```xml
<result name="firstname" value="lastname"/>
```

After investigation I found the mismatch between xml file property and property in metadata class.
This commit fixed this issue.

