### PR TITLE
[Visitor] Add data manipulation support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -37,7 +37,7 @@
         "symfony/validator": "^2.2",
         "symfony/form": "~2.1",
         "symfony/filesystem": "^2.1",
-        "phpunit/phpunit": "^4.8|^5.0"
+        "phpunit/phpunit": "^5.0,<5.4.0|^4.8"
     },
     "autoload": {
         "psr-0": {

--- a/src/JMS/Serializer/GenericSerializationVisitor.php
+++ b/src/JMS/Serializer/GenericSerializationVisitor.php
@@ -160,6 +160,22 @@ abstract class GenericSerializationVisitor extends AbstractVisitor
     }
 
     /**
+     * @return mixed
+     */
+    public function getData()
+    {
+        return $this->data;
+    }
+
+    /**
+     * @param mixed $data
+     */
+    public function setData($data)
+    {
+        $this->data = $data;
+    }
+
+    /**
      * Allows you to add additional data to the current object/root element.
      *
      * @param string $key
@@ -175,6 +191,17 @@ abstract class GenericSerializationVisitor extends AbstractVisitor
         $this->data[$key] = $value;
     }
 
+    /**
+     * @param string $key
+     */
+    public function removeData($key)
+    {
+        unset($this->data[$key]);
+    }
+
+    /**
+     * @return array|\ArrayObject
+     */
     public function getRoot()
     {
         return $this->root;

--- a/tests/JMS/Serializer/Tests/Serializer/JsonSerializationTest.php
+++ b/tests/JMS/Serializer/Tests/Serializer/JsonSerializationTest.php
@@ -122,6 +122,40 @@ class JsonSerializationTest extends BaseSerializationTest
         $this->assertEquals('[{"full_name":"foo","_links":{"details":"http:\/\/foo.bar\/details\/foo","comments":"http:\/\/foo.bar\/details\/foo\/comments"}},{"full_name":"bar","_links":{"details":"http:\/\/foo.bar\/details\/bar","comments":"http:\/\/foo.bar\/details\/bar\/comments"}}]', $this->serialize($list));
     }
 
+    public function testRemoveFullNameToOutput()
+    {
+        $this->dispatcher->addSubscriber(new LinkAddingSubscriber());
+        $this->dispatcher->addSubscriber(new LinkRemovingSubscriber());
+
+        $this->handlerRegistry->registerHandler(GraphNavigator::DIRECTION_SERIALIZATION, 'JMS\Serializer\Tests\Fixtures\AuthorList', 'json',
+            function(VisitorInterface $visitor, AuthorList $data, array $type, Context $context) {
+                return $visitor->visitArray(iterator_to_array($data), $type, $context);
+            }
+        );
+
+        $list = new AuthorList();
+        $list->add(new Author('foo'));
+        $list->add(new Author('bar'));
+
+        $this->assertEquals('[{"full_name":"foo"},{"full_name":"bar"}]', $this->serialize($list));
+    }
+
+    public function testReplaceAuthorToOutput()
+    {
+        $this->dispatcher->addSubscriber(new AuthorReplacingSubscriber());
+        $this->handlerRegistry->registerHandler(GraphNavigator::DIRECTION_SERIALIZATION, 'JMS\Serializer\Tests\Fixtures\AuthorList', 'json',
+            function(VisitorInterface $visitor, AuthorList $data, array $type, Context $context) {
+                return $visitor->visitArray(iterator_to_array($data), $type, $context);
+            }
+        );
+
+        $list = new AuthorList();
+        $list->add(new Author('foo'));
+        $list->add(new Author('bar'));
+
+        $this->assertEquals('["foo","bar"]', $this->serialize($list));
+    }
+
     public function getPrimitiveTypes()
     {
         return array(
@@ -215,7 +249,17 @@ class JsonSerializationTest extends BaseSerializationTest
     }
 }
 
-class LinkAddingSubscriber implements EventSubscriberInterface
+abstract class AbstractSubscriber implements EventSubscriberInterface
+{
+    public static function getSubscribedEvents()
+    {
+        return array(
+            array('event' => 'serializer.post_serialize', 'method' => 'onPostSerialize', 'format' => 'json', 'class' => 'JMS\Serializer\Tests\Fixtures\Author'),
+        );
+    }
+}
+
+class LinkAddingSubscriber extends AbstractSubscriber
 {
     public function onPostSerialize(Event $event)
     {
@@ -226,11 +270,23 @@ class LinkAddingSubscriber implements EventSubscriberInterface
             'comments' => 'http://foo.bar/details/'.$author->getName().'/comments',
         ));
     }
+}
 
-    public static function getSubscribedEvents()
+class LinkRemovingSubscriber extends AbstractSubscriber
+{
+    public function onPostSerialize(Event $event)
     {
-        return array(
-            array('event' => 'serializer.post_serialize', 'method' => 'onPostSerialize', 'format' => 'json', 'class' => 'JMS\Serializer\Tests\Fixtures\Author'),
-        );
+        $event->getVisitor()->removeData('_links');
+    }
+}
+
+class AuthorReplacingSubscriber extends AbstractSubscriber
+{
+    public function onPostSerialize(Event $event)
+    {
+        $visitor = $event->getVisitor();
+        $data = $visitor->getData();
+
+        $visitor->setData($data['full_name']);
     }
 }


### PR DESCRIPTION
Hey!

This PR is mostly the same as #409 with in addition a methdod in order to replace completely the serialized data and it also adds tests for these new functionalities.

I have also refined the PHPUnit constraint in composer due to some warnings triggered related to `getMock` which has been deprecated.
