### PR TITLE
Fix Doctrine PHPCR ODM 2.0 compatibility

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,7 @@
         "twig/twig": "~1.12|~2.0",
         "doctrine/orm": "~2.1",
         "jackalope/jackalope-doctrine-dbal": "^1.1.5",
-        "doctrine/phpcr-odm": "^1.3",
+        "doctrine/phpcr-odm": "^1.3|^2.0",
         "propel/propel1": "~1.7",
         "symfony/yaml": "^2.1",
         "symfony/translation": "^2.1",

--- a/src/JMS/Serializer/Metadata/Driver/DoctrinePHPCRTypeDriver.php
+++ b/src/JMS/Serializer/Metadata/Driver/DoctrinePHPCRTypeDriver.php
@@ -42,7 +42,7 @@ class DoctrinePHPCRTypeDriver extends AbstractDoctrineTypeDriver
     {
         $propertyName = $propertyMetadata->name;
         if ($doctrineMetadata->hasField($propertyName) && $fieldType = $this->normalizeFieldType($doctrineMetadata->getTypeOfField($propertyName))) {
-            $field = $doctrineMetadata->getField($propertyName);
+            $field = $doctrineMetadata->getFieldMapping($propertyName);
             if ( ! empty($field['multivalue'])) {
                 $fieldType = 'array';
             }


### PR DESCRIPTION
This available since PHPCR ODM 1.1 and the old method is removed in 2.0.