### PR TITLE
YAML mapping fails parseing if both handler_callbacks are defined

### DIFF
--- a/src/JMS/Serializer/Metadata/Driver/YamlDriver.php
+++ b/src/JMS/Serializer/Metadata/Driver/YamlDriver.php
@@ -205,8 +205,11 @@ class YamlDriver extends AbstractFileDriver
         if (isset($config['handler_callbacks'])) {
             foreach ($config['handler_callbacks'] as $direction => $formats) {
                 foreach ($formats as $format => $methodName) {
-                    $direction = GraphNavigator::parseDirection($direction);
-                    $metadata->addHandlerCallback($direction, $format, $methodName);
+                    $metadata->addHandlerCallback(
+                        GraphNavigator::parseDirection($direction),
+                        $format,
+                        $methodName
+                    );
                 }
             }
         }


### PR DESCRIPTION
If you define two ``handler_callbacks`` in the YAML mapping the YamlDriver fails because the variable ``$direction`` from line 206 is overwritten in line 208 by ``GraphNavigator::parseDirection($direction)``.
This dont fails if you only define one item below ``handler_callbacks``, but if you define both it will fail with the error message: ``The direction "1" does not exist``