### PR TITLE
Allow to not skip empty not inline array root node

### DIFF
--- a/src/JMS/Serializer/Annotation/XmlCollection.php
+++ b/src/JMS/Serializer/Annotation/XmlCollection.php
@@ -38,5 +38,5 @@ abstract class XmlCollection
     /**
      * @var boolean
      */
-    public $skip_when_empty = true;
+    public $skipWhenEmpty = true;
 }

--- a/src/JMS/Serializer/Metadata/Driver/AnnotationDriver.php
+++ b/src/JMS/Serializer/Metadata/Driver/AnnotationDriver.php
@@ -171,6 +171,7 @@ class AnnotationDriver implements DriverInterface
                         $propertyMetadata->xmlCollectionInline = $annot->inline;
                         $propertyMetadata->xmlEntryName = $annot->entry;
                         $propertyMetadata->xmlEntryNamespace = $annot->namespace;
+                        $propertyMetadata->xmlCollectionSkipWhenEmpty = $annot->skip_when_empty;
                     } elseif ($annot instanceof XmlMap) {
                         $propertyMetadata->xmlCollection = true;
                         $propertyMetadata->xmlCollectionInline = $annot->inline;

--- a/src/JMS/Serializer/Metadata/Driver/AnnotationDriver.php
+++ b/src/JMS/Serializer/Metadata/Driver/AnnotationDriver.php
@@ -171,7 +171,7 @@ class AnnotationDriver implements DriverInterface
                         $propertyMetadata->xmlCollectionInline = $annot->inline;
                         $propertyMetadata->xmlEntryName = $annot->entry;
                         $propertyMetadata->xmlEntryNamespace = $annot->namespace;
-                        $propertyMetadata->xmlCollectionSkipWhenEmpty = $annot->skip_when_empty;
+                        $propertyMetadata->xmlCollectionSkipWhenEmpty = $annot->skipWhenEmpty;
                     } elseif ($annot instanceof XmlMap) {
                         $propertyMetadata->xmlCollection = true;
                         $propertyMetadata->xmlCollectionInline = $annot->inline;

--- a/src/JMS/Serializer/Metadata/Driver/XmlDriver.php
+++ b/src/JMS/Serializer/Metadata/Driver/XmlDriver.php
@@ -162,6 +162,7 @@ class XmlDriver extends AbstractFileDriver
                     }
 
                     if (isset($pElem->{'xml-list'})) {
+
                         $pMetadata->xmlCollection = true;
 
                         $colConfig = $pElem->{'xml-list'};
@@ -171,6 +172,12 @@ class XmlDriver extends AbstractFileDriver
 
                         if (isset($colConfig->attributes()->{'entry-name'})) {
                             $pMetadata->xmlEntryName = (string) $colConfig->attributes()->{'entry-name'};
+                        }
+                        
+                        if (isset($colConfig->attributes()->{'skip-when-empty'})) {
+                            $pMetadata->xmlCollectionSkipWhenEmpty = 'true' === (string) $colConfig->attributes()->{'skip-when-empty'};
+                        } else {
+                            $pMetadata->xmlCollectionSkipWhenEmpty = true;
                         }
 
                         if (isset($colConfig->attributes()->namespace)) {

--- a/src/JMS/Serializer/Metadata/Driver/YamlDriver.php
+++ b/src/JMS/Serializer/Metadata/Driver/YamlDriver.php
@@ -113,11 +113,17 @@ class YamlDriver extends AbstractFileDriver
 
                         $colConfig = $pConfig['xml_list'];
                         if (isset($colConfig['inline'])) {
-                            $pMetadata->xmlCollectionInline = (Boolean) $colConfig['inline'];
+                            $pMetadata->xmlCollectionInline = (Boolean)$colConfig['inline'];
                         }
 
                         if (isset($colConfig['entry_name'])) {
-                            $pMetadata->xmlEntryName = (string) $colConfig['entry_name'];
+                            $pMetadata->xmlEntryName = (string)$colConfig['entry_name'];
+                        }
+
+                        if (isset($colConfig['skip_when_empty'])) {
+                            $pMetadata->xmlCollectionSkipWhenEmpty = (Boolean)$colConfig['skip_when_empty'];
+                        } else {
+                            $pMetadata->xmlCollectionSkipWhenEmpty = true;
                         }
 
                         if (isset($colConfig['namespace'])) {

--- a/src/JMS/Serializer/Metadata/PropertyMetadata.php
+++ b/src/JMS/Serializer/Metadata/PropertyMetadata.php
@@ -34,6 +34,7 @@ class PropertyMetadata extends BasePropertyMetadata
     public $type;
     public $xmlCollection = false;
     public $xmlCollectionInline = false;
+    public $xmlCollectionSkipWhenEmpty = true;
     public $xmlEntryName;
     public $xmlEntryNamespace;
     public $xmlKeyAttribute;
@@ -134,6 +135,7 @@ class PropertyMetadata extends BasePropertyMetadata
             $this->maxDepth,
             parent::serialize(),
             'xmlEntryNamespace' => $this->xmlEntryNamespace,
+            'xmlCollectionSkipWhenEmpty' => $this->xmlCollectionSkipWhenEmpty,
         ));
     }
 
@@ -167,6 +169,10 @@ class PropertyMetadata extends BasePropertyMetadata
         if (isset($unserialized['xmlEntryNamespace'])){
             $this->xmlEntryNamespace = $unserialized['xmlEntryNamespace'];
         }
+        if (isset($unserialized['xmlCollectionSkipWhenEmpty'])){
+            $this->xmlCollectionSkipWhenEmpty = $unserialized['xmlCollectionSkipWhenEmpty'];
+        }
+        
 
         parent::unserialize($parentStr);
     }

--- a/src/JMS/Serializer/XmlDeserializationVisitor.php
+++ b/src/JMS/Serializer/XmlDeserializationVisitor.php
@@ -267,16 +267,13 @@ class XmlDeserializationVisitor extends AbstractVisitor
                 $prefix = uniqid('ns-');
                 $data->registerXPathNamespace($prefix, $namespaces['']);
                 $nodes = $data->xpath('./'.$prefix. ':'.$name );
-                if (empty($nodes)) {
-                    return;
-                }
-                $node = reset($nodes);
             } else {
-                if (!isset($data->$name)) {
-                    return;
-                }
-                $node = $data->$name;
+                $nodes = $data->xpath('./'. $name );
             }
+            if (empty($nodes)) {
+                return;
+            }
+            $node = reset($nodes);
         }
 
         $v = $this->navigator->accept($node, $metadata->type, $context);

--- a/src/JMS/Serializer/XmlSerializationVisitor.php
+++ b/src/JMS/Serializer/XmlSerializationVisitor.php
@@ -303,12 +303,17 @@ class XmlSerializationVisitor extends AbstractVisitor
         if ($addEnclosingElement) {
             $this->revertCurrentNode();
 
-            if ($element->hasChildNodes() || $element->hasAttributes() || ($node === null && $v !== null && !$context->isVisiting($v))) {
+            if ($this->nodeNotEmpty($element) || ((!$metadata->xmlCollection || !$metadata->xmlCollectionSkipWhenEmpty) && $node === null && $v !== null && !$context->isVisiting($v))) {
                 $this->currentNode->appendChild($element);
             }
         }
 
         $this->hasValue = false;
+    }
+
+    private function nodeNotEmpty(\DOMElement $element)
+    {
+        return $element->hasChildNodes() || $element->hasAttributes();
     }
 
     public function endVisitingObject(ClassMetadata $metadata, $data, array $type, Context $context)

--- a/src/JMS/Serializer/XmlSerializationVisitor.php
+++ b/src/JMS/Serializer/XmlSerializationVisitor.php
@@ -443,21 +443,17 @@ class XmlSerializationVisitor extends AbstractVisitor
 
     private function createElement($tagName, $namespace = null)
     {
-        if (null !== $namespace) {
-
-            if ($this->currentNode->isDefaultNamespace($namespace)) {
-                return $this->document->createElementNS($namespace, $tagName);
-            } else {
-                if (!$prefix = $this->currentNode->lookupPrefix($namespace)) {
-                    $prefix = 'ns-'.  substr(sha1($namespace), 0, 8);
-                }
-                return $this->document->createElementNS($namespace, $prefix . ':' . $tagName);
-            }
-
-
-        } else {
+        if (null === $namespace) {
             return $this->document->createElement($tagName);
         }
+        if ($this->currentNode->isDefaultNamespace($namespace)) {
+            return $this->document->createElementNS($namespace, $tagName);
+        }
+        if (!($prefix = $this->currentNode->lookupPrefix($namespace)) && !($prefix = $this->document->lookupPrefix($namespace))) {
+            $prefix = 'ns-'.  substr(sha1($namespace), 0, 8);
+            return $this->document->createElementNS($namespace, $prefix . ':' . $tagName);
+        }
+        return $this->document->createElement($prefix . ':' . $tagName);
     }
 
     private function setAttributeOnNode(\DOMElement $node, $name, $value, $namespace = null)

--- a/src/JMS/Serializer/XmlSerializationVisitor.php
+++ b/src/JMS/Serializer/XmlSerializationVisitor.php
@@ -303,8 +303,7 @@ class XmlSerializationVisitor extends AbstractVisitor
         if ($addEnclosingElement) {
             $this->revertCurrentNode();
 
-            if ($element->hasChildNodes() || $element->hasAttributes()
-                || (isset($metadata->type['name']) && $metadata->type['name'] === 'array' && isset($metadata->type['params'][1]))) {
+            if ($element->hasChildNodes() || $element->hasAttributes() || ($node === null && $v !== null && !$context->isVisiting($v))) {
                 $this->currentNode->appendChild($element);
             }
         }

--- a/tests/JMS/Serializer/Tests/Fixtures/ObjectWithAbsentXmlListNode.php
+++ b/tests/JMS/Serializer/Tests/Fixtures/ObjectWithAbsentXmlListNode.php
@@ -16,27 +16,26 @@
  * limitations under the License.
  */
 
-namespace JMS\Serializer\Annotation;
+namespace JMS\Serializer\Tests\Fixtures;
 
-abstract class XmlCollection
+use JMS\Serializer\Annotation as Serializer;
+
+class ObjectWithAbsentXmlListNode
 {
     /**
-     * @var string
+     * @Serializer\XmlList(inline=false, entry="comment", skip_when_empty=true)
+     * @Serializer\Type("array<string>")
      */
-    public $entry = 'entry';
+    public $absent;
+    /**
+     * @Serializer\XmlList(inline=false, entry="comment", skip_when_empty=false)
+     * @Serializer\Type("array<string>")
+     */
+    public $present;
 
     /**
-     * @var boolean
+     * @Serializer\XmlList(inline=false, entry="comment")
+     * @Serializer\Type("array<string>")
      */
-    public $inline = false;
-
-    /**
-     * @var string
-     */
-    public $namespace;
-
-    /**
-     * @var boolean
-     */
-    public $skip_when_empty = true;
+    public $skipDefault;
 }

--- a/tests/JMS/Serializer/Tests/Fixtures/ObjectWithAbsentXmlListNode.php
+++ b/tests/JMS/Serializer/Tests/Fixtures/ObjectWithAbsentXmlListNode.php
@@ -23,12 +23,12 @@ use JMS\Serializer\Annotation as Serializer;
 class ObjectWithAbsentXmlListNode
 {
     /**
-     * @Serializer\XmlList(inline=false, entry="comment", skip_when_empty=true)
+     * @Serializer\XmlList(inline=false, entry="comment", skipWhenEmpty=true)
      * @Serializer\Type("array<string>")
      */
     public $absent;
     /**
-     * @Serializer\XmlList(inline=false, entry="comment", skip_when_empty=false)
+     * @Serializer\XmlList(inline=false, entry="comment", skipWhenEmpty=false)
      * @Serializer\Type("array<string>")
      */
     public $present;

--- a/tests/JMS/Serializer/Tests/Fixtures/ObjectWithEmptyNullableAndEmptyArrays.php
+++ b/tests/JMS/Serializer/Tests/Fixtures/ObjectWithEmptyNullableAndEmptyArrays.php
@@ -54,26 +54,26 @@ class ObjectWithEmptyNullableAndEmptyArrays
     public $empty_not_inline = [];
 
     /**
-     * @Serializer\XmlList(inline = false, entry = "comment", skip_when_empty=false)
+     * @Serializer\XmlList(inline = false, entry = "comment", skipWhenEmpty=false)
      * @Serializer\Type("array")
      */
     public $not_empty_not_inline = ['not_empty_not_inline'];
 
     /**
-     * @Serializer\XmlList(inline = false, entry = "comment", skip_when_empty=false)
+     * @Serializer\XmlList(inline = false, entry = "comment", skipWhenEmpty=false)
      * @Serializer\Type("array")
      */
     public $null_not_inline_skip = null;
 
     /**
-     * @Serializer\XmlList(inline = false, entry = "comment", skip_when_empty=false)
+     * @Serializer\XmlList(inline = false, entry = "comment", skipWhenEmpty=false)
      * @Serializer\Type("array")
      */
     public $empty_not_inline_skip = [];
 
 
     /**
-     * @Serializer\XmlList(inline = false, entry = "comment", skip_when_empty=false)
+     * @Serializer\XmlList(inline = false, entry = "comment", skipWhenEmpty=false)
      * @Serializer\Type("array")
      */
     public $not_empty_not_inline_skip = ['not_empty_not_inline_skip'];

--- a/tests/JMS/Serializer/Tests/Fixtures/ObjectWithEmptyNullableAndEmptyArrays.php
+++ b/tests/JMS/Serializer/Tests/Fixtures/ObjectWithEmptyNullableAndEmptyArrays.php
@@ -53,10 +53,28 @@ class ObjectWithEmptyNullableAndEmptyArrays
      */
     public $empty_not_inline = [];
 
-
     /**
-     * @Serializer\XmlList(inline = false, entry = "comment")
+     * @Serializer\XmlList(inline = false, entry = "comment", skip_when_empty=false)
      * @Serializer\Type("array")
      */
     public $not_empty_not_inline = ['not_empty_not_inline'];
+
+    /**
+     * @Serializer\XmlList(inline = false, entry = "comment", skip_when_empty=false)
+     * @Serializer\Type("array")
+     */
+    public $null_not_inline_skip = null;
+
+    /**
+     * @Serializer\XmlList(inline = false, entry = "comment", skip_when_empty=false)
+     * @Serializer\Type("array")
+     */
+    public $empty_not_inline_skip = [];
+
+
+    /**
+     * @Serializer\XmlList(inline = false, entry = "comment", skip_when_empty=false)
+     * @Serializer\Type("array")
+     */
+    public $not_empty_not_inline_skip = ['not_empty_not_inline_skip'];
 }

--- a/tests/JMS/Serializer/Tests/Fixtures/ObjectWithEmptyNullableAndEmptyArrays.php
+++ b/tests/JMS/Serializer/Tests/Fixtures/ObjectWithEmptyNullableAndEmptyArrays.php
@@ -1,0 +1,62 @@
+<?php
+
+/*
+ * Copyright 2013 Johannes M. Schmitt <schmittjoh@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace JMS\Serializer\Tests\Fixtures;
+
+use JMS\Serializer\Annotation as Serializer;
+
+class ObjectWithEmptyNullableAndEmptyArrays
+{
+    /**
+     * @Serializer\XmlList(inline = true, entry = "comment")
+     * @Serializer\Type("array")
+     */
+    public $null_inline = null;
+
+    /**
+     * @Serializer\XmlList(inline = true, entry = "comment")
+     * @Serializer\Type("array")
+     */
+    public $empty_inline = [];
+
+
+    /**
+     * @Serializer\XmlList(inline = true, entry = "comment")
+     * @Serializer\Type("array")
+     */
+    public $not_empty_inline = ['not_empty_inline'];
+
+    /**
+     * @Serializer\XmlList(inline = false, entry = "comment")
+     * @Serializer\Type("array")
+     */
+    public $null_not_inline = null;
+
+    /**
+     * @Serializer\XmlList(inline = false, entry = "comment")
+     * @Serializer\Type("array")
+     */
+    public $empty_not_inline = [];
+
+
+    /**
+     * @Serializer\XmlList(inline = false, entry = "comment")
+     * @Serializer\Type("array")
+     */
+    public $not_empty_not_inline = ['not_empty_not_inline'];
+}

--- a/tests/JMS/Serializer/Tests/Metadata/Driver/BaseDriverTest.php
+++ b/tests/JMS/Serializer/Tests/Metadata/Driver/BaseDriverTest.php
@@ -95,6 +95,19 @@ abstract class BaseDriverTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($p, $m->propertyMetadata['price']);
     }
 
+    public function testXMLListAbsentNode()
+    {
+        $m = $this->getDriver()->loadMetadataForClass(new \ReflectionClass('JMS\Serializer\Tests\Fixtures\ObjectWithAbsentXmlListNode'));
+        
+        $this->assertArrayHasKey('absent', $m->propertyMetadata);
+        $this->assertArrayHasKey('present', $m->propertyMetadata);
+        $this->assertArrayHasKey('skipDefault', $m->propertyMetadata);
+
+        $this->assertTrue($m->propertyMetadata['absent']->xmlCollectionSkipWhenEmpty);
+        $this->assertTrue($m->propertyMetadata['skipDefault']->xmlCollectionSkipWhenEmpty);
+        $this->assertFalse($m->propertyMetadata['present']->xmlCollectionSkipWhenEmpty);
+    }
+
     public function testVirtualProperty()
     {
         $m = $this->getDriver()->loadMetadataForClass(new \ReflectionClass('JMS\Serializer\Tests\Fixtures\ObjectWithVirtualProperties'));

--- a/tests/JMS/Serializer/Tests/Metadata/Driver/php/ObjectWithAbsentXmlListNode.php
+++ b/tests/JMS/Serializer/Tests/Metadata/Driver/php/ObjectWithAbsentXmlListNode.php
@@ -1,0 +1,23 @@
+<?php
+
+use JMS\Serializer\Metadata\ClassMetadata;
+use JMS\Serializer\Metadata\PropertyMetadata;
+use JMS\Serializer\Metadata\VirtualPropertyMetadata;
+
+$className = 'JMS\Serializer\Tests\Fixtures\ObjectWithAbsentXmlListNode';
+
+$metadata = new ClassMetadata( $className );
+
+$pMetadata = new PropertyMetadata($className, 'absent');
+$pMetadata->xmlCollectionSkipWhenEmpty = true;
+$metadata->addPropertyMetadata($pMetadata);
+
+$pMetadata = new PropertyMetadata($className, 'present');
+$pMetadata->xmlCollectionSkipWhenEmpty = false;
+$metadata->addPropertyMetadata($pMetadata);
+
+$pMetadata = new PropertyMetadata($className, 'skipDefault');
+$metadata->addPropertyMetadata($pMetadata);
+
+
+return $metadata;

--- a/tests/JMS/Serializer/Tests/Metadata/Driver/xml/ObjectWithAbsentXmlListNode.xml
+++ b/tests/JMS/Serializer/Tests/Metadata/Driver/xml/ObjectWithAbsentXmlListNode.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<serializer>
+    <class name="JMS\Serializer\Tests\Fixtures\ObjectWithAbsentXmlListNode">
+        <property name="absent">
+            <type>array</type>
+            <xml-list skip-when-empty="true"/>
+        </property>
+        <property name="present">
+            <type>array</type>
+            <xml-list skip-when-empty="false"/>
+        </property>
+        <property name="skipDefault">
+            <type>array</type>
+        </property>
+    </class>
+</serializer>

--- a/tests/JMS/Serializer/Tests/Metadata/Driver/yml/ObjectWithAbsentXmlListNode.yml
+++ b/tests/JMS/Serializer/Tests/Metadata/Driver/yml/ObjectWithAbsentXmlListNode.yml
@@ -1,0 +1,14 @@
+JMS\Serializer\Tests\Fixtures\ObjectWithAbsentXmlListNode:
+    properties:
+        absent:
+            type: array
+            xml_list:
+              skip_when_empty: true
+        present:
+            type: array
+            xml_list:
+              skip_when_empty: false
+        skipDefault:
+            type: array
+            xml_list:
+              inline: false

--- a/tests/JMS/Serializer/Tests/Serializer/BaseSerializationTest.php
+++ b/tests/JMS/Serializer/Tests/Serializer/BaseSerializationTest.php
@@ -29,6 +29,7 @@ use JMS\Serializer\Tests\Fixtures\Discriminator\Moped;
 use JMS\Serializer\Tests\Fixtures\Garage;
 use JMS\Serializer\Tests\Fixtures\InlineChildEmpty;
 use JMS\Serializer\Tests\Fixtures\NamedDateTimeArraysObject;
+use JMS\Serializer\Tests\Fixtures\ObjectWithEmptyNullableAndEmptyArrays;
 use JMS\Serializer\Tests\Fixtures\ObjectWithIntListAndIntMap;
 use JMS\Serializer\Tests\Fixtures\Tag;
 use JMS\Serializer\Tests\Fixtures\Timestamp;
@@ -975,6 +976,12 @@ abstract class BaseSerializationTest extends \PHPUnit_Framework_TestCase
         $this->assertSame($order, $deseralizedOrder);
         $this->assertEquals(new Order(new Price(12.34)), $deseralizedOrder);
         $this->assertAttributeInstanceOf('JMS\Serializer\Tests\Fixtures\Price', 'cost', $deseralizedOrder);
+    }
+
+    public function testObjectWithNullableArrays()
+    {
+        $object = new ObjectWithEmptyNullableAndEmptyArrays();
+        $this->assertEquals($this->getContent('nullable_arrays'), $this->serializer->serialize($object, $this->getFormat()));
     }
 
     abstract protected function getContent($key);

--- a/tests/JMS/Serializer/Tests/Serializer/JsonSerializationTest.php
+++ b/tests/JMS/Serializer/Tests/Serializer/JsonSerializationTest.php
@@ -97,7 +97,7 @@ class JsonSerializationTest extends BaseSerializationTest
             $outputs['car_without_type'] = '{"km":5}';
             $outputs['garage'] = '{"vehicles":[{"km":3,"type":"car"},{"km":1,"type":"moped"}]}';
             $outputs['tree'] = '{"tree":{"children":[{"children":[{"children":[],"foo":"bar"}],"foo":"bar"}],"foo":"bar"}}';
-            $outputs['nullable_arrays'] = '{"empty_inline":[],"not_empty_inline":["not_empty_inline"],"empty_not_inline":[],"not_empty_not_inline":["not_empty_not_inline"]}';
+            $outputs['nullable_arrays'] = '{"empty_inline":[],"not_empty_inline":["not_empty_inline"],"empty_not_inline":[],"not_empty_not_inline":["not_empty_not_inline"],"empty_not_inline_skip":[],"not_empty_not_inline_skip":["not_empty_not_inline_skip"]}';
         }
 
         if (!isset($outputs[$key])) {

--- a/tests/JMS/Serializer/Tests/Serializer/JsonSerializationTest.php
+++ b/tests/JMS/Serializer/Tests/Serializer/JsonSerializationTest.php
@@ -97,6 +97,7 @@ class JsonSerializationTest extends BaseSerializationTest
             $outputs['car_without_type'] = '{"km":5}';
             $outputs['garage'] = '{"vehicles":[{"km":3,"type":"car"},{"km":1,"type":"moped"}]}';
             $outputs['tree'] = '{"tree":{"children":[{"children":[{"children":[],"foo":"bar"}],"foo":"bar"}],"foo":"bar"}}';
+            $outputs['nullable_arrays'] = '{"empty_inline":[],"not_empty_inline":["not_empty_inline"],"empty_not_inline":[],"not_empty_not_inline":["not_empty_not_inline"]}';
         }
 
         if (!isset($outputs[$key])) {

--- a/tests/JMS/Serializer/Tests/Serializer/xml/nullable_arrays.xml
+++ b/tests/JMS/Serializer/Tests/Serializer/xml/nullable_arrays.xml
@@ -1,8 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <result>
   <comment><![CDATA[not_empty_inline]]></comment>
-  <empty_not_inline/>
   <not_empty_not_inline>
     <comment><![CDATA[not_empty_not_inline]]></comment>
   </not_empty_not_inline>
+  <empty_not_inline_skip/>
+  <not_empty_not_inline_skip>
+    <comment><![CDATA[not_empty_not_inline_skip]]></comment>
+  </not_empty_not_inline_skip>
 </result>

--- a/tests/JMS/Serializer/Tests/Serializer/xml/nullable_arrays.xml
+++ b/tests/JMS/Serializer/Tests/Serializer/xml/nullable_arrays.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<result>
+  <comment><![CDATA[not_empty_inline]]></comment>
+  <empty_not_inline/>
+  <not_empty_not_inline>
+    <comment><![CDATA[not_empty_not_inline]]></comment>
+  </not_empty_not_inline>
+</result>

--- a/tests/JMS/Serializer/Tests/Serializer/yml/nullable_arrays.yml
+++ b/tests/JMS/Serializer/Tests/Serializer/yml/nullable_arrays.yml
@@ -1,0 +1,6 @@
+empty_inline: []
+not_empty_inline:
+    - not_empty_inline
+empty_not_inline: []
+not_empty_not_inline:
+    - not_empty_not_inline

--- a/tests/JMS/Serializer/Tests/Serializer/yml/nullable_arrays.yml
+++ b/tests/JMS/Serializer/Tests/Serializer/yml/nullable_arrays.yml
@@ -4,3 +4,6 @@ not_empty_inline:
 empty_not_inline: []
 not_empty_not_inline:
     - not_empty_not_inline
+empty_not_inline_skip: []
+not_empty_not_inline_skip:
+    - not_empty_not_inline_skip


### PR DESCRIPTION
The current implementation skips the root node for not inline arrays when serializing into XML.

Given: 

```php
class User {
    /**
     * @Serializer\XmlList(inline = false, entry = "comment")
     * @Serializer\Type("array")
     */
    public $data = [];
}
```

The previous output was: 

```xml
<result/>
```
The new behaviour is: 
```xml
<result>
  <data/>
</result>
```

~~Should this be considered a BC break?~~
probably yes

This change is consistent with the existing JSON and YML implementations since the output is

```json
{
  "data": []
}
```

```yml
data: []
```