### PR TITLE
Change type hint for TypeParser on Serializer

### DIFF
--- a/src/JMS/Serializer/Serializer.php
+++ b/src/JMS/Serializer/Serializer.php
@@ -18,6 +18,7 @@
 
 namespace JMS\Serializer;
 
+use JMS\Parser\AbstractParser;
 use JMS\Serializer\Construction\ObjectConstructorInterface;
 use JMS\Serializer\Exception\RuntimeException;
 use JMS\Serializer\Handler\HandlerRegistryInterface;
@@ -56,9 +57,9 @@ class Serializer implements SerializerInterface
      * @param \PhpCollection\MapInterface $serializationVisitors of VisitorInterface
      * @param \PhpCollection\MapInterface $deserializationVisitors of VisitorInterface
      * @param EventDispatcher\EventDispatcherInterface $dispatcher
-     * @param TypeParser $typeParser
+     * @param AbstractParser $typeParser
      */
-    public function __construct(MetadataFactoryInterface $factory, HandlerRegistryInterface $handlerRegistry, ObjectConstructorInterface $objectConstructor, MapInterface $serializationVisitors, MapInterface $deserializationVisitors, EventDispatcherInterface $dispatcher = null, TypeParser $typeParser = null)
+    public function __construct(MetadataFactoryInterface $factory, HandlerRegistryInterface $handlerRegistry, ObjectConstructorInterface $objectConstructor, MapInterface $serializationVisitors, MapInterface $deserializationVisitors, EventDispatcherInterface $dispatcher = null, AbstractParser $typeParser = null)
     {
         $this->factory = $factory;
         $this->handlerRegistry = $handlerRegistry;


### PR DESCRIPTION
It seems odd that Serializer takes in an argument for the type parser, but type hints it to TypeParser, which is a final class.

I suggest changing the type hint to AbstractParser (which TypeParser extends). This allows the user to provide their own type parser if they so choose.
