### PR TITLE
Fixed #353 - skip custom handler to default (de)serialization process

### DIFF
--- a/src/JMS/Serializer/GraphNavigator.php
+++ b/src/JMS/Serializer/GraphNavigator.php
@@ -28,6 +28,7 @@ use JMS\Serializer\EventDispatcher\EventDispatcherInterface;
 use JMS\Serializer\Metadata\ClassMetadata;
 use Metadata\MetadataFactoryInterface;
 use JMS\Serializer\Exception\InvalidArgumentException;
+use JMS\Serializer\Exception\UnsupportedFormatException;
 
 /**
  * Handles traversal along the object graph.
@@ -176,10 +177,19 @@ final class GraphNavigator
                 // before loading metadata because the type name might not be a class, but
                 // could also simply be an artifical type.
                 if (null !== $handler = $this->handlerRegistry->getHandler($context->getDirection(), $type['name'], $context->getFormat())) {
-                    $rs = call_user_func($handler, $visitor, $data, $type, $context);
-                    $this->leaveScope($context, $data);
 
-                    return $rs;
+                    try {
+                        // We will call custom handler, however, if custom handler would like to skip
+                        // serialization/deserialization handling and fall back to default serialization/deserialization
+                        // process, it should throw \JMS\Serializer\Exception\UnsupportedFormatException
+                        $rs = call_user_func($handler, $visitor, $data, $type, $context);
+                        $this->leaveScope($context, $data);
+
+                        return $rs;
+
+                    } catch (UnsupportedFormatException $e) {
+                        // noop
+                    }
                 }
 
                 $exclusionStrategy = $context->getExclusionStrategy();


### PR DESCRIPTION
Following this issue: https://github.com/schmittjoh/JMSSerializerBundle/issues/353

I have stumbled upon the fact that it is impossible to fall down to default process of serialization/deserialization in our custom handler.

Use case is very simple, in one context I want to use my own handler, in other, I would like to use a default one. This is mostly related to usage of Doctrine Entities when it comes to relations, as well as file uploads.

We want to be able to use both approaches, without inventing fictive types.

Proposed solution is quite easy - if we decide in our custom handler that we would like to continue by using default handling of serialization/deserialization, we just throw 'JMS\Serializer\Exception\UnsupportedFormatException' and GraphNavigator will continue its process.

This is improvement of current functionality and does not introduces any BC breaks.