### PR TITLE
Added public `hasData` function to check if a data key already have been added.

### DIFF
--- a/src/JMS/Serializer/GenericSerializationVisitor.php
+++ b/src/JMS/Serializer/GenericSerializationVisitor.php
@@ -174,6 +174,17 @@ abstract class GenericSerializationVisitor extends AbstractVisitor
 
         $this->data[$key] = $value;
     }
+    
+    /**
+     * Checks if some data key exists.
+     *
+     * @param string $key
+     * @return boolean
+     */
+    public function hasData($key)
+    {
+        return isset($this->data[$key]);
+    }
 
     public function getRoot()
     {

--- a/tests/JMS/Serializer/Tests/Serializer/BaseSerializationTest.php
+++ b/tests/JMS/Serializer/Tests/Serializer/BaseSerializationTest.php
@@ -105,6 +105,10 @@ use JMS\Serializer\Tests\Fixtures\AuthorReadOnlyPerClass;
 abstract class BaseSerializationTest extends \PHPUnit_Framework_TestCase
 {
     protected $factory;
+
+    /**
+     * @var EventDispatcher
+     */
     protected $dispatcher;
 
     /** @var Serializer */

--- a/tests/JMS/Serializer/Tests/Serializer/JsonSerializationTest.php
+++ b/tests/JMS/Serializer/Tests/Serializer/JsonSerializationTest.php
@@ -111,7 +111,16 @@ class JsonSerializationTest extends BaseSerializationTest
 
     public function testAddLinksToOutput()
     {
+        $this->dispatcher->addListener('serializer.post_serialize', function (Event $event) {
+            $this->assertFalse($event->getVisitor()->hasData('_links'));
+        }, 'JMS\Serializer\Tests\Fixtures\Author', 'json');
+
         $this->dispatcher->addSubscriber(new LinkAddingSubscriber());
+
+        $this->dispatcher->addListener('serializer.post_serialize', function (Event $event) {
+            $this->assertTrue($event->getVisitor()->hasData('_links'));
+        }, 'JMS\Serializer\Tests\Fixtures\Author', 'json');
+
         $this->handlerRegistry->registerHandler(GraphNavigator::DIRECTION_SERIALIZATION, 'JMS\Serializer\Tests\Fixtures\AuthorList', 'json',
             function(VisitorInterface $visitor, AuthorList $data, array $type, Context $context) {
                 return $visitor->visitArray(iterator_to_array($data), $type, $context);


### PR DESCRIPTION
Replaces https://github.com/schmittjoh/serializer/pull/466 adding tests

> This pull request is related with schmittjoh/serializer#197 but it's less aggressive.

> In order to reduce try/catch blocks I think it's important to expose data in some way, at least to know if a key already exists.

> This will reduce many try/catch blocks or "added flags".