### PR TITLE
Fix serializing nulls in arrays

### DIFF
--- a/src/JMS/Serializer/Context.php
+++ b/src/JMS/Serializer/Context.php
@@ -54,6 +54,9 @@ abstract class Context
     /** @var boolean|null */
     private $serializeNull;
 
+    /** @var boolean */
+    private $serializeInArrayNull = false;
+
     private $initialized = false;
 
     /** @var \SplStack */
@@ -208,6 +211,35 @@ abstract class Context
     public function shouldSerializeNull()
     {
         return $this->serializeNull;
+    }
+
+    /**
+     * Set if NULLs in arrays should be presented (TRUE) or skipped (FALSE)
+     *
+     * @param bool $bool
+     * @return $this
+     */
+    public function setSerializeInArrayNull($bool)
+    {
+        $this->serializeInArrayNull = (boolean) $bool;
+
+        return $this;
+    }
+
+    /**
+     * Returns TRUE when NULLs in arrays should be presented
+     * Returns FALSE when NULLs in arrays should be skipped
+     *
+     * @return bool
+     */
+    public function shouldSerializeInArrayNull()
+    {
+        return $this->serializeInArrayNull;
+    }
+
+    public function shouldSerializeNullForKey($key)
+    {
+        return is_string($key) ? $this->shouldSerializeNull() : $this->shouldSerializeInArrayNull();
     }
 
     /**

--- a/src/JMS/Serializer/GenericSerializationVisitor.php
+++ b/src/JMS/Serializer/GenericSerializationVisitor.php
@@ -103,7 +103,7 @@ abstract class GenericSerializationVisitor extends AbstractVisitor
         foreach ($data as $k => $v) {
             $v = $this->navigator->accept($v, $this->getElementType($type), $context);
 
-            if (null === $v && ( ! is_string($k) || $context->shouldSerializeNull() !== true)) {
+            if (null === $v && ! $context->shouldSerializeNullForKey($k)) {
                 continue;
             }
 

--- a/src/JMS/Serializer/YamlSerializationVisitor.php
+++ b/src/JMS/Serializer/YamlSerializationVisitor.php
@@ -85,7 +85,7 @@ class YamlSerializationVisitor extends AbstractVisitor
             || array_keys($data) === range(0, count($data) - 1);
 
         foreach ($data as $k => $v) {
-            if (null === $v && ( ! is_string($k) || $context->shouldSerializeNull() !== true)) {
+            if (null === $v && ! $context->shouldSerializeNullForKey($k)) {
                 continue;
             }
 

--- a/tests/JMS/Serializer/Tests/Serializer/BaseSerializationTest.php
+++ b/tests/JMS/Serializer/Tests/Serializer/BaseSerializationTest.php
@@ -274,6 +274,16 @@ abstract class BaseSerializationTest extends \PHPUnit_Framework_TestCase
         }
     }
 
+    public function testArrayNulls()
+    {
+        $arr = array(null, null);
+
+        $this->assertEquals(
+            $this->getContent('array_nulls'),
+            $this->serializer->serialize($arr, $this->getFormat(), SerializationContext::create()->setSerializeInArrayNull(true))
+        );
+    }
+
     public function testArrayObjects()
     {
         $data = array(new SimpleObject('foo', 'bar'), new SimpleObject('baz', 'boo'));

--- a/tests/JMS/Serializer/Tests/Serializer/JsonSerializationTest.php
+++ b/tests/JMS/Serializer/Tests/Serializer/JsonSerializationTest.php
@@ -48,6 +48,7 @@ class JsonSerializationTest extends BaseSerializationTest
             $outputs['array_integers'] = '[1,3,4]';
             $outputs['array_empty'] = '{"array":[]}';
             $outputs['array_floats'] = '[1.34,3,6.42]';
+            $outputs['array_nulls'] = '[null,null]';
             $outputs['array_objects'] = '[{"foo":"foo","moo":"bar","camel_case":"boo"},{"foo":"baz","moo":"boo","camel_case":"boo"}]';
             $outputs['array_list_and_map_difference'] = '{"list":[1,2,3],"map":{"0":1,"2":2,"3":3}}';
             $outputs['array_mixed'] = '["foo",1,true,{"foo":"foo","moo":"bar","camel_case":"boo"},[1,3,true]]';

--- a/tests/JMS/Serializer/Tests/Serializer/xml/array_nulls.xml
+++ b/tests/JMS/Serializer/Tests/Serializer/xml/array_nulls.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<result xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <entry xsi:nil="true"/>
+  <entry xsi:nil="true"/>
+</result>

--- a/tests/JMS/Serializer/Tests/Serializer/yml/array_nulls.yml
+++ b/tests/JMS/Serializer/Tests/Serializer/yml/array_nulls.yml
@@ -1,0 +1,2 @@
+- null
+- null


### PR DESCRIPTION
`null`s in the arrays should not be ignored when serializeNull is `true`.