### PR TITLE
Replace deprecated getMock with createMock

### DIFF
--- a/tests/JMS/Serializer/Tests/BaseTestCase.php
+++ b/tests/JMS/Serializer/Tests/BaseTestCase.php
@@ -1,0 +1,34 @@
+<?php
+
+/*
+ * Copyright 2013 Johannes M. Schmitt <schmittjoh@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace JMS\Serializer\Tests;
+
+class BaseTestCase extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * {@inheritDoc}
+     */
+    public function createMock($originalClassName)
+    {
+        if (!method_exists(\PHPUnit_Framework_TestCase::class, 'createMock')) {
+            return $this->getMock($originalClassName);
+        }
+
+        return parent::createMock($originalClassName);
+    }
+}

--- a/tests/JMS/Serializer/Tests/Exclusion/DisjunctExclusionStrategyTest.php
+++ b/tests/JMS/Serializer/Tests/Exclusion/DisjunctExclusionStrategyTest.php
@@ -22,8 +22,9 @@ use JMS\Serializer\Exclusion\DisjunctExclusionStrategy;
 use JMS\Serializer\Metadata\ClassMetadata;
 use JMS\Serializer\Metadata\StaticPropertyMetadata;
 use JMS\Serializer\SerializationContext;
+use JMS\Serializer\Tests\BaseTestCase;
 
-class DisjunctExclusionStrategyTest extends \PHPUnit_Framework_TestCase
+class DisjunctExclusionStrategyTest extends BaseTestCase
 {
     public function testShouldSkipClassShortCircuiting()
     {
@@ -31,8 +32,8 @@ class DisjunctExclusionStrategyTest extends \PHPUnit_Framework_TestCase
         $context = SerializationContext::create();
 
         $strat = new DisjunctExclusionStrategy(array(
-            $first = $this->getMock('JMS\Serializer\Exclusion\ExclusionStrategyInterface'),
-            $last = $this->getMock('JMS\Serializer\Exclusion\ExclusionStrategyInterface'),
+            $first = $this->createMock('JMS\Serializer\Exclusion\ExclusionStrategyInterface'),
+            $last = $this->createMock('JMS\Serializer\Exclusion\ExclusionStrategyInterface'),
         ));
 
         $first->expects($this->once())
@@ -52,8 +53,8 @@ class DisjunctExclusionStrategyTest extends \PHPUnit_Framework_TestCase
         $context = SerializationContext::create();
 
         $strat = new DisjunctExclusionStrategy(array(
-            $first = $this->getMock('JMS\Serializer\Exclusion\ExclusionStrategyInterface'),
-            $last = $this->getMock('JMS\Serializer\Exclusion\ExclusionStrategyInterface'),
+            $first = $this->createMock('JMS\Serializer\Exclusion\ExclusionStrategyInterface'),
+            $last = $this->createMock('JMS\Serializer\Exclusion\ExclusionStrategyInterface'),
         ));
 
         $first->expects($this->once())
@@ -75,8 +76,8 @@ class DisjunctExclusionStrategyTest extends \PHPUnit_Framework_TestCase
         $context = SerializationContext::create();
 
         $strat = new DisjunctExclusionStrategy(array(
-            $first = $this->getMock('JMS\Serializer\Exclusion\ExclusionStrategyInterface'),
-            $last = $this->getMock('JMS\Serializer\Exclusion\ExclusionStrategyInterface'),
+            $first = $this->createMock('JMS\Serializer\Exclusion\ExclusionStrategyInterface'),
+            $last = $this->createMock('JMS\Serializer\Exclusion\ExclusionStrategyInterface'),
         ));
 
         $first->expects($this->once())
@@ -98,8 +99,8 @@ class DisjunctExclusionStrategyTest extends \PHPUnit_Framework_TestCase
         $context = SerializationContext::create();
 
         $strat = new DisjunctExclusionStrategy(array(
-            $first = $this->getMock('JMS\Serializer\Exclusion\ExclusionStrategyInterface'),
-            $last = $this->getMock('JMS\Serializer\Exclusion\ExclusionStrategyInterface'),
+            $first = $this->createMock('JMS\Serializer\Exclusion\ExclusionStrategyInterface'),
+            $last = $this->createMock('JMS\Serializer\Exclusion\ExclusionStrategyInterface'),
         ));
 
         $first->expects($this->once())
@@ -119,8 +120,8 @@ class DisjunctExclusionStrategyTest extends \PHPUnit_Framework_TestCase
         $context = SerializationContext::create();
 
         $strat = new DisjunctExclusionStrategy(array(
-            $first = $this->getMock('JMS\Serializer\Exclusion\ExclusionStrategyInterface'),
-            $last = $this->getMock('JMS\Serializer\Exclusion\ExclusionStrategyInterface'),
+            $first = $this->createMock('JMS\Serializer\Exclusion\ExclusionStrategyInterface'),
+            $last = $this->createMock('JMS\Serializer\Exclusion\ExclusionStrategyInterface'),
         ));
 
         $first->expects($this->once())
@@ -142,8 +143,8 @@ class DisjunctExclusionStrategyTest extends \PHPUnit_Framework_TestCase
         $context = SerializationContext::create();
 
         $strat = new DisjunctExclusionStrategy(array(
-            $first = $this->getMock('JMS\Serializer\Exclusion\ExclusionStrategyInterface'),
-            $last = $this->getMock('JMS\Serializer\Exclusion\ExclusionStrategyInterface'),
+            $first = $this->createMock('JMS\Serializer\Exclusion\ExclusionStrategyInterface'),
+            $last = $this->createMock('JMS\Serializer\Exclusion\ExclusionStrategyInterface'),
         ));
 
         $first->expects($this->once())

--- a/tests/JMS/Serializer/Tests/Handler/FormErrorHandlerTest.php
+++ b/tests/JMS/Serializer/Tests/Handler/FormErrorHandlerTest.php
@@ -11,8 +11,9 @@ use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\Form\FormBuilder;
 use Symfony\Component\Form\FormError;
 use Symfony\Component\Translation\Translator;
+use JMS\Serializer\Tests\BaseTestCase;
 
-class FormErrorHandlerTest extends \PHPUnit_Framework_TestCase
+class FormErrorHandlerTest extends BaseTestCase
 {
     /**
      * @var \JMS\Serializer\Handler\FormErrorHandler
@@ -39,7 +40,7 @@ class FormErrorHandlerTest extends \PHPUnit_Framework_TestCase
         $this->handler = new FormErrorHandler(new Translator('en'));
         $this->visitor = new JsonSerializationVisitor(new SerializedNameAnnotationStrategy(new CamelCaseNamingStrategy()));
         $this->dispatcher = new EventDispatcher();
-        $this->factory = $this->getMock('Symfony\Component\Form\FormFactoryInterface');
+        $this->factory = $this->createMock('Symfony\Component\Form\FormFactoryInterface');
     }
 
     protected function tearDown()
@@ -90,8 +91,8 @@ class FormErrorHandlerTest extends \PHPUnit_Framework_TestCase
      */
     protected function getMockForm($name = 'name')
     {
-        $form = $this->getMock('Symfony\Component\Form\Test\FormInterface');
-        $config = $this->getMock('Symfony\Component\Form\FormConfigInterface');
+        $form = $this->createMock('Symfony\Component\Form\Test\FormInterface');
+        $config = $this->createMock('Symfony\Component\Form\FormConfigInterface');
 
         $form->expects($this->any())
             ->method('getName')

--- a/tests/JMS/Serializer/Tests/Handler/PropelCollectionHandlerTest.php
+++ b/tests/JMS/Serializer/Tests/Handler/PropelCollectionHandlerTest.php
@@ -3,8 +3,9 @@
 namespace JMS\Serializer\Tests\Handler;
 
 use JMS\Serializer\SerializerBuilder;
+use JMS\Serializer\Tests\BaseTestCase;
 
-class PropelCollectionHandlerTest extends \PHPUnit_Framework_TestCase
+class PropelCollectionHandlerTest extends BaseTestCase
 {
     /** @var  $serializer \JMS\Serializer\Serializer */
     private $serializer;

--- a/tests/JMS/Serializer/Tests/Metadata/ClassMetadataTest.php
+++ b/tests/JMS/Serializer/Tests/Metadata/ClassMetadataTest.php
@@ -20,8 +20,9 @@ namespace JMS\Serializer\Tests\Metadata;
 
 use JMS\Serializer\Metadata\PropertyMetadata;
 use JMS\Serializer\Metadata\ClassMetadata;
+use JMS\Serializer\Tests\BaseTestCase;
 
-class ClassMetadataTest extends \PHPUnit_Framework_TestCase
+class ClassMetadataTest extends BaseTestCase
 {
     public function getAccessOrderCases()
     {

--- a/tests/JMS/Serializer/Tests/Metadata/Driver/BaseDriverTest.php
+++ b/tests/JMS/Serializer/Tests/Metadata/Driver/BaseDriverTest.php
@@ -23,8 +23,9 @@ use JMS\Serializer\Metadata\ClassMetadata;
 use JMS\Serializer\Metadata\PropertyMetadata;
 use JMS\Serializer\Metadata\VirtualPropertyMetadata;
 use Metadata\Driver\DriverInterface;
+use JMS\Serializer\Tests\BaseTestCase;
 
-abstract class BaseDriverTest extends \PHPUnit_Framework_TestCase
+abstract class BaseDriverTest extends BaseTestCase
 {
     public function testLoadBlogPostMetadata()
     {
@@ -99,7 +100,7 @@ abstract class BaseDriverTest extends \PHPUnit_Framework_TestCase
     public function testXMLListAbsentNode()
     {
         $m = $this->getDriver()->loadMetadataForClass(new \ReflectionClass('JMS\Serializer\Tests\Fixtures\ObjectWithAbsentXmlListNode'));
-        
+
         $this->assertArrayHasKey('absent', $m->propertyMetadata);
         $this->assertArrayHasKey('present', $m->propertyMetadata);
         $this->assertArrayHasKey('skipDefault', $m->propertyMetadata);

--- a/tests/JMS/Serializer/Tests/Metadata/Driver/DoctrineDriverTest.php
+++ b/tests/JMS/Serializer/Tests/Metadata/Driver/DoctrineDriverTest.php
@@ -24,8 +24,9 @@ use Doctrine\Common\Annotations\AnnotationReader;
 use Doctrine\ORM\Configuration;
 use Doctrine\ORM\EntityManager;
 use Doctrine\ORM\Mapping\Driver\AnnotationDriver as DoctrineDriver;
+use JMS\Serializer\Tests\BaseTestCase;
 
-class DoctrineDriverTest extends \PHPUnit_Framework_TestCase
+class DoctrineDriverTest extends BaseTestCase
 {
     public function getMetadata()
     {
@@ -124,7 +125,7 @@ class DoctrineDriverTest extends \PHPUnit_Framework_TestCase
 
     protected function getDoctrineDriver()
     {
-        $registry = $this->getMock('Doctrine\Common\Persistence\ManagerRegistry');
+        $registry = $this->createMock('Doctrine\Common\Persistence\ManagerRegistry');
         $registry->expects($this->atLeastOnce())
              ->method('getManagerForClass')
              ->will($this->returnValue($this->getEntityManager()));

--- a/tests/JMS/Serializer/Tests/Metadata/Driver/DoctrinePHPCRDriverTest.php
+++ b/tests/JMS/Serializer/Tests/Metadata/Driver/DoctrinePHPCRDriverTest.php
@@ -24,8 +24,9 @@ use Doctrine\Common\Annotations\AnnotationReader;
 use Doctrine\ODM\PHPCR\Configuration;
 use Doctrine\ODM\PHPCR\DocumentManager;
 use Doctrine\ODM\PHPCR\Mapping\Driver\AnnotationDriver as DoctrinePHPCRDriver;
+use JMS\Serializer\Tests\BaseTestCase;
 
-class DoctrinePHPCRDriverTest extends \PHPUnit_Framework_TestCase
+class DoctrinePHPCRDriverTest extends BaseTestCase
 {
     public function getMetadata()
     {
@@ -102,7 +103,7 @@ class DoctrinePHPCRDriverTest extends \PHPUnit_Framework_TestCase
             new DoctrinePHPCRDriver(new AnnotationReader(), __DIR__.'/../../Fixtures/DoctrinePHPCR')
         );
 
-        $session = $this->getMock('PHPCR\SessionInterface');
+        $session = $this->createMock('PHPCR\SessionInterface');
 
         return DocumentManager::create($session, $config);
     }
@@ -114,7 +115,7 @@ class DoctrinePHPCRDriverTest extends \PHPUnit_Framework_TestCase
 
     protected function getDoctrinePHPCRDriver()
     {
-        $registry = $this->getMock('Doctrine\Common\Persistence\ManagerRegistry');
+        $registry = $this->createMock('Doctrine\Common\Persistence\ManagerRegistry');
         $registry->expects($this->atLeastOnce())
              ->method('getManagerForClass')
              ->will($this->returnValue($this->getDocumentManager()));

--- a/tests/JMS/Serializer/Tests/Serializer/ArrayTest.php
+++ b/tests/JMS/Serializer/Tests/Serializer/ArrayTest.php
@@ -33,8 +33,9 @@ use JMS\Serializer\JsonSerializationVisitor;
 use JMS\Serializer\JsonDeserializationVisitor;
 use JMS\Serializer\Serializer;
 use JMS\Serializer\Naming\CamelCaseNamingStrategy;
+use JMS\Serializer\Tests\BaseTestCase;
 
-class ArrayTest extends \PHPUnit_Framework_TestCase
+class ArrayTest extends BaseTestCase
 {
     protected $serializer;
 

--- a/tests/JMS/Serializer/Tests/Serializer/BaseSerializationTest.php
+++ b/tests/JMS/Serializer/Tests/Serializer/BaseSerializationTest.php
@@ -101,8 +101,9 @@ use PhpCollection\Map;
 use JMS\Serializer\Exclusion\DepthExclusionStrategy;
 use JMS\Serializer\Tests\Fixtures\Node;
 use JMS\Serializer\Tests\Fixtures\AuthorReadOnlyPerClass;
+use JMS\Serializer\Tests\BaseTestCase;
 
-abstract class BaseSerializationTest extends \PHPUnit_Framework_TestCase
+abstract class BaseSerializationTest extends BaseTestCase
 {
     protected $factory;
     protected $dispatcher;
@@ -609,11 +610,11 @@ abstract class BaseSerializationTest extends \PHPUnit_Framework_TestCase
 
     public function testNestedFormErrors()
     {
-        $dispatcher = $this->getMock('Symfony\Component\EventDispatcher\EventDispatcherInterface');
+        $dispatcher = $this->createMock('Symfony\Component\EventDispatcher\EventDispatcherInterface');
 
         $formConfigBuilder = new \Symfony\Component\Form\FormConfigBuilder('foo', null, $dispatcher);
         $formConfigBuilder->setCompound(true);
-        $formConfigBuilder->setDataMapper($this->getMock('Symfony\Component\Form\DataMapperInterface'));
+        $formConfigBuilder->setDataMapper($this->createMock('Symfony\Component\Form\DataMapperInterface'));
         $fooConfig = $formConfigBuilder->getFormConfig();
 
         $form = new Form($fooConfig);
@@ -634,7 +635,7 @@ abstract class BaseSerializationTest extends \PHPUnit_Framework_TestCase
             $this->markTestSkipped('Not using Symfony Form >= 2.3 with submit type');
         }
 
-        $dispatcher = $this->getMock('Symfony\Component\EventDispatcher\EventDispatcherInterface');
+        $dispatcher = $this->createMock('Symfony\Component\EventDispatcher\EventDispatcherInterface');
 
         $factoryBuilder = new FormFactoryBuilder();
         $factoryBuilder->addType(new \Symfony\Component\Form\Extension\Core\Type\SubmitType);
@@ -644,7 +645,7 @@ abstract class BaseSerializationTest extends \PHPUnit_Framework_TestCase
         $formConfigBuilder = new \Symfony\Component\Form\FormConfigBuilder('foo', null, $dispatcher);
         $formConfigBuilder->setFormFactory($factory);
         $formConfigBuilder->setCompound(true);
-        $formConfigBuilder->setDataMapper($this->getMock('Symfony\Component\Form\DataMapperInterface'));
+        $formConfigBuilder->setDataMapper($this->createMock('Symfony\Component\Form\DataMapperInterface'));
         $fooConfig = $formConfigBuilder->getFormConfig();
 
         $form = new Form($fooConfig);

--- a/tests/JMS/Serializer/Tests/Serializer/ContextTest.php
+++ b/tests/JMS/Serializer/Tests/Serializer/ContextTest.php
@@ -25,8 +25,9 @@ use JMS\Serializer\SerializationContext;
 use JMS\Serializer\Tests\Fixtures\InlineChild;
 use JMS\Serializer\Tests\Fixtures\Node;
 use JMS\Serializer\SerializerBuilder;
+use JMS\Serializer\Tests\BaseTestCase;
 
-class ContextTest extends \PHPUnit_Framework_TestCase
+class ContextTest extends BaseTestCase
 {
     public function testSerializationContextPathAndDepth()
     {
@@ -40,7 +41,7 @@ class ContextTest extends \PHPUnit_Framework_TestCase
 
         $self = $this;
 
-        $exclusionStrategy = $this->getMock('JMS\Serializer\Exclusion\ExclusionStrategyInterface');
+        $exclusionStrategy = $this->createMock('JMS\Serializer\Exclusion\ExclusionStrategyInterface');
         $exclusionStrategy->expects($this->any())
             ->method('shouldSkipClass')
             ->with($this->anything(), $this->callback(function (SerializationContext $context) use ($self, $objects) {
@@ -105,7 +106,7 @@ class ContextTest extends \PHPUnit_Framework_TestCase
         ));
         $self = $this;
 
-        $exclusionStrategy = $this->getMock('JMS\Serializer\Exclusion\ExclusionStrategyInterface');
+        $exclusionStrategy = $this->createMock('JMS\Serializer\Exclusion\ExclusionStrategyInterface');
         $exclusionStrategy->expects($this->any())
             ->method('shouldSkipClass')
             ->will($this->returnCallback(function (ClassMetadata $classMetadata, SerializationContext $context) use ($self, $object, $child) {
@@ -157,7 +158,7 @@ class ContextTest extends \PHPUnit_Framework_TestCase
             array(array())
         );
     }
-    
+
     /**
      * @dataProvider getScalars
      */

--- a/tests/JMS/Serializer/Tests/Serializer/DateIntervalFormatTest.php
+++ b/tests/JMS/Serializer/Tests/Serializer/DateIntervalFormatTest.php
@@ -19,8 +19,9 @@
 namespace JMS\Serializer\Tests\Serializer;
 
 use JMS\Serializer\Handler\DateHandler;
+use JMS\Serializer\Tests\BaseTestCase;
 
-class DateIntervalFormatTest extends \PHPUnit_Framework_TestCase
+class DateIntervalFormatTest extends BaseTestCase
 {
     public function testFormat()
     {

--- a/tests/JMS/Serializer/Tests/Serializer/Doctrine/IntegrationTest.php
+++ b/tests/JMS/Serializer/Tests/Serializer/Doctrine/IntegrationTest.php
@@ -23,8 +23,9 @@ use JMS\Serializer\Tests\Fixtures\Doctrine\SingleTableInheritance\Excursion;
 use JMS\Serializer\Tests\Fixtures\Doctrine\SingleTableInheritance\Person;
 use JMS\Serializer\Tests\Fixtures\Doctrine\SingleTableInheritance\Student;
 use JMS\Serializer\Tests\Fixtures\Doctrine\SingleTableInheritance\Teacher;
+use JMS\Serializer\Tests\BaseTestCase;
 
-class IntegrationTest extends \PHPUnit_Framework_TestCase
+class IntegrationTest extends BaseTestCase
 {
     /** @var ManagerRegistry */
     private $registry;

--- a/tests/JMS/Serializer/Tests/Serializer/EventDispatcher/EventDispatcherTest.php
+++ b/tests/JMS/Serializer/Tests/Serializer/EventDispatcher/EventDispatcherTest.php
@@ -22,8 +22,9 @@ use JMS\Serializer\EventDispatcher\Event;
 use JMS\Serializer\EventDispatcher\EventDispatcher;
 use JMS\Serializer\EventDispatcher\EventSubscriberInterface;
 use JMS\Serializer\EventDispatcher\ObjectEvent;
+use JMS\Serializer\Tests\BaseTestCase;
 
-class EventDispatcherTest extends \PHPUnit_Framework_TestCase
+class EventDispatcherTest extends BaseTestCase
 {
     private $dispatcher;
     private $event;
@@ -93,7 +94,7 @@ class EventDispatcherTest extends \PHPUnit_Framework_TestCase
     protected function setUp()
     {
         $this->dispatcher = new EventDispatcher();
-        $this->event = new ObjectEvent($this->getMock('JMS\Serializer\Context'), new \stdClass(), array('name' => 'foo', 'params' => array()));
+        $this->event = new ObjectEvent($this->createMock('JMS\Serializer\Context'), new \stdClass(), array('name' => 'foo', 'params' => array()));
     }
 
     private function dispatch($eventName, $class = 'Foo', $format = 'json', Event $event = null)

--- a/tests/JMS/Serializer/Tests/Serializer/EventDispatcher/Subscriber/DoctrineProxySubscriberTest.php
+++ b/tests/JMS/Serializer/Tests/Serializer/EventDispatcher/Subscriber/DoctrineProxySubscriberTest.php
@@ -22,8 +22,9 @@ use JMS\Serializer\EventDispatcher\PreSerializeEvent;
 use JMS\Serializer\EventDispatcher\Subscriber\DoctrineProxySubscriber;
 use JMS\Serializer\Tests\Fixtures\SimpleObjectProxy;
 use JMS\Serializer\VisitorInterface;
+use JMS\Serializer\Tests\BaseTestCase;
 
-class DoctrineProxySubscriberTest extends \PHPUnit_Framework_TestCase
+class DoctrineProxySubscriberTest extends BaseTestCase
 {
     /** @var VisitorInterface */
     private $visitor;
@@ -52,7 +53,7 @@ class DoctrineProxySubscriberTest extends \PHPUnit_Framework_TestCase
     protected function setUp()
     {
         $this->subscriber = new DoctrineProxySubscriber();
-        $this->visitor = $this->getMock('JMS\Serializer\Context');
+        $this->visitor = $this->createMock('JMS\Serializer\Context');
     }
 
     private function createEvent($object, array $type)

--- a/tests/JMS/Serializer/Tests/Serializer/EventDispatcher/Subscriber/SymfonyValidatorSubscriberTest.php
+++ b/tests/JMS/Serializer/Tests/Serializer/EventDispatcher/Subscriber/SymfonyValidatorSubscriberTest.php
@@ -27,8 +27,9 @@ use JMS\Serializer\SerializerBuilder;
 use JMS\Serializer\Tests\Fixtures\AuthorList;
 use Symfony\Component\Validator\ConstraintViolation;
 use Symfony\Component\Validator\ConstraintViolationList;
+use JMS\Serializer\Tests\BaseTestCase;
 
-class SymfonyValidatorSubscriberTest extends \PHPUnit_Framework_TestCase
+class SymfonyValidatorSubscriberTest extends BaseTestCase
 {
     private $validator;
 
@@ -103,7 +104,7 @@ class SymfonyValidatorSubscriberTest extends \PHPUnit_Framework_TestCase
 
     protected function setUp()
     {
-        $this->validator = $this->getMock('Symfony\Component\Validator\ValidatorInterface');
+        $this->validator = $this->createMock('Symfony\Component\Validator\ValidatorInterface');
         $this->subscriber = new SymfonyValidatorSubscriber($this->validator);
     }
 }

--- a/tests/JMS/Serializer/Tests/Serializer/GraphNavigatorTest.php
+++ b/tests/JMS/Serializer/Tests/Serializer/GraphNavigatorTest.php
@@ -26,8 +26,9 @@ use JMS\Serializer\Handler\SubscribingHandlerInterface;
 use JMS\Serializer\Metadata\Driver\AnnotationDriver;
 use JMS\Serializer\GraphNavigator;
 use Metadata\MetadataFactory;
+use JMS\Serializer\Tests\BaseTestCase;
 
-class GraphNavigatorTest extends \PHPUnit_Framework_TestCase
+class GraphNavigatorTest extends BaseTestCase
 {
     private $metadataFactory;
     private $handlerRegistry;
@@ -56,7 +57,7 @@ class GraphNavigatorTest extends \PHPUnit_Framework_TestCase
 
         $self = $this;
         $context = $this->context;
-        $exclusionStrategy = $this->getMock('JMS\Serializer\Exclusion\ExclusionStrategyInterface');
+        $exclusionStrategy = $this->createMock('JMS\Serializer\Exclusion\ExclusionStrategyInterface');
         $exclusionStrategy->expects($this->once())
             ->method('shouldSkipClass')
             ->will($this->returnCallback(function($passedMetadata, $passedContext) use ($metadata, $context, $self) {
@@ -80,7 +81,7 @@ class GraphNavigatorTest extends \PHPUnit_Framework_TestCase
 
         $this->context->expects($this->any())
             ->method('getVisitor')
-            ->will($this->returnValue($this->getMock('JMS\Serializer\VisitorInterface')));
+            ->will($this->returnValue($this->createMock('JMS\Serializer\VisitorInterface')));
 
         $this->navigator = new GraphNavigator($this->metadataFactory, $this->handlerRegistry, $this->objectConstructor, $this->dispatcher);
         $this->navigator->accept($object, null, $this->context);
@@ -92,7 +93,7 @@ class GraphNavigatorTest extends \PHPUnit_Framework_TestCase
         $metadata = $this->metadataFactory->getMetadataForClass($class);
 
         $context = $this->context;
-        $exclusionStrategy = $this->getMock('JMS\Serializer\Exclusion\ExclusionStrategyInterface');
+        $exclusionStrategy = $this->createMock('JMS\Serializer\Exclusion\ExclusionStrategyInterface');
         $exclusionStrategy->expects($this->once())
             ->method('shouldSkipClass')
             ->with($metadata, $this->callback(function ($navigatorContext) use ($context) {
@@ -115,7 +116,7 @@ class GraphNavigatorTest extends \PHPUnit_Framework_TestCase
 
         $this->context->expects($this->any())
             ->method('getVisitor')
-            ->will($this->returnValue($this->getMock('JMS\Serializer\VisitorInterface')));
+            ->will($this->returnValue($this->createMock('JMS\Serializer\VisitorInterface')));
 
         $this->navigator = new GraphNavigator($this->metadataFactory, $this->handlerRegistry, $this->objectConstructor, $this->dispatcher);
         $this->navigator->accept('random', array('name' => $class, 'params' => array()), $this->context);
@@ -140,7 +141,7 @@ class GraphNavigatorTest extends \PHPUnit_Framework_TestCase
 
         $this->context->expects($this->any())
             ->method('getVisitor')
-            ->will($this->returnValue($this->getMock('JMS\Serializer\VisitorInterface')));
+            ->will($this->returnValue($this->createMock('JMS\Serializer\VisitorInterface')));
 
         $this->navigator = new GraphNavigator($this->metadataFactory, $this->handlerRegistry, $this->objectConstructor, $this->dispatcher);
         $this->navigator->accept($object, null, $this->context);
@@ -148,7 +149,7 @@ class GraphNavigatorTest extends \PHPUnit_Framework_TestCase
 
     protected function setUp()
     {
-        $this->context = $this->getMock('JMS\Serializer\Context');
+        $this->context = $this->createMock('JMS\Serializer\Context');
         $this->dispatcher = new EventDispatcher();
         $this->handlerRegistry = new HandlerRegistry();
         $this->objectConstructor = new UnserializeObjectConstructor();

--- a/tests/JMS/Serializer/Tests/Serializer/JsonSerializationTest.php
+++ b/tests/JMS/Serializer/Tests/Serializer/JsonSerializationTest.php
@@ -192,7 +192,7 @@ class JsonSerializationTest extends BaseSerializationTest
     {
         $visitor = $this->serializationVisitors->get('json')->get();
         $functionToCall = 'visit' . ucfirst($primitiveType);
-        $result = $visitor->$functionToCall($data, array(), $this->getMock('JMS\Serializer\Context'));
+        $result = $visitor->$functionToCall($data, array(), $this->createMock('JMS\Serializer\Context'));
         if ($primitiveType == 'double') {
             $primitiveType = 'float';
         }

--- a/tests/JMS/Serializer/Tests/Serializer/Naming/IdenticalPropertyNamingStrategyTest.php
+++ b/tests/JMS/Serializer/Tests/Serializer/Naming/IdenticalPropertyNamingStrategyTest.php
@@ -19,8 +19,9 @@
 namespace JMS\Serializer\Tests\Serializer\Naming;
 
 use JMS\Serializer\Naming\IdenticalPropertyNamingStrategy;
+use JMS\Serializer\Tests\BaseTestCase;
 
-class IdenticalPropertyNamingStrategyTest extends \PHPUnit_Framework_TestCase
+class IdenticalPropertyNamingStrategyTest extends BaseTestCase
 {
     public function providePropertyNames()
     {

--- a/tests/JMS/Serializer/Tests/Serializer/TypeParserTest.php
+++ b/tests/JMS/Serializer/Tests/Serializer/TypeParserTest.php
@@ -19,8 +19,9 @@
 namespace JMS\Serializer\Tests\Serializer;
 
 use JMS\Serializer\TypeParser;
+use JMS\Serializer\Tests\BaseTestCase;
 
-class TypeParserTest extends \PHPUnit_Framework_TestCase
+class TypeParserTest extends BaseTestCase
 {
     private $parser;
 

--- a/tests/JMS/Serializer/Tests/SerializerBuilderTest.php
+++ b/tests/JMS/Serializer/Tests/SerializerBuilderTest.php
@@ -23,8 +23,9 @@ use Symfony\Component\Filesystem\Filesystem;
 use JMS\Serializer\Handler\HandlerRegistry;
 use JMS\Serializer\JsonSerializationVisitor;
 use JMS\Serializer\Naming\CamelCaseNamingStrategy;
+use JMS\Serializer\Tests\BaseTestCase;
 
-class SerializerBuilderTest extends \PHPUnit_Framework_TestCase
+class SerializerBuilderTest extends BaseTestCase
 {
     /** @var SerializerBuilder */
     private $builder;

--- a/tests/JMS/Serializer/Tests/Twig/SerializerExtensionTest.php
+++ b/tests/JMS/Serializer/Tests/Twig/SerializerExtensionTest.php
@@ -20,12 +20,13 @@ namespace JMS\Serializer\Tests\Twig;
 
 use JMS\Serializer\SerializerInterface;
 use JMS\Serializer\Twig\SerializerExtension;
+use JMS\Serializer\Tests\BaseTestCase;
 
-class SerializerExtensionTest extends \PHPUnit_Framework_TestCase
+class SerializerExtensionTest extends BaseTestCase
 {
     public function setUp()
     {
-        $this->mockSerializer = $this->getMock('JMS\Serializer\SerializerInterface');
+        $this->mockSerializer = $this->createMock('JMS\Serializer\SerializerInterface');
     }
 
     public function testSerialize()


### PR DESCRIPTION
Also require `phpunit: ^5.4` and remove support php 5.5 becase phpunit 5 requires php 5.6 and php 5.5 not supported by php team: http://php.net/supported-versions.php
