### PR TITLE
Revert "Default `$serializeNull` to false"

### DIFF
--- a/src/JMS/Serializer/Context.php
+++ b/src/JMS/Serializer/Context.php
@@ -52,7 +52,7 @@ abstract class Context
     private $exclusionStrategy;
 
     /** @var boolean */
-    private $serializeNull = false;
+    private $serializeNull;
 
     private $initialized = false;
 


### PR DESCRIPTION
Reverts schmittjoh/serializer#317

This PR created some issues with the FosRestBundle https://github.com/FriendsOfSymfony/FOSRestBundle/pull/1557

I think the best thing to do is to revert it and release a 1.3.1