### PR TITLE
MaxDepth is handled incorrectly with Collections

### DIFF
--- a/src/JMS/Serializer/Handler/ArrayCollectionHandler.php
+++ b/src/JMS/Serializer/Handler/ArrayCollectionHandler.php
@@ -19,8 +19,9 @@
 namespace JMS\Serializer\Handler;
 
 use Doctrine\Common\Collections\ArrayCollection;
-use JMS\Serializer\Context;
+use JMS\Serializer\DeserializationContext;
 use JMS\Serializer\GraphNavigator;
+use JMS\Serializer\SerializationContext;
 use JMS\Serializer\VisitorInterface;
 use Doctrine\Common\Collections\Collection;
 
@@ -59,15 +60,22 @@ class ArrayCollectionHandler implements SubscribingHandlerInterface
         return $methods;
     }
 
-    public function serializeCollection(VisitorInterface $visitor, Collection $collection, array $type, Context $context)
+    public function serializeCollection(VisitorInterface $visitor, Collection $collection, array $type, SerializationContext $context)
     {
+        //  Pop ourselves out of the context not to be counted as a depth level
+        $context->stopVisiting($collection);
+
         // We change the base type, and pass through possible parameters.
         $type['name'] = 'array';
+        $result = $visitor->visitArray($collection->toArray(), $type, $context);
 
-        return $visitor->visitArray($collection->toArray(), $type, $context);
+        //  Push ourselves back in, so we can be popped after leaving the handler
+        $context->startVisiting($collection);
+
+        return $result;
     }
 
-    public function deserializeCollection(VisitorInterface $visitor, $data, array $type, Context $context)
+    public function deserializeCollection(VisitorInterface $visitor, $data, array $type, DeserializationContext $context)
     {
         // See above.
         $type['name'] = 'array';

--- a/src/JMS/Serializer/Handler/PhpCollectionHandler.php
+++ b/src/JMS/Serializer/Handler/PhpCollectionHandler.php
@@ -18,8 +18,9 @@
 
 namespace JMS\Serializer\Handler;
 
-use JMS\Serializer\Context;
+use JMS\Serializer\DeserializationContext;
 use JMS\Serializer\GraphNavigator;
+use JMS\Serializer\SerializationContext;
 use JMS\Serializer\VisitorInterface;
 use PhpCollection\Map;
 use PhpCollection\Sequence;
@@ -56,29 +57,44 @@ class PhpCollectionHandler implements SubscribingHandlerInterface
         return $methods;
     }
 
-    public function serializeMap(VisitorInterface $visitor, Map $map, array $type, Context $context)
+    public function serializeMap(VisitorInterface $visitor, Map $map, array $type, SerializationContext $context)
     {
-        $type['name'] = 'array';
+        //  Pop ourselves out of the context not to be counted as a depth level
+        $context->stopVisiting($map);
 
-        return $visitor->visitArray(iterator_to_array($map), $type, $context);
+        // We change the base type, and pass through possible parameters.
+        $type['name'] = 'array';
+        $result = $visitor->visitArray(iterator_to_array($map), $type, $context);
+
+        //  Push ourselves back in, so we can be popped after leaving the handler
+        $context->startVisiting($map);
+
+        return $result;
     }
 
-    public function deserializeMap(VisitorInterface $visitor, $data, array $type, Context $context)
+    public function deserializeMap(VisitorInterface $visitor, $data, array $type, DeserializationContext $context)
     {
         $type['name'] = 'array';
 
         return new Map($visitor->visitArray($data, $type, $context));
     }
 
-    public function serializeSequence(VisitorInterface $visitor, Sequence $sequence, array $type, Context $context)
+    public function serializeSequence(VisitorInterface $visitor, Sequence $sequence, array $type, SerializationContext $context)
     {
+        //  Pop ourselves out of the context not to be counted as a depth level
+        $context->stopVisiting($sequence);
+
         // We change the base type, and pass through possible parameters.
         $type['name'] = 'array';
+        $result = $visitor->visitArray($sequence->all(), $type, $context);
 
-        return $visitor->visitArray($sequence->all(), $type, $context);
+        //  Push ourselves back in, so we can be popped after leaving the handler
+        $context->startVisiting($sequence);
+
+        return $result;
     }
 
-    public function deserializeSequence(VisitorInterface $visitor, $data, array $type, Context $context)
+    public function deserializeSequence(VisitorInterface $visitor, $data, array $type, DeserializationContext $context)
     {
         // See above.
         $type['name'] = 'array';

--- a/tests/JMS/Serializer/Tests/Handler/CollectionDepthTest.php
+++ b/tests/JMS/Serializer/Tests/Handler/CollectionDepthTest.php
@@ -1,0 +1,71 @@
+<?php
+
+namespace JMS\Serializer\Tests\Handler;
+
+use JMS\Serializer\Annotation as Serializer;
+use JMS\Serializer\Exclusion\DepthExclusionStrategy;
+use JMS\Serializer\SerializationContext;
+use JMS\Serializer\SerializerBuilder;
+
+class CollectionDepthTest extends \PHPUnit_Framework_TestCase
+{
+
+    /** @var \JMS\Serializer\Serializer */
+    private $serializer;
+
+    public function setUp()
+    {
+        $this->serializer = SerializerBuilder::create()->build();
+    }
+
+    /**
+     * @dataProvider getCollections
+     */
+    public function testDepth($collection)
+    {
+        $context = SerializationContext::create()
+            ->addExclusionStrategy(new DepthExclusionStrategy());
+        $result = $this->serializer->serialize(new CollectionWrapper($collection), 'json', $context);
+        $this->assertSame('{"collection":[{"name":"lvl1","next":{"name":"lvl2"}}]}', $result);
+    }
+
+    public static function getCollections()
+    {
+        $data = [new Node('lvl1', new Node('lvl2', new Node('lvl3')))];
+        return [
+            [$data],
+            [new \Doctrine\Common\Collections\ArrayCollection($data)],
+            [new \PropelObjectCollection($data)],
+            [new \PhpCollection\Sequence($data)],
+            [new \PhpCollection\Map($data)],
+        ];
+    }
+}
+
+class CollectionWrapper
+{
+
+    /**
+     * @Serializer\MaxDepth(2)
+     */
+    public $collection;
+
+    public function __construct($collection)
+    {
+        $this->collection = $collection;
+    }
+}
+
+class Node
+{
+
+    public $name;
+
+    public $next;
+
+    public function __construct($name, $next = null)
+    {
+        $this->name = $name;
+        $this->next = $next;
+    }
+}


### PR DESCRIPTION
This is an updated version of PR #423 with included tests. Original description:

This fixes handling collections for the purpose of depth calculations. Since arrays are not counted as a depth level, neither should Collections.
The other side effect of this change is that @MaxDepth on an entity inside a collection will be handled correctly as well (before, each Collection contributed +1 to depth, but did not leave PropertyMetadata, therefore was not subtracted when calculating relative depth).

fixeds https://github.com/schmittjoh/serializer/issues/148 https://github.com/schmittjoh/serializer/issues/500 https://github.com/schmittjoh/serializer/issues/702 https://github.com/schmittjoh/serializer/issues/272 https://github.com/schmittjoh/serializer/issues/411 https://github.com/schmittjoh/serializer/issues/407
