### PR TITLE
Remove deprecated FileCacheReader for doctrine annotations

### DIFF
--- a/src/JMS/Serializer/SerializerBuilder.php
+++ b/src/JMS/Serializer/SerializerBuilder.php
@@ -18,6 +18,8 @@
 
 namespace JMS\Serializer;
 
+use Doctrine\Common\Annotations\CachedReader;
+use Doctrine\Common\Cache\FilesystemCache;
 use JMS\Serializer\Builder\DefaultDriverFactory;
 use JMS\Serializer\Builder\DriverFactoryInterface;
 use JMS\Serializer\Handler\PhpCollectionHandler;
@@ -42,7 +44,6 @@ use JMS\Serializer\Naming\CamelCaseNamingStrategy;
 use JMS\Serializer\Naming\PropertyNamingStrategyInterface;
 use Doctrine\Common\Annotations\Reader;
 use Doctrine\Common\Annotations\AnnotationReader;
-use Doctrine\Common\Annotations\FileCacheReader;
 use Metadata\Cache\FileCache;
 use JMS\Serializer\Naming\SerializedNameAnnotationStrategy;
 use JMS\Serializer\Exception\InvalidArgumentException;
@@ -341,7 +342,8 @@ class SerializerBuilder
 
             if (null !== $this->cacheDir) {
                 $this->createDir($this->cacheDir.'/annotations');
-                $annotationReader = new FileCacheReader($annotationReader, $this->cacheDir.'/annotations', $this->debug);
+                $annotationsCache = new FilesystemCache($this->cacheDir.'/annotations');
+                $annotationReader = new CachedReader($annotationReader, $annotationsCache, $this->debug);
             }
         }
 


### PR DESCRIPTION
FileCacheReader has been deprecated by the doctrine team.