### PR TITLE
Xml namespaces improvements

### DIFF
--- a/src/JMS/Serializer/XmlSerializationVisitor.php
+++ b/src/JMS/Serializer/XmlSerializationVisitor.php
@@ -463,9 +463,8 @@ class XmlSerializationVisitor extends AbstractVisitor
         }
         if (!($prefix = $this->currentNode->lookupPrefix($namespace)) && !($prefix = $this->document->lookupPrefix($namespace))) {
             $prefix = 'ns-'.  substr(sha1($namespace), 0, 8);
-            return $this->document->createElementNS($namespace, $prefix . ':' . $tagName);
         }
-        return $this->document->createElement($prefix . ':' . $tagName);
+        return $this->document->createElementNS($namespace, $prefix . ':' . $tagName);
     }
 
     private function setAttributeOnNode(\DOMElement $node, $name, $value, $namespace = null)

--- a/src/JMS/Serializer/XmlSerializationVisitor.php
+++ b/src/JMS/Serializer/XmlSerializationVisitor.php
@@ -298,6 +298,7 @@ class XmlSerializationVisitor extends AbstractVisitor
                 $defaultNamespace = $this->getClassDefaultNamespace($this->objectMetadataStack->top());
                 $element = $this->createElement($elementName, $defaultNamespace);
             }
+            $this->currentNode->appendChild($element);
             $this->setCurrentNode($element);
         }
 
@@ -312,8 +313,8 @@ class XmlSerializationVisitor extends AbstractVisitor
         if ($addEnclosingElement) {
             $this->revertCurrentNode();
 
-            if ($this->nodeNotEmpty($element) || ((!$metadata->xmlCollection || !$metadata->xmlCollectionSkipWhenEmpty) && $node === null && $v !== null && !$context->isVisiting($v))) {
-                $this->currentNode->appendChild($element);
+            if (!($this->nodeNotEmpty($element) || ((!$metadata->xmlCollection || !$metadata->xmlCollectionSkipWhenEmpty) && $node === null && $v !== null && !$context->isVisiting($v)))) {
+                $this->currentNode->removeChild($element);
             }
         }
 

--- a/tests/JMS/Serializer/Tests/Fixtures/ObjectWithXmlNamespacesAndObjectProperty.php
+++ b/tests/JMS/Serializer/Tests/Fixtures/ObjectWithXmlNamespacesAndObjectProperty.php
@@ -1,0 +1,49 @@
+<?php
+
+/*
+ * Copyright 2013 Johannes M. Schmitt <schmittjoh@gmail.com>
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace JMS\Serializer\Tests\Fixtures;
+
+use JMS\Serializer\Annotation\Type;
+use JMS\Serializer\Annotation\XmlRoot;
+use JMS\Serializer\Annotation\XmlNamespace;
+use JMS\Serializer\Annotation\XmlElement;
+
+/**
+ * @XmlRoot("property:test-object", namespace="http://example.com/namespace-property")
+ * @XmlNamespace(uri="http://example.com/namespace-property", prefix="property")
+ */
+class ObjectWithXmlNamespacesAndObjectProperty
+{
+    /**
+     * @Type("string")
+     * @XmlElement(namespace="http://example.com/namespace-property");
+     */
+    private $title;
+
+    /**
+     * @Type("JMS\Serializer\Tests\Fixtures\ObjectWithXmlNamespacesAndObjectPropertyAuthor")
+     * @XmlElement(namespace="http://example.com/namespace-property")
+     */
+    private $author;
+
+    public function __construct($title, $author)
+    {
+        $this->title = $title;
+        $this->author = $author;
+    }
+}

--- a/tests/JMS/Serializer/Tests/Fixtures/ObjectWithXmlNamespacesAndObjectPropertyAuthor.php
+++ b/tests/JMS/Serializer/Tests/Fixtures/ObjectWithXmlNamespacesAndObjectPropertyAuthor.php
@@ -1,0 +1,53 @@
+<?php
+
+/*
+ * Copyright 2013 Johannes M. Schmitt <schmittjoh@gmail.com>
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace JMS\Serializer\Tests\Fixtures;
+
+use JMS\Serializer\Annotation\Type;
+use JMS\Serializer\Annotation\XmlNamespace;
+use JMS\Serializer\Annotation\XmlElement;
+
+/**
+ * @XmlNamespace(uri="http://example.com/namespace-author")
+ */
+class ObjectWithXmlNamespacesAndObjectPropertyAuthor
+{
+    /**
+     * @Type("string")
+     * @XmlElement(namespace="http://example.com/namespace-modified");
+     */
+    private $author;
+
+    /**
+     * @Type("string")
+     * @XmlElement(namespace="http://example.com/namespace-author");
+     */
+    private $info = "hidden-info";
+
+    /**
+     * @Type("string")
+     * @XmlElement(namespace="http://example.com/namespace-property")
+     */
+    private $name;
+
+    public function __construct($name, $author)
+    {
+        $this->name = $name;
+        $this->author = $author;
+    }
+}

--- a/tests/JMS/Serializer/Tests/Fixtures/ObjectWithXmlNamespacesAndObjectPropertyVirtual.php
+++ b/tests/JMS/Serializer/Tests/Fixtures/ObjectWithXmlNamespacesAndObjectPropertyVirtual.php
@@ -1,0 +1,49 @@
+<?php
+
+/*
+ * Copyright 2013 Johannes M. Schmitt <schmittjoh@gmail.com>
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace JMS\Serializer\Tests\Fixtures;
+
+use JMS\Serializer\Annotation\Type;
+use JMS\Serializer\Annotation\XmlRoot;
+use JMS\Serializer\Annotation\XmlNamespace;
+use JMS\Serializer\Annotation\XmlElement;
+
+/**
+ * @XmlRoot("property:test-object", namespace="http://example.com/namespace-property")
+ * @XmlNamespace(uri="http://example.com/namespace-property", prefix="property")
+ */
+class ObjectWithXmlNamespacesAndObjectPropertyVirtual
+{
+    /**
+     * @Type("string")
+     * @XmlElement(namespace="http://example.com/namespace-property");
+     */
+    private $title;
+
+    /**
+     * @Type("ObjectWithXmlNamespacesAndObjectPropertyAuthorVirtual")
+     * @XmlElement(namespace="http://example.com/namespace-property")
+     */
+    private $author;
+
+    public function __construct($title, $author)
+    {
+        $this->title = $title;
+        $this->author = $author;
+    }
+}

--- a/tests/JMS/Serializer/Tests/Serializer/xml/object_with_xml_namespaces_and_object_property.xml
+++ b/tests/JMS/Serializer/Tests/Serializer/xml/object_with_xml_namespaces_and_object_property.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<property:test-object xmlns:property="http://example.com/namespace-property">
+  <property:title><![CDATA[This is a nice title.]]></property:title>
+  <property:author xmlns="http://example.com/namespace-author">
+    <ns-ac3651ed:author xmlns:ns-ac3651ed="http://example.com/namespace-modified"><![CDATA[smith]]></ns-ac3651ed:author>
+    <info><![CDATA[hidden-info]]></info>
+    <property:name><![CDATA[mr]]></property:name>
+  </property:author>
+</property:test-object>

--- a/tests/JMS/Serializer/Tests/Serializer/xml/object_with_xml_namespaces_and_object_property_virtual.xml
+++ b/tests/JMS/Serializer/Tests/Serializer/xml/object_with_xml_namespaces_and_object_property_virtual.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<property:test-object xmlns:property="http://example.com/namespace-property">
+  <property:title><![CDATA[This is a nice title.]]></property:title>
+  <property:author>
+    <foo xmlns="http://example.com/namespace-author">
+      <ns-ac3651ed:author xmlns:ns-ac3651ed="http://example.com/namespace-modified"><![CDATA[smith]]></ns-ac3651ed:author>
+      <info><![CDATA[hidden-info]]></info>
+      <property:name><![CDATA[mr]]></property:name>
+    </foo>
+  </property:author>
+</property:test-object>


### PR DESCRIPTION
This PR improves the XML namespace prefix lookup by adding the node to the DOM tree as soon as possible.

Before:

``` xml
<a:root xmlns:a="a">
   <b:node xmlns:b="b">
         <a:subnode xmlns:a="a">
   </b:node>
</a:root>
```

after 

``` xml
<a:root xmlns:a="a">
   <b:node xmlns:b="b">
         <a:subnode>
   </b:node>
</a:root>
```

The new behavior produces a cleaner tree since the namespace "a:subnode"   was already defined on the root, and re-defining it on the node is redundant.
