### PR TITLE
Run serialization benchmarks in the build process

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,7 +32,11 @@ before_script:
     - composer self-update
     - composer update $COMPOSER_FLAGS
 
-script: vendor/bin/phpunit $PHPUNIT_FLAGS
+script:
+    - vendor/bin/phpunit $PHPUNIT_FLAGS
+    - php tests/benchmark.php json 10
+    - php tests/benchmark.php yml 10
+    - php tests/benchmark.php xml 10
 
 after_success:
     - if [[ $TRAVIS_PHP_VERSION = '5.6' ]]; then wget https://scrutinizer-ci.com/ocular.phar; fi


### PR DESCRIPTION
To make more visible the performance impact of any change to the code base, we run the benchmark script for each build.