### PR TITLE
Renamed replaceData to setData

### DIFF
--- a/src/JMS/Serializer/GenericSerializationVisitor.php
+++ b/src/JMS/Serializer/GenericSerializationVisitor.php
@@ -161,7 +161,7 @@ abstract class GenericSerializationVisitor extends AbstractVisitor
 
     /**
      * Allows you to add additional data to the current object/root element.
-     *
+     * @deprecated use setData instead
      * @param string $key
      * @param integer|float|boolean|string|array|null $value This value must either be a regular scalar, or an array.
      *                                                       It must not contain any objects anymore.
@@ -193,7 +193,7 @@ abstract class GenericSerializationVisitor extends AbstractVisitor
      * @param integer|float|boolean|string|array|null $value This value must either be a regular scalar, or an array.
      *                                                       It must not contain any objects anymore.
      */
-    public function replaceData($key, $value)
+    public function setData($key, $value)
     {
         $this->data[$key] = $value;
     }

--- a/tests/JMS/Serializer/Tests/Serializer/JsonSerializationTest.php
+++ b/tests/JMS/Serializer/Tests/Serializer/JsonSerializationTest.php
@@ -289,7 +289,7 @@ class ReplaceNameSubscriber implements EventSubscriberInterface
 {
     public function onPostSerialize(Event $event)
     {
-        $event->getVisitor()->replaceData('full_name', 'new name');
+        $event->getVisitor()->setData('full_name', 'new name');
     }
 
     public static function getSubscribedEvents()


### PR DESCRIPTION
Renamed `replaceData` to `setData` and deprecated the old `addData`

Reference conversation https://github.com/schmittjoh/serializer/commit/447c7d38cd3ac6542c6eaec2818c608f4d9f6e89#commitcomment-18973157
