### PR TITLE
Handle both int and integer

### DIFF
--- a/src/JMS/Serializer/GraphNavigator.php
+++ b/src/JMS/Serializer/GraphNavigator.php
@@ -115,6 +115,7 @@ final class GraphNavigator
             case 'string':
                 return $visitor->visitString($data, $type, $context);
 
+            case 'int':
             case 'integer':
                 return $visitor->visitInteger($data, $type, $context);
 


### PR DESCRIPTION
Ofter required to write `int` not `integer`, because of PHP (habbit). Now serializer thinks that `int` is a kind of an object and warn about it:
> Expected object but got integer. Do you have the wrong @ Type mapping or could this be a Doctrine many-to-many relation?