### PR TITLE
Document the implied 'Default' property group when no group is specified

### DIFF
--- a/doc/cookbook/exclusion_strategies.rst
+++ b/doc/cookbook/exclusion_strategies.rst
@@ -86,7 +86,9 @@ Another default exclusion strategy is to create different views of your objects.
 Let's say you would like to serialize your object in a different view depending
 whether it is displayed in a list view or in a details view.
 
-You can achieve that by using the ``@Groups`` annotation on your properties.
+You can achieve that by using the ``@Groups`` annotation on your properties. Any
+property without an explicit ``@Groups`` annotation will be included in a
+``Default`` group, which can be used when specifying groups in the serializer.
 
 .. code-block :: php
 

--- a/doc/cookbook/exclusion_strategies.rst
+++ b/doc/cookbook/exclusion_strategies.rst
@@ -88,7 +88,8 @@ whether it is displayed in a list view or in a details view.
 
 You can achieve that by using the ``@Groups`` annotation on your properties. Any
 property without an explicit ``@Groups`` annotation will be included in a
-``Default`` group, which can be used when specifying groups in the serializer.
+``Default`` group, which can be used when specifying groups in the serialization
+context.
 
 .. code-block :: php
 


### PR DESCRIPTION
Pretty sure the example code should be referencing `details` and not `Default`.