### PR TITLE
Restrict doctrine annotations version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
         "jms/parser-lib": "1.*",
         "phpoption/phpoption": "^1.1",
         "phpcollection/phpcollection": "~0.1",
-        "doctrine/annotations": "^1.0",
+        "doctrine/annotations": "^1.2",
         "doctrine/instantiator": "^1.0.3"
     },
     "conflict": {


### PR DESCRIPTION
To keep php 5.5 compatibility. [Doctrine 1.3](https://github.com/doctrine/annotations/releases/tag/v1.3.0) requires php 5.6 at least.