### PR TITLE
Added clearing previous libxml errors

### DIFF
--- a/src/JMS/Serializer/Metadata/Driver/XmlDriver.php
+++ b/src/JMS/Serializer/Metadata/Driver/XmlDriver.php
@@ -33,6 +33,8 @@ class XmlDriver extends AbstractFileDriver
     protected function loadMetadataFromFile(\ReflectionClass $class, $path)
     {
         $previous = libxml_use_internal_errors(true);
+        libxml_clear_errors();
+
         $elem = simplexml_load_file($path);
         libxml_use_internal_errors($previous);
 

--- a/src/JMS/Serializer/XmlDeserializationVisitor.php
+++ b/src/JMS/Serializer/XmlDeserializationVisitor.php
@@ -59,6 +59,8 @@ class XmlDeserializationVisitor extends AbstractVisitor
     public function prepare($data)
     {
         $previous = libxml_use_internal_errors(true);
+        libxml_clear_errors();
+
         $previousEntityLoaderState = libxml_disable_entity_loader($this->disableExternalEntities);
 
         if (false !== stripos($data, '<!doctype')) {

--- a/tests/JMS/Serializer/Tests/Serializer/XmlSerializationTest.php
+++ b/tests/JMS/Serializer/Tests/Serializer/XmlSerializationTest.php
@@ -361,6 +361,14 @@ class XmlSerializationTest extends BaseSerializationTest
         $this->assertXmlStringEqualsXmlString($this->getContent('simple_class_object_minified'), $stringXml);
     }
 
+    /**
+     * @expectedException \JMS\Serializer\Exception\XmlErrorException
+     */
+    public function testDeserializeEmptyString()
+    {
+        $this->deserialize('', 'stdClass');
+    }
+
     private function xpathFirstToString(\SimpleXMLElement $xml, $xpath)
     {
         $nodes = $xml->xpath($xpath);


### PR DESCRIPTION
For the empty document string `libxml_*` error functions return the *previous* error, not the *error caused by last xml operation*.

The simple reproduction script:

https://3v4l.org/RKEb0

```php
$previous = libxml_use_internal_errors(true);
$doc = simplexml_load_string('foo');
libxml_use_internal_errors($previous);

$result = libxml_get_last_error();

$previous = libxml_use_internal_errors(true);
$doc = simplexml_load_string('');
libxml_use_internal_errors($previous);

$result = libxml_get_last_error();

var_dump($doc, $result);
```

What it means is that if there is any "previous error" it would mask the problem with `libxml_get_last_error` returning not what the JMSSerializer expects.

In this PR I'm sending the test (so the travis run here fails deliberately) that should have passed and that demonstrates initial problem (masked with the lack of `libxml_clear_errors()` call).

I additionally sent a php bug report https://bugs.php.net/bug.php?id=73670, to either fix the php documentation or `libxml`-related implementation.

In either case, JMSSerializer should handle it properly.