### PR TITLE
added support for xml-attributes as discriminators

### DIFF
--- a/doc/reference/annotations.rst
+++ b/doc/reference/annotations.rst
@@ -424,6 +424,18 @@ Resulting XML:
 ~~~~~~~~~~~~~~~~~
 This annotation allows to modify the behaviour of @Discriminator regarding handling of XML.
 
+
+Available Options:
+
++-------------------------------------+--------------------------------------------------+
+| Type                                | Description                                      |
++=====================================+==================================================+
+| attribute                           | use an attribute instead of a child node         |
++-------------------------------------+--------------------------------------------------+
+| cdata                               | render child node content with or without cdata  |
++-------------------------------------+--------------------------------------------------+
+
+Example for "attribute":
 .. code-block :: php
 
     <?php
@@ -443,6 +455,31 @@ Resulting XML:
 .. code-block :: xml
 
     <vehicle type="car" />
+
+
+Example for "cdata":
+
+.. code-block :: php
+    <?php
+
+    use JMS\Serializer\Annotation\Discriminator;
+    use JMS\Serializer\Annotation\XmlDiscriminator;
+
+
+
+    /**
+     * @Discriminator(field = "type", map = {"car": "Car", "moped": "Moped"}, groups={"foo", "bar"})
+     * @XmlDiscriminator(attribute=true)
+     */
+    abstract class Vehicle { }
+    class Car extends Vehicle { }
+
+Resulting XML:
+
+.. code-block :: xml
+
+    <vehicle><type>car</type></vehicle>
+
 
 @XmlValue
 ~~~~~~~~~

--- a/doc/reference/annotations.rst
+++ b/doc/reference/annotations.rst
@@ -420,20 +420,20 @@ Resulting XML:
     </result>
 
 
-@XmlDiscriminatorAttribute
-~~~~~~~~~~~~~
-This, used in conjunction with @Discriminator, allows you to use an attribute of the root node as discriminator
+@XmlDiscriminator
+~~~~~~~~~~~~~~~~~
+This annotation allows to modify the behaviour of @Discriminator regarding handling of XML.
 
 .. code-block :: php
 
     <?php
 
     use JMS\Serializer\Annotation\Discriminator;
-    use JMS\Serializer\Annotation\XmlDiscriminatorAttribute;
+    use JMS\Serializer\Annotation\XmlDiscriminator;
 
     /**
      * @Discriminator(field = "type", map = {"car": "Car", "moped": "Moped"}, groups={"foo", "bar"})
-     * @XmlDiscriminatorAttribute
+     * @XmlDiscriminator(attribute=true)
      */
     abstract class Vehicle { }
     class Car extends Vehicle { }
@@ -442,9 +442,7 @@ Resulting XML:
 
 .. code-block :: xml
 
-    <vehicle type="car">
-    </result>
-
+    <vehicle type="car" />
 
 @XmlValue
 ~~~~~~~~~

--- a/doc/reference/annotations.rst
+++ b/doc/reference/annotations.rst
@@ -419,6 +419,33 @@ Resulting XML:
         <name><![CDATA[Johannes]]></name>
     </result>
 
+
+@XmlDiscriminatorAttribute
+~~~~~~~~~~~~~
+This, used in conjunction with @Discriminator, allows you to use an attribute of the root node as discriminator
+
+.. code-block :: php
+
+    <?php
+
+    use JMS\Serializer\Annotation\Discriminator;
+    use JMS\Serializer\Annotation\XmlDiscriminatorAttribute;
+
+    /**
+     * @Discriminator(field = "type", map = {"car": "Car", "moped": "Moped"}, groups={"foo", "bar"})
+     * @XmlDiscriminatorAttribute
+     */
+    abstract class Vehicle { }
+    class Car extends Vehicle { }
+
+Resulting XML:
+
+.. code-block :: xml
+
+    <vehicle type="car">
+    </result>
+
+
 @XmlValue
 ~~~~~~~~~
 This allows you to mark properties which should be set as the value of the

--- a/doc/reference/xml_reference.rst
+++ b/doc/reference/xml_reference.rst
@@ -5,11 +5,11 @@ XML Reference
     <!-- MyBundle\Resources\config\serializer\Fully.Qualified.ClassName.xml -->
     <?xml version="1.0" encoding="UTF-8" ?>
     <serializer>
-        <class name="Fully\Qualified\ClassName" exclusion-policy="ALL" xml-root-name="foo-bar"
-            xml-discriminator-attribute="false" exclude="true"
+        <class name="Fully\Qualified\ClassName" exclusion-policy="ALL" xml-root-name="foo-bar" exclude="true"
             accessor-order="custom" custom-accessor-order="propertyName1,propertyName2,...,propertyNameN"
             access-type="public_method" discriminator-field-name="type"  read-only="false">
             <xml-namespace prefix="atom" uri="http://www.w3.org/2005/Atom"/>
+            <xml-discriminator attribute="true"/>
             <discriminator-class value="some-value">ClassName</discriminator-class>
             <discriminator-groups>
                 <group>foo</group>

--- a/doc/reference/xml_reference.rst
+++ b/doc/reference/xml_reference.rst
@@ -5,7 +5,8 @@ XML Reference
     <!-- MyBundle\Resources\config\serializer\Fully.Qualified.ClassName.xml -->
     <?xml version="1.0" encoding="UTF-8" ?>
     <serializer>
-        <class name="Fully\Qualified\ClassName" exclusion-policy="ALL" xml-root-name="foo-bar" exclude="true"
+        <class name="Fully\Qualified\ClassName" exclusion-policy="ALL" xml-root-name="foo-bar"
+            xml-discriminator-attribute="false" exclude="true"
             accessor-order="custom" custom-accessor-order="propertyName1,propertyName2,...,propertyNameN"
             access-type="public_method" discriminator-field-name="type"  read-only="false">
             <xml-namespace prefix="atom" uri="http://www.w3.org/2005/Atom"/>

--- a/doc/reference/xml_reference.rst
+++ b/doc/reference/xml_reference.rst
@@ -9,7 +9,7 @@ XML Reference
             accessor-order="custom" custom-accessor-order="propertyName1,propertyName2,...,propertyNameN"
             access-type="public_method" discriminator-field-name="type"  read-only="false">
             <xml-namespace prefix="atom" uri="http://www.w3.org/2005/Atom"/>
-            <xml-discriminator attribute="true"/>
+            <xml-discriminator attribute="true" cdata="false"/>
             <discriminator-class value="some-value">ClassName</discriminator-class>
             <discriminator-groups>
                 <group>foo</group>

--- a/doc/reference/yml_reference.rst
+++ b/doc/reference/yml_reference.rst
@@ -7,7 +7,8 @@ YAML Reference
         exclusion_policy: ALL
         xml_root_name: foobar
         xml_root_namespace: http://your.default.namespace
-        xml_discriminator_attribute: http://your.default.namespace
+        xml_discriminator:
+            attribute: true
         exclude: true
         read_only: false
         access_type: public_method # defaults to property

--- a/doc/reference/yml_reference.rst
+++ b/doc/reference/yml_reference.rst
@@ -7,6 +7,7 @@ YAML Reference
         exclusion_policy: ALL
         xml_root_name: foobar
         xml_root_namespace: http://your.default.namespace
+        xml_discriminator_attribute: http://your.default.namespace
         exclude: true
         read_only: false
         access_type: public_method # defaults to property

--- a/doc/reference/yml_reference.rst
+++ b/doc/reference/yml_reference.rst
@@ -9,6 +9,7 @@ YAML Reference
         xml_root_namespace: http://your.default.namespace
         xml_discriminator:
             attribute: true
+            cdata: false
         exclude: true
         read_only: false
         access_type: public_method # defaults to property

--- a/doc/reference/yml_reference.rst
+++ b/doc/reference/yml_reference.rst
@@ -7,9 +7,6 @@ YAML Reference
         exclusion_policy: ALL
         xml_root_name: foobar
         xml_root_namespace: http://your.default.namespace
-        xml_discriminator:
-            attribute: true
-            cdata: false
         exclude: true
         read_only: false
         access_type: public_method # defaults to property
@@ -20,6 +17,9 @@ YAML Reference
             map:
                 some-value: ClassName
             groups: [foo, bar]
+            xml_attribute: true
+            xml_element:
+                cdata: false
         virtual_properties:
             getSomeProperty:
                 serialized_name: foo

--- a/src/JMS/Serializer/Annotation/XmlDiscriminator.php
+++ b/src/JMS/Serializer/Annotation/XmlDiscriminator.php
@@ -29,4 +29,9 @@ class XmlDiscriminator
      * @var boolean
      */
     public $attribute = false;
+
+    /**
+     * @var boolean
+     */
+    public $cdata = true;
 }

--- a/src/JMS/Serializer/Annotation/XmlDiscriminator.php
+++ b/src/JMS/Serializer/Annotation/XmlDiscriminator.php
@@ -23,10 +23,10 @@ namespace JMS\Serializer\Annotation;
  * @Annotation
  * @Target("CLASS")
  */
-class XmlDiscriminatorAttribute
+class XmlDiscriminator
 {
     /**
      * @var boolean
      */
-    public $attribute = true;
+    public $attribute = false;
 }

--- a/src/JMS/Serializer/Annotation/XmlDiscriminatorAttribute.php
+++ b/src/JMS/Serializer/Annotation/XmlDiscriminatorAttribute.php
@@ -1,0 +1,32 @@
+<?php
+
+/*
+ * Copyright 2016 Björn Bösel <bjoern.boesel@twt.de>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace JMS\Serializer\Annotation;
+
+
+/**
+ * @Annotation
+ * @Target("CLASS")
+ */
+class XmlDiscriminatorAttribute
+{
+    /**
+     * @var boolean
+     */
+    public $attribute = true;
+}

--- a/src/JMS/Serializer/GraphNavigator.php
+++ b/src/JMS/Serializer/GraphNavigator.php
@@ -261,6 +261,11 @@ final class GraphNavigator
                 $typeValue = (string) $data->{$metadata->discriminatorFieldName};
                 break;
 
+            // Check XML attribute for discriminatorFieldName
+            case is_object($data) && $metadata->xmlDiscriminatorAttribute && isset($data[$metadata->discriminatorFieldName]):
+                $typeValue = (string) $data[$metadata->discriminatorFieldName];
+                break;
+
             default:
                 throw new \LogicException(sprintf(
                     'The discriminator field name "%s" for base-class "%s" was not found in input data.',

--- a/src/JMS/Serializer/GraphNavigator.php
+++ b/src/JMS/Serializer/GraphNavigator.php
@@ -257,13 +257,13 @@ final class GraphNavigator
                 $typeValue = (string) $data[$metadata->discriminatorFieldName];
                 break;
 
-            case is_object($data) && isset($data->{$metadata->discriminatorFieldName}):
-                $typeValue = (string) $data->{$metadata->discriminatorFieldName};
-                break;
-
             // Check XML attribute for discriminatorFieldName
             case is_object($data) && $metadata->xmlDiscriminatorAttribute && isset($data[$metadata->discriminatorFieldName]):
                 $typeValue = (string) $data[$metadata->discriminatorFieldName];
+                break;
+
+            case is_object($data) && isset($data->{$metadata->discriminatorFieldName}):
+                $typeValue = (string) $data->{$metadata->discriminatorFieldName};
                 break;
 
             default:

--- a/src/JMS/Serializer/Metadata/ClassMetadata.php
+++ b/src/JMS/Serializer/Metadata/ClassMetadata.php
@@ -58,6 +58,8 @@ class ClassMetadata extends MergeableClassMetadata
     public $discriminatorMap = array();
     public $discriminatorGroups = array();
 
+    public $xmlDiscriminatorAttribute = false;
+
     public function setDiscriminator($fieldName, array $map, array $groups = array())
     {
         if (empty($fieldName)) {
@@ -72,6 +74,10 @@ class ClassMetadata extends MergeableClassMetadata
         $this->discriminatorFieldName = $fieldName;
         $this->discriminatorMap = $map;
         $this->discriminatorGroups = $groups;
+    }
+
+    public function setXmlDiscriminator($attribute = false) {
+        $this->xmlDiscriminatorAttribute = $attribute;
     }
 
     /**
@@ -203,6 +209,7 @@ class ClassMetadata extends MergeableClassMetadata
                 $this->discriminatorGroups
             );
             $discriminatorProperty->serializedName = $this->discriminatorFieldName;
+            $discriminatorProperty->xmlAttribute = $this->xmlDiscriminatorAttribute;
             $this->propertyMetadata[$this->discriminatorFieldName] = $discriminatorProperty;
         }
 

--- a/src/JMS/Serializer/Metadata/ClassMetadata.php
+++ b/src/JMS/Serializer/Metadata/ClassMetadata.php
@@ -59,6 +59,7 @@ class ClassMetadata extends MergeableClassMetadata
     public $discriminatorGroups = array();
 
     public $xmlDiscriminatorAttribute = false;
+    public $xmlDiscriminatorCData = true;
 
     public function setDiscriminator($fieldName, array $map, array $groups = array())
     {
@@ -253,6 +254,7 @@ class ClassMetadata extends MergeableClassMetadata
             parent::serialize(),
             'discriminatorGroups' => $this->discriminatorGroups,
             'xmlDiscriminatorAttribute' => $this->xmlDiscriminatorAttribute,
+            'xmlDiscriminatorCData' => $this->xmlDiscriminatorCData,
         ));
     }
 
@@ -285,6 +287,10 @@ class ClassMetadata extends MergeableClassMetadata
 
         if (isset($deserializedData['xmlDiscriminatorAttribute'])) {
             $this->xmlDiscriminatorAttribute = $deserializedData['xmlDiscriminatorAttribute'];
+        }
+
+        if (isset($deserializedData['xmlDiscriminatorCData'])) {
+            $this->xmlDiscriminatorCData = $deserializedData['xmlDiscriminatorCData'];
         }
 
         parent::unserialize($parentStr);

--- a/src/JMS/Serializer/Metadata/ClassMetadata.php
+++ b/src/JMS/Serializer/Metadata/ClassMetadata.php
@@ -76,10 +76,6 @@ class ClassMetadata extends MergeableClassMetadata
         $this->discriminatorGroups = $groups;
     }
 
-    public function setXmlDiscriminator($attribute = false) {
-        $this->xmlDiscriminatorAttribute = $attribute;
-    }
-
     /**
      * Sets the order of properties in the class.
      *
@@ -256,6 +252,7 @@ class ClassMetadata extends MergeableClassMetadata
             $this->discriminatorGroups,
             parent::serialize(),
             'discriminatorGroups' => $this->discriminatorGroups,
+            'xmlDiscriminatorAttribute' => $this->xmlDiscriminatorAttribute,
         ));
     }
 
@@ -284,6 +281,10 @@ class ClassMetadata extends MergeableClassMetadata
 
         if (isset($deserializedData['discriminatorGroups'])) {
             $this->discriminatorGroups = $deserializedData['discriminatorGroups'];
+        }
+
+        if (isset($deserializedData['xmlDiscriminatorAttribute'])) {
+            $this->xmlDiscriminatorAttribute = $deserializedData['xmlDiscriminatorAttribute'];
         }
 
         parent::unserialize($parentStr);

--- a/src/JMS/Serializer/Metadata/Driver/AnnotationDriver.php
+++ b/src/JMS/Serializer/Metadata/Driver/AnnotationDriver.php
@@ -102,6 +102,7 @@ class AnnotationDriver implements DriverInterface
                 }
             } elseif ($annot instanceof XmlDiscriminator) {
                 $classMetadata->xmlDiscriminatorAttribute = $annot->attribute;
+                $classMetadata->xmlDiscriminatorCData = $annot->cdata;
             }
         }
 

--- a/src/JMS/Serializer/Metadata/Driver/AnnotationDriver.php
+++ b/src/JMS/Serializer/Metadata/Driver/AnnotationDriver.php
@@ -19,6 +19,7 @@
 namespace JMS\Serializer\Metadata\Driver;
 
 use JMS\Serializer\Annotation\Discriminator;
+use JMS\Serializer\Annotation\XmlDiscriminatorAttribute;
 use JMS\Serializer\GraphNavigator;
 use JMS\Serializer\Annotation\HandlerCallback;
 use JMS\Serializer\Annotation\AccessorOrder;
@@ -99,6 +100,8 @@ class AnnotationDriver implements DriverInterface
                 } else {
                     $classMetadata->setDiscriminator($annot->field, $annot->map, $annot->groups);
                 }
+            } elseif ($annot instanceof XmlDiscriminatorAttribute) {
+                $classMetadata->setXmlDiscriminator($annot->attribute);
             }
         }
 

--- a/src/JMS/Serializer/Metadata/Driver/AnnotationDriver.php
+++ b/src/JMS/Serializer/Metadata/Driver/AnnotationDriver.php
@@ -19,7 +19,7 @@
 namespace JMS\Serializer\Metadata\Driver;
 
 use JMS\Serializer\Annotation\Discriminator;
-use JMS\Serializer\Annotation\XmlDiscriminatorAttribute;
+use JMS\Serializer\Annotation\XmlDiscriminator;
 use JMS\Serializer\GraphNavigator;
 use JMS\Serializer\Annotation\HandlerCallback;
 use JMS\Serializer\Annotation\AccessorOrder;
@@ -100,8 +100,8 @@ class AnnotationDriver implements DriverInterface
                 } else {
                     $classMetadata->setDiscriminator($annot->field, $annot->map, $annot->groups);
                 }
-            } elseif ($annot instanceof XmlDiscriminatorAttribute) {
-                $classMetadata->setXmlDiscriminator($annot->attribute);
+            } elseif ($annot instanceof XmlDiscriminator) {
+                $classMetadata->xmlDiscriminatorAttribute = $annot->attribute;
             }
         }
 

--- a/src/JMS/Serializer/Metadata/Driver/AnnotationDriver.php
+++ b/src/JMS/Serializer/Metadata/Driver/AnnotationDriver.php
@@ -101,8 +101,8 @@ class AnnotationDriver implements DriverInterface
                     $classMetadata->setDiscriminator($annot->field, $annot->map, $annot->groups);
                 }
             } elseif ($annot instanceof XmlDiscriminator) {
-                $classMetadata->xmlDiscriminatorAttribute = $annot->attribute;
-                $classMetadata->xmlDiscriminatorCData = $annot->cdata;
+                $classMetadata->xmlDiscriminatorAttribute = (bool) $annot->attribute;
+                $classMetadata->xmlDiscriminatorCData = (bool) $annot->cdata;
             }
         }
 

--- a/src/JMS/Serializer/Metadata/Driver/XmlDriver.php
+++ b/src/JMS/Serializer/Metadata/Driver/XmlDriver.php
@@ -108,6 +108,9 @@ class XmlDriver extends AbstractFileDriver
             if (isset($xmlDiscriminator->attributes()->attribute)) {
                 $metadata->xmlDiscriminatorAttribute = (string) $xmlDiscriminator->attributes()->attribute === 'true';
             }
+            if (isset($xmlDiscriminator->attributes()->cdata)) {
+                $metadata->xmlDiscriminatorCData = (string) $xmlDiscriminator->attributes()->cdata === 'true';
+            }
         }
 
         foreach ($elem->xpath('./virtual-property') as $method) {

--- a/src/JMS/Serializer/Metadata/Driver/XmlDriver.php
+++ b/src/JMS/Serializer/Metadata/Driver/XmlDriver.php
@@ -67,10 +67,6 @@ class XmlDriver extends AbstractFileDriver
             $metadata->xmlRootNamespace = (string) $xmlRootNamespace;
         }
 
-        if (null !== $xmlDiscriminatorAttribute = $elem->attributes()->{'xml-discriminator-attribute'}) {
-            $metadata->setXmlDiscriminator('true' == (string) $xmlDiscriminatorAttribute);
-        }
-
         $readOnlyClass = 'true' === strtolower($elem->attributes()->{'read-only'});
 
         $discriminatorFieldName = (string) $elem->attributes()->{'discriminator-field-name'};
@@ -106,6 +102,12 @@ class XmlDriver extends AbstractFileDriver
             }
 
             $metadata->registerNamespace((string) $xmlNamespace->attributes()->uri, $prefix);
+        }
+
+        foreach ($elem->xpath('./xml-discriminator') as $xmlDiscriminator) {
+            if (isset($xmlDiscriminator->attributes()->attribute)) {
+                $metadata->xmlDiscriminatorAttribute = (string) $xmlDiscriminator->attributes()->attribute === 'true';
+            }
         }
 
         foreach ($elem->xpath('./virtual-property') as $method) {

--- a/src/JMS/Serializer/Metadata/Driver/XmlDriver.php
+++ b/src/JMS/Serializer/Metadata/Driver/XmlDriver.php
@@ -67,6 +67,10 @@ class XmlDriver extends AbstractFileDriver
             $metadata->xmlRootNamespace = (string) $xmlRootNamespace;
         }
 
+        if (null !== $xmlDiscriminatorAttribute = $elem->attributes()->{'xml-discriminator-attribute'}) {
+            $metadata->setXmlDiscriminator('true' == (string) $xmlDiscriminatorAttribute);
+        }
+
         $readOnlyClass = 'true' === strtolower($elem->attributes()->{'read-only'});
 
         $discriminatorFieldName = (string) $elem->attributes()->{'discriminator-field-name'};

--- a/src/JMS/Serializer/Metadata/Driver/YamlDriver.php
+++ b/src/JMS/Serializer/Metadata/Driver/YamlDriver.php
@@ -259,10 +259,10 @@ class YamlDriver extends AbstractFileDriver
 
         if (isset($config['xml_discriminator'])) {
             if (isset($config['xml_discriminator']['attribute'])) {
-                $metadata->xmlDiscriminatorAttribute = $config['xml_discriminator']['attribute'];
+                $metadata->xmlDiscriminatorAttribute = (bool) $config['xml_discriminator']['attribute'];
             }
             if (isset($config['xml_discriminator']['cdata'])) {
-                $metadata->xmlDiscriminatorCData = $config['xml_discriminator']['cdata'];
+                $metadata->xmlDiscriminatorCData = (bool) $config['xml_discriminator']['cdata'];
             }
         }
 

--- a/src/JMS/Serializer/Metadata/Driver/YamlDriver.php
+++ b/src/JMS/Serializer/Metadata/Driver/YamlDriver.php
@@ -257,10 +257,11 @@ class YamlDriver extends AbstractFileDriver
             $metadata->xmlRootNamespace = (string) $config['xml_root_namespace'];
         }
 
-        if (isset($config['xml_discriminator_attribute'])) {
-            $metadata->setXmlDiscriminator($config['xml_discriminator_attribute']);
+        if (isset($config['xml_discriminator'])) {
+            if (isset($config['xml_discriminator']['attribute'])) {
+                $metadata->xmlDiscriminatorAttribute = $config['xml_discriminator']['attribute'];
+            }
         }
-
 
         if (array_key_exists('xml_namespaces', $config)) {
 

--- a/src/JMS/Serializer/Metadata/Driver/YamlDriver.php
+++ b/src/JMS/Serializer/Metadata/Driver/YamlDriver.php
@@ -257,15 +257,6 @@ class YamlDriver extends AbstractFileDriver
             $metadata->xmlRootNamespace = (string) $config['xml_root_namespace'];
         }
 
-        if (isset($config['xml_discriminator'])) {
-            if (isset($config['xml_discriminator']['attribute'])) {
-                $metadata->xmlDiscriminatorAttribute = (bool) $config['xml_discriminator']['attribute'];
-            }
-            if (isset($config['xml_discriminator']['cdata'])) {
-                $metadata->xmlDiscriminatorCData = (bool) $config['xml_discriminator']['cdata'];
-            }
-        }
-
         if (array_key_exists('xml_namespaces', $config)) {
 
             foreach ($config['xml_namespaces'] as $prefix => $uri) {
@@ -287,6 +278,17 @@ class YamlDriver extends AbstractFileDriver
                 }
                 $groups = isset($config['discriminator']['groups']) ? $config['discriminator']['groups'] : array();
                 $metadata->setDiscriminator($config['discriminator']['field_name'], $config['discriminator']['map'], $groups);
+
+
+                if (isset($config['discriminator']['xml_attribute'])) {
+                    $metadata->xmlDiscriminatorAttribute = (bool) $config['discriminator']['xml_attribute'];
+                }
+                if (isset($config['discriminator']['xml_element'])) {
+                    if (isset($config['discriminator']['xml_element']['cdata'])) {
+                        $metadata->xmlDiscriminatorCData = (bool) $config['discriminator']['xml_element']['cdata'];
+                    }
+                }
+
             }
         }
     }

--- a/src/JMS/Serializer/Metadata/Driver/YamlDriver.php
+++ b/src/JMS/Serializer/Metadata/Driver/YamlDriver.php
@@ -279,7 +279,6 @@ class YamlDriver extends AbstractFileDriver
                 $groups = isset($config['discriminator']['groups']) ? $config['discriminator']['groups'] : array();
                 $metadata->setDiscriminator($config['discriminator']['field_name'], $config['discriminator']['map'], $groups);
 
-
                 if (isset($config['discriminator']['xml_attribute'])) {
                     $metadata->xmlDiscriminatorAttribute = (bool) $config['discriminator']['xml_attribute'];
                 }

--- a/src/JMS/Serializer/Metadata/Driver/YamlDriver.php
+++ b/src/JMS/Serializer/Metadata/Driver/YamlDriver.php
@@ -257,6 +257,11 @@ class YamlDriver extends AbstractFileDriver
             $metadata->xmlRootNamespace = (string) $config['xml_root_namespace'];
         }
 
+        if (isset($config['xml_discriminator_attribute'])) {
+            $metadata->setXmlDiscriminator($config['xml_discriminator_attribute']);
+        }
+
+
         if (array_key_exists('xml_namespaces', $config)) {
 
             foreach ($config['xml_namespaces'] as $prefix => $uri) {

--- a/src/JMS/Serializer/Metadata/Driver/YamlDriver.php
+++ b/src/JMS/Serializer/Metadata/Driver/YamlDriver.php
@@ -261,6 +261,9 @@ class YamlDriver extends AbstractFileDriver
             if (isset($config['xml_discriminator']['attribute'])) {
                 $metadata->xmlDiscriminatorAttribute = $config['xml_discriminator']['attribute'];
             }
+            if (isset($config['xml_discriminator']['cdata'])) {
+                $metadata->xmlDiscriminatorCData = $config['xml_discriminator']['cdata'];
+            }
         }
 
         if (array_key_exists('xml_namespaces', $config)) {

--- a/tests/JMS/Serializer/Tests/Fixtures/Discriminator/ObjectWithXmlAttributeDiscriminatorChild.php
+++ b/tests/JMS/Serializer/Tests/Fixtures/Discriminator/ObjectWithXmlAttributeDiscriminatorChild.php
@@ -1,0 +1,23 @@
+<?php
+
+/*
+ * Copyright 2016 Björn Bösel <bjoern.boesel@twt.de>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace JMS\Serializer\Tests\Fixtures\Discriminator;
+
+class ObjectWithXmlAttributeDiscriminatorChild extends ObjectWithXmlAttributeDiscriminatorParent
+{
+}

--- a/tests/JMS/Serializer/Tests/Fixtures/Discriminator/ObjectWithXmlAttributeDiscriminatorParent.php
+++ b/tests/JMS/Serializer/Tests/Fixtures/Discriminator/ObjectWithXmlAttributeDiscriminatorParent.php
@@ -24,7 +24,7 @@ use JMS\Serializer\Annotation as Serializer;
  * @Serializer\Discriminator(field = "type", map = {
  *    "child": "JMS\Serializer\Tests\Fixtures\Discriminator\ObjectWithXmlAttributeDiscriminatorChild"
  * })
- * @Serializer\XmlDiscriminator(attribute=true)
+ * @Serializer\XmlDiscriminator(attribute=true, cdata=false)
  */
 class ObjectWithXmlAttributeDiscriminatorParent
 {

--- a/tests/JMS/Serializer/Tests/Fixtures/Discriminator/ObjectWithXmlAttributeDiscriminatorParent.php
+++ b/tests/JMS/Serializer/Tests/Fixtures/Discriminator/ObjectWithXmlAttributeDiscriminatorParent.php
@@ -1,0 +1,32 @@
+<?php
+
+/*
+ * Copyright 2016 Björn Bösel <bjoern.boesel@twt.de>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace JMS\Serializer\Tests\Fixtures\Discriminator;
+
+use JMS\Serializer\Annotation as Serializer;
+
+/**
+ * @Serializer\Discriminator(field = "type", map = {
+ *    "child": "JMS\Serializer\Tests\Fixtures\Discriminator\ObjectWithXmlAttributeDiscriminatorChild"
+ * })
+ * @Serializer\XmlDiscriminatorAttribute
+ */
+class ObjectWithXmlAttributeDiscriminatorParent
+{
+
+}

--- a/tests/JMS/Serializer/Tests/Fixtures/Discriminator/ObjectWithXmlAttributeDiscriminatorParent.php
+++ b/tests/JMS/Serializer/Tests/Fixtures/Discriminator/ObjectWithXmlAttributeDiscriminatorParent.php
@@ -24,7 +24,7 @@ use JMS\Serializer\Annotation as Serializer;
  * @Serializer\Discriminator(field = "type", map = {
  *    "child": "JMS\Serializer\Tests\Fixtures\Discriminator\ObjectWithXmlAttributeDiscriminatorChild"
  * })
- * @Serializer\XmlDiscriminatorAttribute
+ * @Serializer\XmlDiscriminator(attribute=true)
  */
 class ObjectWithXmlAttributeDiscriminatorParent
 {

--- a/tests/JMS/Serializer/Tests/Metadata/Driver/BaseDriverTest.php
+++ b/tests/JMS/Serializer/Tests/Metadata/Driver/BaseDriverTest.php
@@ -188,6 +188,7 @@ abstract class BaseDriverTest extends \PHPUnit_Framework_TestCase
             $m->discriminatorMap
         );
         $this->assertTrue($m->xmlDiscriminatorAttribute);
+        $this->assertFalse($m->xmlDiscriminatorCData);
     }
 
     public function testLoadDiscriminatorWithGroup()

--- a/tests/JMS/Serializer/Tests/Metadata/Driver/BaseDriverTest.php
+++ b/tests/JMS/Serializer/Tests/Metadata/Driver/BaseDriverTest.php
@@ -22,6 +22,8 @@ use JMS\Serializer\GraphNavigator;
 use JMS\Serializer\Metadata\ClassMetadata;
 use JMS\Serializer\Metadata\PropertyMetadata;
 use JMS\Serializer\Metadata\VirtualPropertyMetadata;
+use JMS\Serializer\Tests\Fixtures\Discriminator\ObjectWithXmlAttributeDiscriminatorChild;
+use JMS\Serializer\Tests\Fixtures\Discriminator\ObjectWithXmlAttributeDiscriminatorParent;
 use Metadata\Driver\DriverInterface;
 
 abstract class BaseDriverTest extends \PHPUnit_Framework_TestCase
@@ -169,6 +171,23 @@ abstract class BaseDriverTest extends \PHPUnit_Framework_TestCase
             ),
             $m->discriminatorMap
         );
+    }
+
+    public function testLoadXmlDiscriminator()
+    {
+        /** @var $m ClassMetadata */
+        $m = $this->getDriver()->loadMetadataForClass(new \ReflectionClass(ObjectWithXmlAttributeDiscriminatorParent::class));
+
+        $this->assertNotNull($m);
+        $this->assertEquals('type', $m->discriminatorFieldName);
+        $this->assertEquals($m->name, $m->discriminatorBaseClass);
+        $this->assertEquals(
+            array(
+                'child' => ObjectWithXmlAttributeDiscriminatorChild::class,
+            ),
+            $m->discriminatorMap
+        );
+        $this->assertTrue($m->xmlDiscriminatorAttribute);
     }
 
     public function testLoadDiscriminatorWithGroup()

--- a/tests/JMS/Serializer/Tests/Metadata/Driver/php/Discriminator.ObjectWithXmlAttributeDiscriminatorParent.php
+++ b/tests/JMS/Serializer/Tests/Metadata/Driver/php/Discriminator.ObjectWithXmlAttributeDiscriminatorParent.php
@@ -8,5 +8,5 @@ $metadata->setDiscriminator('type', array(
     'child' => 'JMS\Serializer\Tests\Fixtures\Discriminator\ObjectWithXmlAttributeDiscriminatorChild'
 ));
 $metadata->xmlDiscriminatorAttribute = true;
-
+$metadata->xmlDiscriminatorCData = false;
 return $metadata;

--- a/tests/JMS/Serializer/Tests/Metadata/Driver/php/Discriminator.ObjectWithXmlAttributeDiscriminatorParent.php
+++ b/tests/JMS/Serializer/Tests/Metadata/Driver/php/Discriminator.ObjectWithXmlAttributeDiscriminatorParent.php
@@ -1,0 +1,12 @@
+<?php
+
+use JMS\Serializer\Metadata\ClassMetadata;
+use JMS\Serializer\Metadata\PropertyMetadata;
+
+$metadata = new ClassMetadata('JMS\Serializer\Tests\Fixtures\Discriminator\ObjectWithXmlAttributeDiscriminatorParent');
+$metadata->setDiscriminator('type', array(
+    'child' => 'JMS\Serializer\Tests\Fixtures\Discriminator\ObjectWithXmlAttributeDiscriminatorChild'
+));
+$metadata->setXmlDiscriminator(true);
+
+return $metadata;

--- a/tests/JMS/Serializer/Tests/Metadata/Driver/php/Discriminator.ObjectWithXmlAttributeDiscriminatorParent.php
+++ b/tests/JMS/Serializer/Tests/Metadata/Driver/php/Discriminator.ObjectWithXmlAttributeDiscriminatorParent.php
@@ -7,6 +7,6 @@ $metadata = new ClassMetadata('JMS\Serializer\Tests\Fixtures\Discriminator\Objec
 $metadata->setDiscriminator('type', array(
     'child' => 'JMS\Serializer\Tests\Fixtures\Discriminator\ObjectWithXmlAttributeDiscriminatorChild'
 ));
-$metadata->setXmlDiscriminator(true);
+$metadata->xmlDiscriminatorAttribute = true;
 
 return $metadata;

--- a/tests/JMS/Serializer/Tests/Metadata/Driver/xml/Discriminator.ObjectWithXmlAttributeDiscriminatorParent.xml
+++ b/tests/JMS/Serializer/Tests/Metadata/Driver/xml/Discriminator.ObjectWithXmlAttributeDiscriminatorParent.xml
@@ -5,6 +5,6 @@
            xml-discriminator-attribute="true"
     >
         <discriminator-class value="child">JMS\Serializer\Tests\Fixtures\Discriminator\ObjectWithXmlAttributeDiscriminatorChild</discriminator-class>
-        <xml-discriminator attribute="true" />
+        <xml-discriminator attribute="true" cdata="false" />
     </class>
 </serializer>

--- a/tests/JMS/Serializer/Tests/Metadata/Driver/xml/Discriminator.ObjectWithXmlAttributeDiscriminatorParent.xml
+++ b/tests/JMS/Serializer/Tests/Metadata/Driver/xml/Discriminator.ObjectWithXmlAttributeDiscriminatorParent.xml
@@ -2,7 +2,6 @@
 <serializer>
     <class name="JMS\Serializer\Tests\Fixtures\Discriminator\ObjectWithXmlAttributeDiscriminatorParent"
            discriminator-field-name="type"
-           xml-discriminator-attribute="true"
     >
         <discriminator-class value="child">JMS\Serializer\Tests\Fixtures\Discriminator\ObjectWithXmlAttributeDiscriminatorChild</discriminator-class>
         <xml-discriminator attribute="true" cdata="false" />

--- a/tests/JMS/Serializer/Tests/Metadata/Driver/xml/Discriminator.ObjectWithXmlAttributeDiscriminatorParent.xml
+++ b/tests/JMS/Serializer/Tests/Metadata/Driver/xml/Discriminator.ObjectWithXmlAttributeDiscriminatorParent.xml
@@ -5,5 +5,6 @@
            xml-discriminator-attribute="true"
     >
         <discriminator-class value="child">JMS\Serializer\Tests\Fixtures\Discriminator\ObjectWithXmlAttributeDiscriminatorChild</discriminator-class>
+        <xml-discriminator attribute="true" />
     </class>
 </serializer>

--- a/tests/JMS/Serializer/Tests/Metadata/Driver/xml/Discriminator.ObjectWithXmlAttributeDiscriminatorParent.xml
+++ b/tests/JMS/Serializer/Tests/Metadata/Driver/xml/Discriminator.ObjectWithXmlAttributeDiscriminatorParent.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<serializer>
+    <class name="JMS\Serializer\Tests\Fixtures\Discriminator\ObjectWithXmlAttributeDiscriminatorParent"
+           discriminator-field-name="type"
+           xml-discriminator-attribute="true"
+    >
+        <discriminator-class value="child">JMS\Serializer\Tests\Fixtures\Discriminator\ObjectWithXmlAttributeDiscriminatorChild</discriminator-class>
+    </class>
+</serializer>

--- a/tests/JMS/Serializer/Tests/Metadata/Driver/yml/Discriminator.ObjectWithXmlAttributeDiscriminatorParent.yml
+++ b/tests/JMS/Serializer/Tests/Metadata/Driver/yml/Discriminator.ObjectWithXmlAttributeDiscriminatorParent.yml
@@ -3,6 +3,6 @@ JMS\Serializer\Tests\Fixtures\Discriminator\ObjectWithXmlAttributeDiscriminatorP
         field_name: type
         map:
             child: JMS\Serializer\Tests\Fixtures\Discriminator\ObjectWithXmlAttributeDiscriminatorChild
-    xml_discriminator:
-        attribute: true
-        cdata: false
+        xml_attribute: true
+        xml_element:
+            cdata: false

--- a/tests/JMS/Serializer/Tests/Metadata/Driver/yml/Discriminator.ObjectWithXmlAttributeDiscriminatorParent.yml
+++ b/tests/JMS/Serializer/Tests/Metadata/Driver/yml/Discriminator.ObjectWithXmlAttributeDiscriminatorParent.yml
@@ -5,3 +5,4 @@ JMS\Serializer\Tests\Fixtures\Discriminator\ObjectWithXmlAttributeDiscriminatorP
             child: JMS\Serializer\Tests\Fixtures\Discriminator\ObjectWithXmlAttributeDiscriminatorChild
     xml_discriminator:
         attribute: true
+        cdata: false

--- a/tests/JMS/Serializer/Tests/Metadata/Driver/yml/Discriminator.ObjectWithXmlAttributeDiscriminatorParent.yml
+++ b/tests/JMS/Serializer/Tests/Metadata/Driver/yml/Discriminator.ObjectWithXmlAttributeDiscriminatorParent.yml
@@ -1,0 +1,6 @@
+JMS\Serializer\Tests\Fixtures\Discriminator\ObjectWithXmlAttributeDiscriminatorParent:
+    discriminator:
+        field_name: type
+        map:
+            child: JMS\Serializer\Tests\Fixtures\Discriminator\ObjectWithXmlAttributeDiscriminatorChild
+    xml_discriminator_attribute: true

--- a/tests/JMS/Serializer/Tests/Metadata/Driver/yml/Discriminator.ObjectWithXmlAttributeDiscriminatorParent.yml
+++ b/tests/JMS/Serializer/Tests/Metadata/Driver/yml/Discriminator.ObjectWithXmlAttributeDiscriminatorParent.yml
@@ -3,4 +3,5 @@ JMS\Serializer\Tests\Fixtures\Discriminator\ObjectWithXmlAttributeDiscriminatorP
         field_name: type
         map:
             child: JMS\Serializer\Tests\Fixtures\Discriminator\ObjectWithXmlAttributeDiscriminatorChild
-    xml_discriminator_attribute: true
+    xml_discriminator:
+        attribute: true

--- a/tests/JMS/Serializer/Tests/Serializer/XmlSerializationTest.php
+++ b/tests/JMS/Serializer/Tests/Serializer/XmlSerializationTest.php
@@ -25,6 +25,7 @@ use JMS\Serializer\Naming\CamelCaseNamingStrategy;
 use JMS\Serializer\Naming\SerializedNameAnnotationStrategy;
 use JMS\Serializer\SerializationContext;
 use JMS\Serializer\Serializer;
+use JMS\Serializer\Tests\Fixtures\Discriminator\ObjectWithXmlAttributeDiscriminatorParent;
 use JMS\Serializer\Tests\Fixtures\InvalidUsageOfXmlValue;
 use JMS\Serializer\Exception\InvalidArgumentException;
 use JMS\Serializer\Tests\Fixtures\PersonCollection;
@@ -40,6 +41,7 @@ use JMS\Serializer\Tests\Fixtures\SimpleSubClassObject;
 use JMS\Serializer\Tests\Fixtures\ObjectWithNamespacesAndList;
 use JMS\Serializer\XmlSerializationVisitor;
 use PhpCollection\Map;
+use JMS\Serializer\Tests\Fixtures\Discriminator\ObjectWithXmlAttributeDiscriminatorChild;
 
 class XmlSerializationTest extends BaseSerializationTest
 {
@@ -359,6 +361,20 @@ class XmlSerializationTest extends BaseSerializationTest
 
         $stringXml = $serializer->serialize($object, $this->getFormat());
         $this->assertXmlStringEqualsXmlString($this->getContent('simple_class_object_minified'), $stringXml);
+    }
+
+    public function testDiscriminatorAsXmlAttribute()
+    {
+        $xml = simplexml_load_string($this->serialize(new ObjectWithXmlAttributeDiscriminatorChild()));
+        $this->assertEquals('type="child"', trim($xml->xpath('//result/@type')[0]->saveXML()));
+
+        $this->assertInstanceOf(
+            ObjectWithXmlAttributeDiscriminatorChild::class,
+            $this->deserialize(
+                $xml->asXML(),
+                ObjectWithXmlAttributeDiscriminatorParent::class
+            )
+        );
     }
 
     private function xpathFirstToString(\SimpleXMLElement $xml, $xpath)

--- a/tests/JMS/Serializer/Tests/Serializer/XmlSerializationTest.php
+++ b/tests/JMS/Serializer/Tests/Serializer/XmlSerializationTest.php
@@ -365,13 +365,12 @@ class XmlSerializationTest extends BaseSerializationTest
 
     public function testDiscriminatorAsXmlAttribute()
     {
-        $xml = simplexml_load_string($this->serialize(new ObjectWithXmlAttributeDiscriminatorChild()));
-        $this->assertEquals('type="child"', trim($xml->xpath('//result/@type')[0]->saveXML()));
-
+        $xml = $this->serialize(new ObjectWithXmlAttributeDiscriminatorChild());
+        $this->assertEquals($this->getContent('xml_discriminator_attribute'), $xml);
         $this->assertInstanceOf(
             ObjectWithXmlAttributeDiscriminatorChild::class,
             $this->deserialize(
-                $xml->asXML(),
+                $xml,
                 ObjectWithXmlAttributeDiscriminatorParent::class
             )
         );

--- a/tests/JMS/Serializer/Tests/Serializer/xml/xml_discriminator_attribute.xml
+++ b/tests/JMS/Serializer/Tests/Serializer/xml/xml_discriminator_attribute.xml
@@ -1,0 +1,2 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<result type="child"/>


### PR DESCRIPTION
Until now when using Discriminator-maps with XML, the discriminator was hard coded to be a child node. This PR allows to use an attribute instead if desired.

```
 /**
 * @Discriminator(field = "type", map = {"car": "Car", "moped": "Moped"})
 */
 abstract class Vehicle { }
 class Car extends Vehicle { }
 class Moped extends Vehicle { }
 $serializer->serialize(new Car(), 'xml');
```

would result in
```
<vehicle>
    <type>car</type>
</vehicle>
```
now you can do this:

```
/**
 * @Discriminator(field = "type", map = {"car": "Car", "moped": "Moped"})
 * @XmlDiscriminatorAttribute
 */
abstract class Vehicle { }
class Car extends Vehicle { }
class Moped extends Vehicle { }

$serializer->serialize(new Car(), 'xml'); 
```
to get:
```
<vehicle type="car" />
```