### PR TITLE
Use GroupsExclusionStrategy::DEFAULT_GROUP instead default group.

### DIFF
--- a/src/JMS/Serializer/Exclusion/GroupsExclusionStrategy.php
+++ b/src/JMS/Serializer/Exclusion/GroupsExclusionStrategy.php
@@ -78,7 +78,7 @@ class GroupsExclusionStrategy implements ExclusionStrategyInterface
         foreach ($paths as $index => $path) {
             if (!array_key_exists($path, $groups)) {
                 if ($index > 0) {
-                    $groups = array('Default');
+                    $groups = array(self::DEFAULT_GROUP);
                 }
 
                 break;

--- a/tests/JMS/Serializer/Tests/Exclusion/GroupsExclusionStrategyTest.php
+++ b/tests/JMS/Serializer/Tests/Exclusion/GroupsExclusionStrategyTest.php
@@ -48,21 +48,21 @@ class GroupsExclusionStrategyTest extends \PHPUnit_Framework_TestCase
             [['foo'], ['bar'], true],
             [['bar'], ['foo'], true],
 
-            [['foo', 'Default'], [], false],
+            [['foo', GroupsExclusionStrategy::DEFAULT_GROUP], [], false],
             [['foo', 'bar'], [], true],
-            [['foo', 'bar'], ['Default'], true],
+            [['foo', 'bar'], [GroupsExclusionStrategy::DEFAULT_GROUP], true],
             [['foo', 'bar'], ['foo'], false],
 
-            [['foo', 'Default'], ['test'], true],
-            [['foo', 'Default', 'test'], ['test'], false],
+            [['foo', GroupsExclusionStrategy::DEFAULT_GROUP], ['test'], true],
+            [['foo', GroupsExclusionStrategy::DEFAULT_GROUP, 'test'], ['test'], false],
 
-            [['foo'], ['Default'], true],
-            [['Default'], [], false],
-            [[], ['Default'], false],
-            [['Default'], ['Default'], false],
-            [['Default', 'foo'], ['Default'], false],
-            [['Default'], ['Default','foo'], false],
-            [['foo'], ['Default','foo'], false],
+            [['foo'], [GroupsExclusionStrategy::DEFAULT_GROUP], true],
+            [[GroupsExclusionStrategy::DEFAULT_GROUP], [], false],
+            [[], [GroupsExclusionStrategy::DEFAULT_GROUP], false],
+            [[GroupsExclusionStrategy::DEFAULT_GROUP], [GroupsExclusionStrategy::DEFAULT_GROUP], false],
+            [[GroupsExclusionStrategy::DEFAULT_GROUP, 'foo'], [GroupsExclusionStrategy::DEFAULT_GROUP], false],
+            [[GroupsExclusionStrategy::DEFAULT_GROUP], [GroupsExclusionStrategy::DEFAULT_GROUP, 'foo'], false],
+            [['foo'], [GroupsExclusionStrategy::DEFAULT_GROUP, 'foo'], false],
         ];
     }
 }

--- a/tests/JMS/Serializer/Tests/Serializer/BaseSerializationTest.php
+++ b/tests/JMS/Serializer/Tests/Serializer/BaseSerializationTest.php
@@ -20,6 +20,7 @@ namespace JMS\Serializer\Tests\Serializer;
 
 use JMS\Serializer\Context;
 use JMS\Serializer\DeserializationContext;
+use JMS\Serializer\Exclusion\GroupsExclusionStrategy;
 use JMS\Serializer\GraphNavigator;
 use JMS\Serializer\Handler\PhpCollectionHandler;
 use JMS\Serializer\SerializationContext;
@@ -819,12 +820,12 @@ abstract class BaseSerializationTest extends \PHPUnit_Framework_TestCase
 
         $this->assertEquals(
             $this->getContent('groups_default'),
-            $this->serializer->serialize($groupsObject, $this->getFormat(), SerializationContext::create()->setGroups(array('Default')))
+            $this->serializer->serialize($groupsObject, $this->getFormat(), SerializationContext::create()->setGroups(array(GroupsExclusionStrategy::DEFAULT_GROUP)))
         );
 
         $this->assertEquals(
             $this->getContent('groups_default'),
-            $this->serializer->serialize($groupsObject, $this->getFormat(), SerializationContext::create()->setGroups(array('Default')))
+            $this->serializer->serialize($groupsObject, $this->getFormat(), SerializationContext::create()->setGroups(array(GroupsExclusionStrategy::DEFAULT_GROUP)))
         );
     }
 
@@ -861,12 +862,12 @@ abstract class BaseSerializationTest extends \PHPUnit_Framework_TestCase
                 $adrien,
                 $this->getFormat(),
                 SerializationContext::create()->setGroups(array(
-                    'Default',
+                    GroupsExclusionStrategy::DEFAULT_GROUP,
                     'manager_group',
                     'friends_group',
 
                     'manager' => array(
-                        'Default',
+                        GroupsExclusionStrategy::DEFAULT_GROUP,
                         'friends_group',
 
                         'friends' => array('nickname_group'),


### PR DESCRIPTION
I think using the `GroupsExclusionStrategy::DEFAULT_GROUP` constant is more correct.