### PR TITLE
Bugfix for #695, #674

### DIFF
--- a/src/JMS/Serializer/XmlDeserializationVisitor.php
+++ b/src/JMS/Serializer/XmlDeserializationVisitor.php
@@ -150,11 +150,7 @@ class XmlDeserializationVisitor extends AbstractVisitor
             $namespace = isset($classMetadata->xmlNamespaces[''])?$classMetadata->xmlNamespaces['']:$namespace;
         }
 
-        if (0 === $data->count()){
-            $hasNode = false;
-        } else {
-            $hasNode = null !== $namespace ? isset($data->children($namespace)->$entryName) : isset($data->$entryName);
-        }
+        $hasNode = null !== $namespace ? isset($data->children($namespace)->$entryName) : isset($data->$entryName);
 
         if (false === $hasNode) {
             if (null === $this->result) {
@@ -249,6 +245,10 @@ class XmlDeserializationVisitor extends AbstractVisitor
         if ($metadata->xmlCollection) {
             $enclosingElem = $data;
             if (!$metadata->xmlCollectionInline) {
+                if (!isset($data->children($metadata->xmlNamespace)->$name)) {
+                    $metadata->setValue($this->currentObject, array());
+                    return;
+                }
                 $enclosingElem = $data->children($metadata->xmlNamespace)->$name;
             }
 

--- a/src/JMS/Serializer/XmlDeserializationVisitor.php
+++ b/src/JMS/Serializer/XmlDeserializationVisitor.php
@@ -150,8 +150,8 @@ class XmlDeserializationVisitor extends AbstractVisitor
             $namespace = isset($classMetadata->xmlNamespaces[''])?$classMetadata->xmlNamespaces['']:$namespace;
         }
 
-        $hasNode = null !== $namespace ? isset($data->children($namespace)->$entryName) : isset($data->$entryName);
 
+        $hasNode = null !== $namespace ? isset($data->children($namespace)->$entryName) : isset($data->$entryName);
         if (false === $hasNode) {
             if (null === $this->result) {
                 return $this->result = array();
@@ -245,11 +245,11 @@ class XmlDeserializationVisitor extends AbstractVisitor
         if ($metadata->xmlCollection) {
             $enclosingElem = $data;
             if (!$metadata->xmlCollectionInline) {
-                if (!isset($data->children($metadata->xmlNamespace)->$name)) {
-                    $metadata->setValue($this->currentObject, array());
-                    return;
+                if (isset($data->children($metadata->xmlNamespace)->$name)) {
+                    $enclosingElem = $data->children($metadata->xmlNamespace)->$name;
+                } else {
+                    $enclosingElem = $data->addChild($name, $metadata->xmlNamespace);
                 }
-                $enclosingElem = $data->children($metadata->xmlNamespace)->$name;
             }
 
             $this->setCurrentMetadata($metadata);

--- a/tests/JMS/Serializer/Tests/Serializer/XmlSerializationTest.php
+++ b/tests/JMS/Serializer/Tests/Serializer/XmlSerializationTest.php
@@ -228,6 +228,33 @@ class XmlSerializationTest extends BaseSerializationTest
         );
     }
 
+
+    public function testObjectWithOnlyNamespacesAndList()
+    {
+        $object = new ObjectWithNamespacesAndList();
+
+        $object->phones = array();
+        $object->addresses = array();
+
+        $object->phonesAlternativeB = array();
+        $object->addressesAlternativeB = array();
+
+        $object->phonesAlternativeC = array('777', '888');
+        $object->addressesAlternativeC = array('A'=>'Street 7', 'B'=>'Street 8');
+
+        $object->phonesAlternativeD = array();
+        $object->addressesAlternativeD = array();
+
+        $this->assertEquals(
+            $this->getContent('object_with_only_namespaces_and_list'),
+            $this->serialize($object, SerializationContext::create())
+        );
+        $this->assertEquals(
+            $object,
+            $this->deserialize($this->getContent('object_with_only_namespaces_and_list'), get_class($object))
+        );
+    }
+
     public function testArrayKeyValues()
     {
         $this->assertEquals($this->getContent('array_key_values'), $this->serializer->serialize(new ObjectWithXmlKeyValuePairs(), 'xml'));

--- a/tests/JMS/Serializer/Tests/Serializer/xml/object_with_only_namespaces_and_list.xml
+++ b/tests/JMS/Serializer/Tests/Serializer/xml/object_with_only_namespaces_and_list.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ObjectWithNamespacesAndList xmlns="http://example.com/namespace" xmlns:x="http://example.com/namespace2">
+  <x:phone><![CDATA[777]]></x:phone>
+  <x:phone><![CDATA[888]]></x:phone>
+  <x:address id="A"><![CDATA[Street 7]]></x:address>
+  <x:address id="B"><![CDATA[Street 8]]></x:address>
+</ObjectWithNamespacesAndList>


### PR DESCRIPTION
During XML deserialization, do not visit property if that node is absent.

fixes Deserializing XMLList with Namespaces not (always) working as intended #695