### PR TITLE
Deserializing XMLList with Namespaces not (always) working as intended

### DIFF
--- a/src/JMS/Serializer/XmlDeserializationVisitor.php
+++ b/src/JMS/Serializer/XmlDeserializationVisitor.php
@@ -150,13 +150,15 @@ class XmlDeserializationVisitor extends AbstractVisitor
             $namespace = isset($classMetadata->xmlNamespaces[''])?$classMetadata->xmlNamespaces['']:$namespace;
         }
 
-        if (0 === $data->count()){
-            $hasNode = false;
+        if (null !== $namespace) {
+            $prefix = uniqid('ns-');
+            $data->registerXPathNamespace($prefix, $namespace);
+            $nodes = $data->xpath("$prefix:$entryName");
         } else {
-            $hasNode = null !== $namespace ? isset($data->children($namespace)->$entryName) : isset($data->$entryName);
+            $nodes = $data->xpath($entryName);
         }
 
-        if (false === $hasNode) {
+        if (!count($nodes)) {
             if (null === $this->result) {
                 return $this->result = array();
             }
@@ -175,7 +177,6 @@ class XmlDeserializationVisitor extends AbstractVisitor
                     $this->result = &$result;
                 }
 
-                $nodes = $data->children($namespace)->$entryName;
                 foreach ($nodes as $v) {
                     $result[] = $this->navigator->accept($v, $type['params'][0], $context);
                 }

--- a/tests/JMS/Serializer/Tests/Serializer/XmlSerializationTest.php
+++ b/tests/JMS/Serializer/Tests/Serializer/XmlSerializationTest.php
@@ -276,6 +276,31 @@ class XmlSerializationTest extends BaseSerializationTest
         $this->serializer->serialize(new Input($attributes), $this->getFormat());
     }
 
+    public function testObjectWithOnlyNamespacesAndList()
+    {
+        $object = new ObjectWithNamespacesAndList();
+
+        $object->phones = array();
+        $object->addresses = array();
+
+        $object->phonesAlternativeB = array();
+        $object->addressesAlternativeB = array();
+
+        $object->phonesAlternativeC = array('777', '888');
+        $object->addressesAlternativeC = array('A'=>'Street 7', 'B'=>'Street 8');
+
+        $object->phonesAlternativeD = array();
+        $object->addressesAlternativeD = array();
+
+        $this->assertEquals(
+            $this->getContent('object_with_only_namespaces_and_list'),
+            $this->serialize($object, SerializationContext::create())
+        );
+
+        $deserialized = $this->deserialize($this->getContent('object_with_only_namespaces_and_list'), get_class($object));
+        $this->assertEquals($object, $deserialized);
+    }
+
     public function testDeserializingNull()
     {
         $this->markTestSkipped('Not supported in XML.');

--- a/tests/JMS/Serializer/Tests/Serializer/xml/object_with_only_namespaces_and_list.xml
+++ b/tests/JMS/Serializer/Tests/Serializer/xml/object_with_only_namespaces_and_list.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ObjectWithNamespacesAndList xmlns="http://example.com/namespace" xmlns:x="http://example.com/namespace2">
+  <x:phone><![CDATA[777]]></x:phone>
+  <x:phone><![CDATA[888]]></x:phone>
+  <x:address id="A"><![CDATA[Street 7]]></x:address>
+  <x:address id="B"><![CDATA[Street 8]]></x:address>
+</ObjectWithNamespacesAndList>


### PR DESCRIPTION
Trying to solve https://github.com/schmittjoh/serializer/issues/695 using XPATH

relates #696, #674

The advantage of this is the use or one single xpath xpression to do the whole job.

no multiple `isset`, `count` or `children`. 

the disadvantage is that xpath should be probably slower

closes https://github.com/schmittjoh/serializer/pull/697  #695