### PR TITLE
[RFC] Extra parameter that allows to typehint the first step serialization

### DIFF
--- a/src/JMS/Serializer/Serializer.php
+++ b/src/JMS/Serializer/Serializer.php
@@ -88,15 +88,19 @@ class Serializer implements SerializerInterface, ArrayTransformerInterface
         $this->deserializationContextFactory = new DefaultDeserializationContextFactory();
     }
 
-    public function serialize($data, $format, SerializationContext $context = null)
+    public function serialize($data, $format, SerializationContext $context = null, $type = null)
     {
         if (null === $context) {
             $context = $this->serializationContextFactory->createSerializationContext();
         }
 
+        if (null !== $type) {
+            $type = $this->typeParser->parse($type);
+        }
+
         return $this->serializationVisitors->get($format)
-            ->map(function(VisitorInterface $visitor) use ($context, $data, $format) {
-                $this->visit($visitor, $context, $visitor->prepare($data), $format);
+            ->map(function(VisitorInterface $visitor) use ($context, $data, $format, $type) {
+                $this->visit($visitor, $context, $visitor->prepare($data), $format, $type);
 
                 return $visitor->getResult();
             })

--- a/src/JMS/Serializer/SerializerInterface.php
+++ b/src/JMS/Serializer/SerializerInterface.php
@@ -30,11 +30,12 @@ interface SerializerInterface
      *
      * @param object|array|scalar $data
      * @param string $format
-     * @param Context $context
+     * @param SerializationContext $context
+     * @param string $type
      *
      * @return string
      */
-    public function serialize($data, $format, SerializationContext $context = null);
+    public function serialize($data, $format, SerializationContext $context = null, $type = null);
 
     /**
      * Deserializes the given data to the specified type.
@@ -42,7 +43,7 @@ interface SerializerInterface
      * @param string $data
      * @param string $type
      * @param string $format
-     * @param Context $context
+     * @param DeserializationContext $context
      *
      * @return object|array|scalar
      */

--- a/tests/JMS/Serializer/Tests/Serializer/JsonSerializationTest.php
+++ b/tests/JMS/Serializer/Tests/Serializer/JsonSerializationTest.php
@@ -229,6 +229,32 @@ class JsonSerializationTest extends BaseSerializationTest
         $this->assertInternalType($primitiveType, $result);
     }
 
+    public function testSerializeRootArrayWithDefinedKeys()
+    {
+        $author1 = new Author("Jim");
+        $author2 = new Author("Mark");
+
+        $data = array(
+            'jim' => $author1,
+            'mark' => $author2,
+        );
+
+        $this->assertEquals('[{"full_name":"Jim"},{"full_name":"Mark"}]', $this->serializer->serialize($data, $this->getFormat(), null, 'array<JMS\Serializer\Tests\Fixtures\Author>'));
+        $this->assertEquals('{"jim":{"full_name":"Jim"},"mark":{"full_name":"Mark"}}', $this->serializer->serialize($data, $this->getFormat(), null, 'array<string,JMS\Serializer\Tests\Fixtures\Author>'));
+        $this->assertEquals('{"jim":{"full_name":"Jim"},"mark":{"full_name":"Mark"}}', $this->serializer->serialize($data, $this->getFormat(), null, 'array'));
+
+        //$this->assertEquals('{"jim":{"full_name":"Jim"},"mark":{"full_name":"Mark"}}', $this->serializer->serialize($data, $this->getFormat(), null, 'array<int, NULL>')); // autodetect type for each element
+
+        $data = array(
+            $author1,
+            $author2,
+        );
+        $this->assertEquals('[{"full_name":"Jim"},{"full_name":"Mark"}]', $this->serializer->serialize($data, $this->getFormat(), null, 'array<int,JMS\Serializer\Tests\Fixtures\Author>'));
+        //$this->assertEquals('[{"full_name":"Jim"},{"full_name":"Mark"}]', $this->serializer->serialize($data, $this->getFormat(), null, 'array<int,NULL>')); // autodetect type for each element
+        $this->assertEquals('{"0":{"full_name":"Jim"},"1":{"full_name":"Mark"}}', $this->serializer->serialize($data, $this->getFormat(), null, 'array<int,JMS\Serializer\Tests\Fixtures\Author>'));
+        $this->assertEquals('{"0":{"full_name":"Jim"},"1":{"full_name":"Mark"}}', $this->serializer->serialize($data, $this->getFormat(), null, 'array<string,JMS\Serializer\Tests\Fixtures\Author>'));
+    }
+
     /**
      * @group empty-object
      */


### PR DESCRIPTION
this will allow:

-  putting custom handlers and virtual types on the first level serialization objects
- solve some issues with json/yaml arrays serialized as hashes
- ?? something else

- What about the `toArray` and `fromArray`?
- What about additional XML options?