### PR TITLE
Change branch alias

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -48,7 +48,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "1.4-dev"
+            "dev-master": "1.x-dev"
         }
     }
 }


### PR DESCRIPTION
Anybody experienced with `composer` branch aliasing here?

The serializer does not have parallel maintained branches.

What should be the branch alias for `master` ?
- `1.x-dev`
- `1.0.x-dev`
- `1.0-dev` (not sure if this is valid)

And how this will impact on the "require" section? Are this expression valid? Will all of them work or not with any of the branch alias proposed before?

- `1.0.0@dev`
- `1.0@dev`
- `1@dev`