### PR TITLE
Expression language based virtual properties

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,6 +21,7 @@
         "doctrine/instantiator": "^1.0.3"
     },
     "conflict": {
+        "jms/serializer-bundle": "<1.2.1",
         "twig/twig": "<1.12"
     },
     "suggest": {

--- a/doc/reference/annotations.rst
+++ b/doc/reference/annotations.rst
@@ -180,6 +180,56 @@ default the order is undefined, but you may change it to either "alphabetical", 
 This annotation can be defined on a method to indicate that the data returned by
 the method should appear like a property of the object.
 
+A virtual property can be defined for a method of an object to serialize and can be
+also defined at class level exposing data using the Symfony Expression Language.
+
+.. code-block :: php
+
+    /**
+     * @Serializer\VirtualProperty(
+     *     "firstName",
+     *     exp="object.getFirstName()",
+     *     options={@Serializer\SerializedName("my_first_name")}
+     *  )
+     */
+    class Author
+    {
+        /**
+         * @Serializer\Expose()
+         */
+        private $id;
+
+        /**
+         * @Serializer\Exclude()
+         */
+        private $firstName;
+
+        /**
+         * @Serializer\Exclude()
+         */
+        private $lastName;
+
+        /**
+         * @Serializer\VirtualProperty()
+         */
+        public function getLastName()
+        {
+            return $this->lastName;
+        }
+
+        public function getFirstName()
+        {
+            return $this->firstName;
+        }
+    }
+
+In this example:
+
+- ``id`` is exposed using the object reflection.
+- ``lastName`` is exposed using the ``getLastName`` getter method.
+- ``id`` is exposed using the ``object.getFirstName()`` expression (``exp`` can contain any valid symfony expression).
+
+
 **Note**: This only works for serialization and is completely ignored during
 deserialization.
 

--- a/doc/reference/xml_reference.rst
+++ b/doc/reference/xml_reference.rst
@@ -67,6 +67,25 @@ XML Reference
                       xml-attribute-map="true"
                       max-depth="2"
             >
+            <virtual-property expression="object.getName()"
+                      name="some-property"
+                      exclude="true"
+                      expose="true"
+                      type="string"
+                      serialized-name="foo"
+                      since-version="1.0"
+                      until-version="1.1"
+                      xml-attribute="true"
+                      access-type="public_method"
+                      accessor-getter="getSomeProperty"
+                      accessor-setter="setSomeProperty"
+                      inline="true"
+                      read-only="true"
+                      groups="foo,bar"
+                      xml-key-value-pairs="true"
+                      xml-attribute-map="true"
+                      max-depth="2"
+            >
                 <!-- You can also specify the type as element which is necessary if
                      your type contains "<" or ">" characters. -->
                 <type><![CDATA[]]></type>

--- a/doc/reference/yml_reference.rst
+++ b/doc/reference/yml_reference.rst
@@ -25,6 +25,10 @@ YAML Reference
             getSomeProperty:
                 serialized_name: foo
                 type: integer
+            expression_prop:
+                exp: object.getName()
+                serialized_name: foo
+                type: integer
         xml_namespaces:
             "": http://your.default.namespace
             atom: http://www.w3.org/2005/Atom

--- a/src/JMS/Serializer/AbstractVisitor.php
+++ b/src/JMS/Serializer/AbstractVisitor.php
@@ -18,15 +18,23 @@
 
 namespace JMS\Serializer;
 
+use JMS\Serializer\Accessor\AccessorStrategyInterface;
+use JMS\Serializer\Accessor\DefaultAccessorStrategy;
 use JMS\Serializer\Naming\PropertyNamingStrategyInterface;
 
 abstract class AbstractVisitor implements VisitorInterface
 {
     protected $namingStrategy;
 
-    public function __construct(PropertyNamingStrategyInterface $namingStrategy)
+    /**
+     * @var AccessorStrategyInterface
+     */
+    protected $accessor;
+
+    public function __construct(PropertyNamingStrategyInterface $namingStrategy, AccessorStrategyInterface $accessorStrategy = null)
     {
         $this->namingStrategy = $namingStrategy;
+        $this->accessor = $accessorStrategy ?: new DefaultAccessorStrategy();
     }
 
     public function getNamingStrategy()

--- a/src/JMS/Serializer/Accessor/AccessorStrategyInterface.php
+++ b/src/JMS/Serializer/Accessor/AccessorStrategyInterface.php
@@ -1,0 +1,42 @@
+<?php
+
+/*
+ * Copyright 2016 Johannes M. Schmitt <schmittjoh@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace JMS\Serializer\Accessor;
+
+use JMS\Serializer\Metadata\PropertyMetadata;
+
+/**
+ * @author Asmir Mustafic <goetas@gmail.com>
+ */
+interface AccessorStrategyInterface
+{
+    /**
+     * @param object $object
+     * @param PropertyMetadata $metadata
+     * @return mixed
+     */
+    public function getValue($object, PropertyMetadata $metadata);
+
+    /**
+     * @param object $object
+     * @param mixed $value
+     * @param PropertyMetadata $metadata
+     * @return void
+     */
+    public function setValue($object, $value, PropertyMetadata $metadata);
+}

--- a/src/JMS/Serializer/Accessor/DefaultAccessorStrategy.php
+++ b/src/JMS/Serializer/Accessor/DefaultAccessorStrategy.php
@@ -1,0 +1,38 @@
+<?php
+
+/*
+ * Copyright 2016 Johannes M. Schmitt <schmittjoh@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace JMS\Serializer\Accessor;
+
+use JMS\Serializer\Metadata\PropertyMetadata;
+
+/**
+ * @author Asmir Mustafic <goetas@gmail.com>
+ */
+class DefaultAccessorStrategy implements AccessorStrategyInterface
+{
+
+    public function getValue($object, PropertyMetadata $metadata)
+    {
+        return $metadata->getValue($object);
+    }
+
+    public function setValue($object, $value, PropertyMetadata $metadata)
+    {
+        $metadata->setValue($object, $value);
+    }
+}

--- a/src/JMS/Serializer/Accessor/ExpressionAccessorStrategy.php
+++ b/src/JMS/Serializer/Accessor/ExpressionAccessorStrategy.php
@@ -1,0 +1,57 @@
+<?php
+
+/*
+ * Copyright 2016 Johannes M. Schmitt <schmittjoh@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace JMS\Serializer\Accessor;
+
+use JMS\Serializer\Expression\ExpressionEvaluatorInterface;
+use JMS\Serializer\Metadata\ExpressionPropertyMetadata;
+use JMS\Serializer\Metadata\PropertyMetadata;
+
+/**
+ * @author Asmir Mustafic <goetas@gmail.com>
+ */
+class ExpressionAccessorStrategy implements AccessorStrategyInterface
+{
+    /**
+     * @var AccessorStrategyInterface
+     */
+    private $fallback;
+    /**
+     * @var ExpressionEvaluatorInterface
+     */
+    private $evaluator;
+
+    public function __construct(ExpressionEvaluatorInterface $evaluator, AccessorStrategyInterface $fallback)
+    {
+        $this->fallback = $fallback;
+        $this->evaluator = $evaluator;
+    }
+
+    public function getValue($object, PropertyMetadata $metadata)
+    {
+        if ($metadata instanceof ExpressionPropertyMetadata) {
+            return $this->evaluator->evaluate($metadata->expression, array('object' => $object));
+        }
+        return $this->fallback->getValue($object, $metadata);
+    }
+
+    public function setValue($object, $value, PropertyMetadata $metadata)
+    {
+        $this->fallback->setValue($object, $value, $metadata);
+    }
+}

--- a/src/JMS/Serializer/Annotation/Exclude.php
+++ b/src/JMS/Serializer/Annotation/Exclude.php
@@ -20,7 +20,7 @@ namespace JMS\Serializer\Annotation;
 
 /**
  * @Annotation
- * @Target({"PROPERTY", "CLASS", "METHOD"})
+ * @Target({"PROPERTY", "CLASS", "METHOD", "ANNOTATION"})
  */
 final class Exclude
 {

--- a/src/JMS/Serializer/Annotation/Expose.php
+++ b/src/JMS/Serializer/Annotation/Expose.php
@@ -20,7 +20,7 @@ namespace JMS\Serializer\Annotation;
 
 /**
  * @Annotation
- * @Target({"PROPERTY", "METHOD"})
+ * @Target({"PROPERTY", "METHOD","ANNOTATION"})
  */
 final class Expose
 {

--- a/src/JMS/Serializer/Annotation/Groups.php
+++ b/src/JMS/Serializer/Annotation/Groups.php
@@ -20,7 +20,7 @@ namespace JMS\Serializer\Annotation;
 
 /**
  * @Annotation
- * @Target({"PROPERTY","METHOD"})
+ * @Target({"PROPERTY","METHOD","ANNOTATION"})
  */
 final class Groups
 {

--- a/src/JMS/Serializer/Annotation/Inline.php
+++ b/src/JMS/Serializer/Annotation/Inline.php
@@ -20,7 +20,7 @@ namespace JMS\Serializer\Annotation;
 
 /**
  * @Annotation
- * @Target({"PROPERTY","METHOD"})
+ * @Target({"PROPERTY","METHOD","ANNOTATION"})
  */
 final class Inline
 {

--- a/src/JMS/Serializer/Annotation/MaxDepth.php
+++ b/src/JMS/Serializer/Annotation/MaxDepth.php
@@ -20,7 +20,7 @@ namespace JMS\Serializer\Annotation;
 
 /**
  * @Annotation
- * @Target({"PROPERTY","METHOD"})
+ * @Target({"PROPERTY","METHOD","ANNOTATION"})
  */
 final class MaxDepth
 {

--- a/src/JMS/Serializer/Annotation/SerializedName.php
+++ b/src/JMS/Serializer/Annotation/SerializedName.php
@@ -22,7 +22,7 @@ use JMS\Serializer\Exception\RuntimeException;
 
 /**
  * @Annotation
- * @Target({"PROPERTY","METHOD"})
+ * @Target({"PROPERTY","METHOD", "ANNOTATION"})
  */
 final class SerializedName
 {

--- a/src/JMS/Serializer/Annotation/Type.php
+++ b/src/JMS/Serializer/Annotation/Type.php
@@ -20,7 +20,7 @@ namespace JMS\Serializer\Annotation;
 
 /**
  * @Annotation
- * @Target({"PROPERTY", "METHOD"})
+ * @Target({"PROPERTY", "METHOD","ANNOTATION"})
  */
 final class Type
 {

--- a/src/JMS/Serializer/Annotation/VirtualProperty.php
+++ b/src/JMS/Serializer/Annotation/VirtualProperty.php
@@ -20,10 +20,29 @@ namespace JMS\Serializer\Annotation;
 
 /**
  * @Annotation
- * @Target("METHOD")
+ * @Target({"METHOD", "CLASS"})
  *
  * @author Alexander Klimenkov <alx.devel@gmail.com>
  */
 final class VirtualProperty
 {
+    public $exp;
+    public $name;
+    public $options = array();
+
+    public function __construct(array $data)
+    {
+        if (isset($data['value'])) {
+            $data['name'] = $data['value'];
+            unset($data['value']);
+        }
+
+        foreach ($data as $key => $value) {
+            if (!property_exists(__CLASS__, $key)) {
+                throw new \BadMethodCallException(sprintf('Unknown property "%s" on annotation "%s".', $key, __CLASS__));
+            }
+            $this->{$key} = $value;
+        }
+    }
 }
+

--- a/src/JMS/Serializer/Annotation/XmlAttribute.php
+++ b/src/JMS/Serializer/Annotation/XmlAttribute.php
@@ -20,7 +20,7 @@ namespace JMS\Serializer\Annotation;
 
 /**
  * @Annotation
- * @Target({"PROPERTY", "METHOD"})
+ * @Target({"PROPERTY", "METHOD","ANNOTATION"})
  */
 final class XmlAttribute
 {

--- a/src/JMS/Serializer/Annotation/XmlElement.php
+++ b/src/JMS/Serializer/Annotation/XmlElement.php
@@ -20,7 +20,7 @@ namespace JMS\Serializer\Annotation;
 
 /**
  * @Annotation
- * @Target({"PROPERTY", "METHOD"})
+ * @Target({"PROPERTY", "METHOD","ANNOTATION"})
  */
 final class XmlElement
 {

--- a/src/JMS/Serializer/Annotation/XmlKeyValuePairs.php
+++ b/src/JMS/Serializer/Annotation/XmlKeyValuePairs.php
@@ -20,7 +20,7 @@ namespace JMS\Serializer\Annotation;
 
 /**
  * @Annotation
- * @Target({"PROPERTY","METHOD"})
+ * @Target({"PROPERTY","METHOD","ANNOTATION"})
  */
 final class XmlKeyValuePairs
 {

--- a/src/JMS/Serializer/Annotation/XmlList.php
+++ b/src/JMS/Serializer/Annotation/XmlList.php
@@ -20,7 +20,7 @@ namespace JMS\Serializer\Annotation;
 
 /**
  * @Annotation
- * @Target({"PROPERTY","METHOD"})
+ * @Target({"PROPERTY","METHOD","ANNOTATION"})
  */
 final class XmlList extends XmlCollection
 {

--- a/src/JMS/Serializer/Annotation/XmlMap.php
+++ b/src/JMS/Serializer/Annotation/XmlMap.php
@@ -20,7 +20,7 @@ namespace JMS\Serializer\Annotation;
 
 /**
  * @Annotation
- * @Target({"PROPERTY","METHOD"})
+ * @Target({"PROPERTY","METHOD","ANNOTATION"})
  */
 final class XmlMap extends XmlCollection
 {

--- a/src/JMS/Serializer/Annotation/XmlValue.php
+++ b/src/JMS/Serializer/Annotation/XmlValue.php
@@ -20,7 +20,7 @@ namespace JMS\Serializer\Annotation;
 
 /**
  * @Annotation
- * @Target({"PROPERTY","METHOD"})
+ * @Target({"PROPERTY","METHOD","ANNOTATION"})
  */
 final class XmlValue
 {

--- a/src/JMS/Serializer/GenericDeserializationVisitor.php
+++ b/src/JMS/Serializer/GenericDeserializationVisitor.php
@@ -180,7 +180,8 @@ abstract class GenericDeserializationVisitor extends AbstractVisitor
 
         $v = $data[$name] !== null ? $this->navigator->accept($data[$name], $metadata->type, $context) : null;
 
-        $metadata->setValue($this->currentObject, $v);
+        $this->accessor->setValue($this->currentObject, $v, $metadata);
+
     }
 
     public function endVisitingObject(ClassMetadata $metadata, $data, array $type, Context $context)

--- a/src/JMS/Serializer/GenericSerializationVisitor.php
+++ b/src/JMS/Serializer/GenericSerializationVisitor.php
@@ -141,7 +141,7 @@ abstract class GenericSerializationVisitor extends AbstractVisitor
 
     public function visitProperty(PropertyMetadata $metadata, $data, Context $context)
     {
-        $v = $metadata->getValue($data);
+        $v = $this->accessor->getValue($data, $metadata);
 
         $v = $this->navigator->accept($v, $metadata->type, $context);
         if (null === $v && $context->shouldSerializeNull() !== true) {

--- a/src/JMS/Serializer/Metadata/Driver/AnnotationDriver.php
+++ b/src/JMS/Serializer/Metadata/Driver/AnnotationDriver.php
@@ -38,6 +38,7 @@ use JMS\Serializer\Annotation\PostSerialize;
 use JMS\Serializer\Annotation\PostDeserialize;
 use JMS\Serializer\Annotation\PreSerialize;
 use JMS\Serializer\Annotation\VirtualProperty;
+use JMS\Serializer\Metadata\ExpressionPropertyMetadata;
 use Metadata\MethodMetadata;
 use Doctrine\Common\Annotations\Reader;
 use JMS\Serializer\Annotation\Type;
@@ -104,6 +105,10 @@ class AnnotationDriver implements DriverInterface
             } elseif ($annot instanceof XmlDiscriminator) {
                 $classMetadata->xmlDiscriminatorAttribute = (bool) $annot->attribute;
                 $classMetadata->xmlDiscriminatorCData = (bool) $annot->cdata;
+            } elseif ($annot instanceof VirtualProperty) {
+                $virtualPropertyMetadata = new ExpressionPropertyMetadata($name, $annot->name, $annot->exp);
+                $propertiesMetadata[] = $virtualPropertyMetadata;
+                $propertiesAnnotations[] = $annot->options;
             }
         }
 

--- a/src/JMS/Serializer/Metadata/Driver/XmlDriver.php
+++ b/src/JMS/Serializer/Metadata/Driver/XmlDriver.php
@@ -22,6 +22,7 @@ use JMS\Serializer\GraphNavigator;
 use JMS\Serializer\Exception\RuntimeException;
 use JMS\Serializer\Exception\XmlErrorException;
 use JMS\Serializer\Annotation\ExclusionPolicy;
+use JMS\Serializer\Metadata\ExpressionPropertyMetadata;
 use JMS\Serializer\Metadata\PropertyMetadata;
 use JMS\Serializer\Metadata\VirtualPropertyMetadata;
 use Metadata\MethodMetadata;
@@ -114,11 +115,15 @@ class XmlDriver extends AbstractFileDriver
         }
 
         foreach ($elem->xpath('./virtual-property') as $method) {
-            if ( ! isset($method->attributes()->method)) {
-                throw new RuntimeException('The method attribute must be set for all virtual-property elements.');
-            }
 
-            $virtualPropertyMetadata = new VirtualPropertyMetadata($name, (string) $method->attributes()->method);
+            if (isset($method->attributes()->expression)) {
+                $virtualPropertyMetadata = new ExpressionPropertyMetadata($name, (string)$method->attributes()->name, (string)$method->attributes()->expression);
+            } else {
+                if ( ! isset($method->attributes()->method)) {
+                    throw new RuntimeException('The method attribute must be set for all virtual-property elements.');
+                }
+                $virtualPropertyMetadata = new VirtualPropertyMetadata($name, (string) $method->attributes()->method);
+            }
 
             $propertiesMetadata[] = $virtualPropertyMetadata;
             $propertiesNodes[] = $method;

--- a/src/JMS/Serializer/Metadata/Driver/YamlDriver.php
+++ b/src/JMS/Serializer/Metadata/Driver/YamlDriver.php
@@ -21,6 +21,7 @@ namespace JMS\Serializer\Metadata\Driver;
 use JMS\Serializer\GraphNavigator;
 use JMS\Serializer\Exception\RuntimeException;
 use JMS\Serializer\Annotation\ExclusionPolicy;
+use JMS\Serializer\Metadata\ExpressionPropertyMetadata;
 use Metadata\MethodMetadata;
 use JMS\Serializer\Metadata\PropertyMetadata;
 use JMS\Serializer\Metadata\VirtualPropertyMetadata;
@@ -51,12 +52,17 @@ class YamlDriver extends AbstractFileDriver
         $propertiesMetadata = array();
         if (array_key_exists('virtual_properties', $config)) {
             foreach ($config['virtual_properties'] as $methodName => $propertySettings) {
-                if ( ! $class->hasMethod($methodName)) {
-                    throw new RuntimeException('The method '.$methodName.' not found in class '.$class->name);
+                if (isset($propertySettings['exp'])) {
+                    $virtualPropertyMetadata = new ExpressionPropertyMetadata( $name, $methodName, $propertySettings['exp']);
+                    unset($propertySettings['exp']);
+
+                } else {
+
+                    if ( ! $class->hasMethod($methodName)) {
+                        throw new RuntimeException('The method '.$methodName.' not found in class '.$class->name);
+                    }
+                    $virtualPropertyMetadata = new VirtualPropertyMetadata($name, $methodName);
                 }
-
-                $virtualPropertyMetadata = new VirtualPropertyMetadata($name, $methodName);
-
                 $propertiesMetadata[$methodName] = $virtualPropertyMetadata;
                 $config['properties'][$methodName] = $propertySettings;
             }

--- a/src/JMS/Serializer/Metadata/ExpressionPropertyMetadata.php
+++ b/src/JMS/Serializer/Metadata/ExpressionPropertyMetadata.php
@@ -18,6 +18,8 @@
 
 namespace JMS\Serializer\Metadata;
 
+use JMS\Serializer\Exception\ExpressionLanguageRequiredException;
+
 /**
  * @Annotation
  * @Target("METHOD")
@@ -49,12 +51,12 @@ class ExpressionPropertyMetadata extends PropertyMetadata
      */
     public function getValue($object)
     {
-        throw new \LogicException('This property requires the expression evaluator to be enabled.');
+        throw new ExpressionLanguageRequiredException(sprintf('The property %s on %s requires the expression evaluator to be enabled.', $this->name, $this->class));
     }
 
     public function setValue($obj, $value)
     {
-        throw new \LogicException('This property requires the expression evaluator to be enabled.');
+        throw new \LogicException('ExpressionPropertyMetadata is immutable.');
     }
 
     public function serialize()

--- a/src/JMS/Serializer/Metadata/ExpressionPropertyMetadata.php
+++ b/src/JMS/Serializer/Metadata/ExpressionPropertyMetadata.php
@@ -1,0 +1,125 @@
+<?php
+
+/*
+ * Copyright 2016 Johannes M. Schmitt <schmittjoh@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace JMS\Serializer\Metadata;
+
+/**
+ * @Annotation
+ * @Target("METHOD")
+ *
+ * @author Asmir Mustafic <goetas@gmail.com>
+ */
+class ExpressionPropertyMetadata extends PropertyMetadata
+{
+    /**
+     * @var string
+     */
+    public $expression;
+
+    public function __construct($class, $fieldName, $expression)
+    {
+        $this->class = $class;
+        $this->name = $fieldName;
+        $this->expression = $expression;
+        $this->readOnly = true;
+    }
+
+    public function setAccessor($type, $getter = null, $setter = null)
+    {
+    }
+
+    /**
+     * @param object $object
+     * @return mixed
+     */
+    public function getValue($object)
+    {
+        throw new \LogicException('This property requires the expression evaluator to be enabled.');
+    }
+
+    public function setValue($obj, $value)
+    {
+        throw new \LogicException('This property requires the expression evaluator to be enabled.');
+    }
+
+    public function serialize()
+    {
+        return serialize(array(
+            $this->sinceVersion,
+            $this->untilVersion,
+            $this->groups,
+            $this->serializedName,
+            $this->type,
+            $this->xmlCollection,
+            $this->xmlCollectionInline,
+            $this->xmlEntryName,
+            $this->xmlKeyAttribute,
+            $this->xmlAttribute,
+            $this->xmlValue,
+            $this->xmlNamespace,
+            $this->xmlKeyValuePairs,
+            $this->xmlElementCData,
+            $this->xmlAttributeMap,
+            $this->maxDepth,
+            $this->getter,
+            $this->setter,
+            $this->inline,
+            $this->readOnly,
+            $this->class,
+            $this->name,
+            'excludeIf' => $this->excludeIf,
+            'expression' => $this->expression,
+        ));
+    }
+
+    public function unserialize($str)
+    {
+        $unserialized = unserialize($str);
+        list(
+            $this->sinceVersion,
+            $this->untilVersion,
+            $this->groups,
+            $this->serializedName,
+            $this->type,
+            $this->xmlCollection,
+            $this->xmlCollectionInline,
+            $this->xmlEntryName,
+            $this->xmlKeyAttribute,
+            $this->xmlAttribute,
+            $this->xmlValue,
+            $this->xmlNamespace,
+            $this->xmlKeyValuePairs,
+            $this->xmlElementCData,
+            $this->xmlAttributeMap,
+            $this->maxDepth,
+            $this->getter,
+            $this->setter,
+            $this->inline,
+            $this->readOnly,
+            $this->class,
+            $this->name
+        ) = $unserialized;
+
+        if (isset($unserialized['excludeIf'])){
+            $this->excludeIf = $unserialized['excludeIf'];
+        }
+        if (isset($unserialized['expression'])){
+            $this->expression = $unserialized['expression'];
+        }
+    }
+}

--- a/src/JMS/Serializer/XmlDeserializationVisitor.php
+++ b/src/JMS/Serializer/XmlDeserializationVisitor.php
@@ -234,7 +234,7 @@ class XmlDeserializationVisitor extends AbstractVisitor
             $attributes = $data->attributes($metadata->xmlNamespace);
             if (isset($attributes[$name])) {
                 $v = $this->navigator->accept($attributes[$name], $metadata->type, $context);
-                $metadata->setValue($this->currentObject, $v);
+                $this->accessor->setValue($this->currentObject, $v, $metadata);
             }
 
             return;
@@ -242,7 +242,7 @@ class XmlDeserializationVisitor extends AbstractVisitor
 
         if ($metadata->xmlValue) {
             $v = $this->navigator->accept($data, $metadata->type, $context);
-            $metadata->setValue($this->currentObject, $v);
+            $this->accessor->setValue($this->currentObject, $v, $metadata);
 
             return;
         }
@@ -256,7 +256,7 @@ class XmlDeserializationVisitor extends AbstractVisitor
             $this->setCurrentMetadata($metadata);
             $v = $this->navigator->accept($enclosingElem, $metadata->type, $context);
             $this->revertCurrentMetadata();
-            $metadata->setValue($this->currentObject, $v);
+            $this->accessor->setValue($this->currentObject, $v, $metadata);
 
             return;
         }
@@ -285,7 +285,7 @@ class XmlDeserializationVisitor extends AbstractVisitor
 
         $v = $this->navigator->accept($node, $metadata->type, $context);
 
-        $metadata->setValue($this->currentObject, $v);
+        $this->accessor->setValue($this->currentObject, $v, $metadata);
     }
 
     public function endVisitingObject(ClassMetadata $metadata, $data, array $type, Context $context)

--- a/src/JMS/Serializer/XmlSerializationVisitor.php
+++ b/src/JMS/Serializer/XmlSerializationVisitor.php
@@ -18,9 +18,11 @@
 
 namespace JMS\Serializer;
 
+use JMS\Serializer\Accessor\AccessorStrategyInterface;
 use JMS\Serializer\Exception\RuntimeException;
 use JMS\Serializer\Metadata\ClassMetadata;
 use JMS\Serializer\Metadata\PropertyMetadata;
+use JMS\Serializer\Naming\PropertyNamingStrategyInterface;
 
 /**
  * XmlSerializationVisitor.
@@ -47,9 +49,9 @@ class XmlSerializationVisitor extends AbstractVisitor
     /** @var boolean */
     private $formatOutput;
 
-    public function __construct($namingStrategy)
+    public function __construct(PropertyNamingStrategyInterface $namingStrategy, AccessorStrategyInterface $accessorStrategy = null)
     {
-        parent::__construct($namingStrategy);
+        parent::__construct($namingStrategy, $accessorStrategy);
         $this->objectMetadataStack = new \SplStack;
         $this->formatOutput = true;
     }
@@ -228,7 +230,7 @@ class XmlSerializationVisitor extends AbstractVisitor
 
     public function visitProperty(PropertyMetadata $metadata, $object, Context $context)
     {
-        $v = $metadata->getValue($object);
+        $v = $this->accessor->getValue($object, $metadata);
 
         if (null === $v && $context->shouldSerializeNull() !== true) {
             return;

--- a/src/JMS/Serializer/YamlSerializationVisitor.php
+++ b/src/JMS/Serializer/YamlSerializationVisitor.php
@@ -18,6 +18,7 @@
 
 namespace JMS\Serializer;
 
+use JMS\Serializer\Accessor\AccessorStrategyInterface;
 use Symfony\Component\Yaml\Inline;
 use JMS\Serializer\Metadata\PropertyMetadata;
 use JMS\Serializer\Naming\PropertyNamingStrategyInterface;
@@ -39,9 +40,9 @@ class YamlSerializationVisitor extends AbstractVisitor
     private $metadataStack;
     private $currentMetadata;
 
-    public function __construct(PropertyNamingStrategyInterface $namingStrategy)
+    public function __construct(PropertyNamingStrategyInterface $namingStrategy, AccessorStrategyInterface $accessorStrategy = null)
     {
-        parent::__construct($namingStrategy);
+        parent::__construct($namingStrategy, $accessorStrategy);
 
         $this->writer = new Writer();
     }
@@ -159,7 +160,7 @@ class YamlSerializationVisitor extends AbstractVisitor
 
     public function visitProperty(PropertyMetadata $metadata, $data, Context $context)
     {
-        $v = $metadata->getValue($data);
+        $v = $this->accessor->getValue($data, $metadata);
 
         if (null === $v && $context->shouldSerializeNull() !== true) {
             return;

--- a/tests/JMS/Serializer/Tests/Fixtures/AuthorExpressionAccess.php
+++ b/tests/JMS/Serializer/Tests/Fixtures/AuthorExpressionAccess.php
@@ -1,0 +1,59 @@
+<?php
+
+/*
+ * Copyright 2016 Johannes M. Schmitt <schmittjoh@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace JMS\Serializer\Tests\Fixtures;
+
+use JMS\Serializer\Annotation as Serializer;
+
+/**
+ * @Serializer\VirtualProperty("firstName", exp="object.getFirstName()", options={@Serializer\SerializedName("my_first_name")})
+ */
+class AuthorExpressionAccess
+{
+    private $id;
+    /**
+     * @Serializer\Exclude()
+     */
+    private $firstName;
+
+    /**
+     * @Serializer\Exclude()
+     */
+    private $lastName;
+
+    public function __construct($id, $firstName, $lastName)
+    {
+        $this->id = $id;
+        $this->firstName = $firstName;
+        $this->lastName = $lastName;
+    }
+
+    public function getFirstName()
+    {
+        return $this->firstName;
+    }
+
+    /**
+     * @Serializer\VirtualProperty()
+     */
+    public function getLastName()
+    {
+        return $this->lastName;
+    }
+
+}

--- a/tests/JMS/Serializer/Tests/Metadata/Driver/BaseDriverTest.php
+++ b/tests/JMS/Serializer/Tests/Metadata/Driver/BaseDriverTest.php
@@ -156,6 +156,15 @@ abstract class BaseDriverTest extends \PHPUnit_Framework_TestCase
         $this->assertNotNull($m);
     }
 
+    public function testExpressionVirtualProperty()
+    {
+        /** @var $m ClassMetadata */
+        $m = $this->getDriver()->loadMetadataForClass(new \ReflectionClass('JMS\Serializer\Tests\Fixtures\AuthorExpressionAccess'));
+
+        $keys = array_keys($m->propertyMetadata);
+        $this->assertEquals(['firstName', 'lastName', 'id'], $keys);
+    }
+
     public function testLoadDiscriminator()
     {
         /** @var $m ClassMetadata */

--- a/tests/JMS/Serializer/Tests/Metadata/Driver/php/AuthorExpressionAccess.php
+++ b/tests/JMS/Serializer/Tests/Metadata/Driver/php/AuthorExpressionAccess.php
@@ -1,0 +1,19 @@
+<?php
+
+use JMS\Serializer\Metadata\ClassMetadata;
+use JMS\Serializer\Metadata\VirtualPropertyMetadata;
+use \JMS\Serializer\Metadata\ExpressionPropertyMetadata;
+use \JMS\Serializer\Metadata\PropertyMetadata;
+
+$metadata = new ClassMetadata('JMS\Serializer\Tests\Fixtures\AuthorExpressionAccess');
+
+$p = new ExpressionPropertyMetadata('JMS\Serializer\Tests\Fixtures\AuthorExpressionAccess', 'firstName', 'object.getFirstName()');
+$metadata->addPropertyMetadata($p);
+
+$p = new VirtualPropertyMetadata('JMS\Serializer\Tests\Fixtures\AuthorExpressionAccess', 'getLastName');
+$metadata->addPropertyMetadata($p);
+
+$p = new PropertyMetadata('JMS\Serializer\Tests\Fixtures\AuthorExpressionAccess', 'id');
+$metadata->addPropertyMetadata($p);
+
+return $metadata;

--- a/tests/JMS/Serializer/Tests/Metadata/Driver/xml/AuthorExpressionAccess.xml
+++ b/tests/JMS/Serializer/Tests/Metadata/Driver/xml/AuthorExpressionAccess.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<serializer>
+    <class name="JMS\Serializer\Tests\Fixtures\AuthorExpressionAccess">
+        <property name="id"/>
+        <virtual-property name="firstName" expression="object.getFirstName()"/>
+        <virtual-property name="lastName" method="getLastName"/>
+    </class>
+</serializer>

--- a/tests/JMS/Serializer/Tests/Metadata/Driver/yml/AuthorExpressionAccess.yml
+++ b/tests/JMS/Serializer/Tests/Metadata/Driver/yml/AuthorExpressionAccess.yml
@@ -1,0 +1,11 @@
+JMS\Serializer\Tests\Fixtures\AuthorExpressionAccess:
+    xml_root_name: author
+    properties:
+        id:
+            expose: true
+    virtual_properties:
+        firstName:
+            exp: object.getFirstName()
+        getLastName:
+            expose: true
+

--- a/tests/JMS/Serializer/Tests/Serializer/JsonSerializationTest.php
+++ b/tests/JMS/Serializer/Tests/Serializer/JsonSerializationTest.php
@@ -108,6 +108,7 @@ class JsonSerializationTest extends BaseSerializationTest
             $outputs['nullable_arrays'] = '{"empty_inline":[],"not_empty_inline":["not_empty_inline"],"empty_not_inline":[],"not_empty_not_inline":["not_empty_not_inline"],"empty_not_inline_skip":[],"not_empty_not_inline_skip":["not_empty_not_inline_skip"]}';
             $outputs['object_with_object_property_no_array_to_author'] = '{"foo": "bar", "author": "baz"}';
             $outputs['object_with_object_property'] = '{"foo": "bar", "author": {"full_name": "baz"}}';
+            $outputs['author_expression'] = '{"my_first_name":"Ruud","last_name":"Kamphuis","id":123}';
         }
 
         if (!isset($outputs[$key])) {

--- a/tests/JMS/Serializer/Tests/Serializer/xml/author_expression.xml
+++ b/tests/JMS/Serializer/Tests/Serializer/xml/author_expression.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<result>
+  <my_first_name><![CDATA[Ruud]]></my_first_name>
+  <last_name><![CDATA[Kamphuis]]></last_name>
+  <id>123</id>
+</result>

--- a/tests/JMS/Serializer/Tests/Serializer/yml/author_expression.yml
+++ b/tests/JMS/Serializer/Tests/Serializer/yml/author_expression.yml
@@ -1,0 +1,3 @@
+my_first_name: Ruud
+last_name: Kamphuis
+id: 123


### PR DESCRIPTION
This PR adds to the serializer the possibility to use the symfony expression language to expose virtual properties.


A lot of use cases that currently require custom handlers or post/pre serialization listeners, with this can be implemented in a more easy way and with almost no code. :)

An example:

```php
/**
 * @Serializer\VirtualProperty(
 *     "firstName",
 *     exp="object.getFirstName()",
 *     options={@Serializer\SerializedName("my_first_name"), @Serializer\Type("string")}
 *  )
 * @Serializer\VirtualProperty(
 *     "profile_views",
 *     exp="service('app.profile_views_service').getViews(object)"
 *  )
 */
class Author
{
    /**
     * @Serializer\Expose()
     */
    private $id;

    /**
     * @Serializer\Exclude()
     */
    private $firstName;

    public function getId()
    {
        return $this->id;
    }

    public function getFirstName()
    {
        return $this->firstName;
    }
}
```

Anybody interested to review?


closes https://github.com/schmittjoh/serializer/issues/359 https://github.com/schmittjoh/serializer/issues/171 https://github.com/schmittjoh/serializer/issues/22 https://github.com/schmittjoh/JMSSerializerBundle/issues/403 https://github.com/schmittjoh/serializer/issues/359

