### PR TITLE
Use namespace from bottom of object stack

### DIFF
--- a/src/JMS/Serializer/XmlDeserializationVisitor.php
+++ b/src/JMS/Serializer/XmlDeserializationVisitor.php
@@ -146,7 +146,7 @@ class XmlDeserializationVisitor extends AbstractVisitor
         $namespace = null !== $this->currentMetadata && $this->currentMetadata->xmlEntryNamespace ? $this->currentMetadata->xmlEntryNamespace : null;
 
         if ($namespace === null && $this->objectMetadataStack->count()) {
-            $classMetadata = $this->objectMetadataStack->top();
+            $classMetadata = $this->objectMetadataStack->bottom();
             $namespace = isset($classMetadata->xmlNamespaces[''])?$classMetadata->xmlNamespaces['']:$namespace;
         }
 

--- a/src/JMS/Serializer/XmlSerializationVisitor.php
+++ b/src/JMS/Serializer/XmlSerializationVisitor.php
@@ -295,7 +295,7 @@ class XmlSerializationVisitor extends AbstractVisitor
             if (null !== $metadata->xmlNamespace) {
                 $element = $this->createElement($elementName, $metadata->xmlNamespace);
             } else {
-                $defaultNamespace = $this->getClassDefaultNamespace($this->objectMetadataStack->top());
+                $defaultNamespace = $this->getClassDefaultNamespace($this->objectMetadataStack->bottom());
                 $element = $this->createElement($elementName, $defaultNamespace);
             }
             $this->setCurrentNode($element);
@@ -454,7 +454,7 @@ class XmlSerializationVisitor extends AbstractVisitor
 
     private function createElement($tagName, $namespace = null)
     {
-        if (null === $namespace) {
+        if (null === $namespace || $this->document->isDefaultNamespace($namespace)) {
             return $this->document->createElement($tagName);
         }
         if ($this->currentNode->isDefaultNamespace($namespace)) {

--- a/tests/JMS/Serializer/Tests/Fixtures/ObjectList.php
+++ b/tests/JMS/Serializer/Tests/Fixtures/ObjectList.php
@@ -1,0 +1,53 @@
+<?php
+
+/*
+ * Copyright 2016 Johannes M. Schmitt <schmittjoh@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace JMS\Serializer\Tests\Fixtures;
+
+use JMS\Serializer\Annotation as Serializer;
+
+class ObjectList
+{
+    /**
+     * @var SimpleObject[]
+     *
+     * @Serializer\Type("array<JMS\Serializer\Tests\Fixtures\SimpleObject>")
+     * @Serializer\SerializedName("children")
+     * @Serializer\XmlList(inline = false, entry = "child")
+     */
+    public $children = [];
+
+    /**
+     * @var ObjectList
+     *
+     * @Serializer\Type("JMS\Serializer\Tests\Fixtures\ObjectList")
+     * @Serializer\SerializedName("list")
+     */
+    public $objectList;
+
+    /**
+     * ObjectList constructor.
+     *
+     * @param array $children
+     * @param null  $objectList
+     */
+    public function __construct($children = [], $objectList = null)
+    {
+        $this->children = $children;
+        $this->objectList = $objectList;
+    }
+}

--- a/tests/JMS/Serializer/Tests/Fixtures/ObjectWithNamespacesAndListInList.php
+++ b/tests/JMS/Serializer/Tests/Fixtures/ObjectWithNamespacesAndListInList.php
@@ -1,0 +1,40 @@
+<?php
+
+/*
+ * Copyright 2016 Johannes M. Schmitt <schmittjoh@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace JMS\Serializer\Tests\Fixtures;
+
+use JMS\Serializer\Annotation\SerializedName;
+use JMS\Serializer\Annotation\Type;
+use JMS\Serializer\Annotation\XmlRoot;
+use JMS\Serializer\Annotation\XmlNamespace;
+use JMS\Serializer\Annotation\XmlList;
+
+/**
+ * @XmlRoot("ObjectWithNamespacesAndListInList", namespace="http://example.com/namespace")
+ * @XmlNamespace(uri="http://example.com/namespace")
+ */
+class ObjectWithNamespacesAndListInList
+{
+    /**
+     * @Type("array<JMS\Serializer\Tests\Fixtures\ObjectList>")
+     * @SerializedName("lists")
+     * @XmlList(inline = false, entry = "list")
+     */
+    public $lists = [];
+}
+

--- a/tests/JMS/Serializer/Tests/Serializer/XmlSerializationTest.php
+++ b/tests/JMS/Serializer/Tests/Serializer/XmlSerializationTest.php
@@ -30,6 +30,8 @@ use JMS\Serializer\Tests\Fixtures\Discriminator\ObjectWithXmlNotCDataDiscriminat
 use JMS\Serializer\Tests\Fixtures\Discriminator\ObjectWithXmlNotCDataDiscriminatorParent;
 use JMS\Serializer\Tests\Fixtures\InvalidUsageOfXmlValue;
 use JMS\Serializer\Exception\InvalidArgumentException;
+use JMS\Serializer\Tests\Fixtures\ObjectList;
+use JMS\Serializer\Tests\Fixtures\ObjectWithNamespacesAndListInList;
 use JMS\Serializer\Tests\Fixtures\PersonCollection;
 use JMS\Serializer\Tests\Fixtures\PersonLocation;
 use JMS\Serializer\Tests\Fixtures\Person;
@@ -39,6 +41,7 @@ use JMS\Serializer\Tests\Fixtures\ObjectWithXmlNamespaces;
 use JMS\Serializer\Tests\Fixtures\ObjectWithXmlRootNamespace;
 use JMS\Serializer\Tests\Fixtures\Input;
 use JMS\Serializer\Tests\Fixtures\SimpleClassObject;
+use JMS\Serializer\Tests\Fixtures\SimpleObject;
 use JMS\Serializer\Tests\Fixtures\SimpleSubClassObject;
 use JMS\Serializer\Tests\Fixtures\ObjectWithNamespacesAndList;
 use JMS\Serializer\XmlSerializationVisitor;
@@ -229,6 +232,28 @@ class XmlSerializationTest extends BaseSerializationTest
         $this->assertEquals(
             $object,
             $this->deserialize($this->getContent('object_with_namespaces_and_list'), get_class($object))
+        );
+    }
+
+    public function testObjectWithNamespacesAndListInList()
+    {
+        $object = new ObjectWithNamespacesAndListInList();
+
+        $list1 = new ObjectList([
+            new SimpleObject('test', 'test')
+        ]);
+        $list2 = new ObjectList([
+            new SimpleObject('test', 'test'),
+        ], $list1);
+        $object->lists[] = $list2;
+
+        $this->assertEquals(
+            $this->getContent('object_with_namespaces_and_list_in_list'),
+            $this->serialize($object, SerializationContext::create())
+        );
+        $this->assertEquals(
+            $object,
+            $this->deserialize($this->getContent('object_with_namespaces_and_list_in_list'), get_class($object))
         );
     }
 

--- a/tests/JMS/Serializer/Tests/Serializer/xml/object_with_namespaces_and_list_in_list.xml
+++ b/tests/JMS/Serializer/Tests/Serializer/xml/object_with_namespaces_and_list_in_list.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ObjectWithNamespacesAndListInList xmlns="http://example.com/namespace">
+  <lists>
+    <list>
+      <children>
+        <child>
+          <foo><![CDATA[test]]></foo>
+          <moo><![CDATA[test]]></moo>
+          <camel_case><![CDATA[boo]]></camel_case>
+        </child>
+      </children>
+      <list>
+        <children>
+          <child>
+            <foo><![CDATA[test]]></foo>
+            <moo><![CDATA[test]]></moo>
+            <camel_case><![CDATA[boo]]></camel_case>
+          </child>
+        </children>
+      </list>
+    </list>
+  </lists>
+</ObjectWithNamespacesAndListInList>


### PR DESCRIPTION
I encountered problems with unserializing xml lists in xml lists with a default namespace from the root element.
The cause is, that you use the top element of the stack (newest one) not the bottom element (root).

I also added a test which fails with the previous implementation.