### PR TITLE
Serialize correctly empty intervals according to ISO-8601

### DIFF
--- a/src/JMS/Serializer/Handler/DateHandler.php
+++ b/src/JMS/Serializer/Handler/DateHandler.php
@@ -248,6 +248,10 @@ class DateHandler implements SubscribingHandlerInterface
             $format .= $dateInterval->s.'S';
         }
 
+        if ($format === 'P') {
+            $format = 'P0DT0S';
+        }
+
         return $format;
     }
 }

--- a/tests/JMS/Serializer/Tests/Serializer/DateIntervalFormatTest.php
+++ b/tests/JMS/Serializer/Tests/Serializer/DateIntervalFormatTest.php
@@ -26,6 +26,12 @@ class DateIntervalFormatTest extends \PHPUnit_Framework_TestCase
     {
         $dtf = new DateHandler();
 
+        $iso8601DateIntervalString = $dtf->format(new \DateInterval('P0D'));
+        $this->assertEquals($iso8601DateIntervalString, 'P0DT0S');
+
+        $iso8601DateIntervalString = $dtf->format(new \DateInterval('P0DT0S'));
+        $this->assertEquals($iso8601DateIntervalString, 'P0DT0S');
+
         $iso8601DateIntervalString = $dtf->format(new \DateInterval('PT45M'));
 
         $this->assertEquals($iso8601DateIntervalString, 'PT45M');


### PR DESCRIPTION
This is an alternative implementation of https://github.com/schmittjoh/serializer/pull/503 and as pointed out in https://github.com/schmittjoh/serializer/pull/503#issuecomment-281642946 by @courentin it is a bug of the current implementation 

Thanks to @taavit for #503

Closes https://github.com/schmittjoh/serializer/pull/503