### PR TITLE
Include reference to cache

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,8 @@
         "twig/twig": "<1.12"
     },
     "suggest": {
-        "symfony/yaml": "Required if you'd like to serialize data to YAML format."
+        "symfony/yaml": "Required if you'd like to serialize data to YAML format.",
+        "doctrine/cache": "Required if you like to use cache functionality."
     },
     "require-dev": {
         "ext-pdo_sqlite": "*",


### PR DESCRIPTION
Since the `require` section is not perfect for this dependency (who doesn't want cache in production?), can we have it in `suggest`?

In reference to: https://github.com/schmittjoh/serializer/issues/676