### PR TITLE
check that cache directory was not created before throwing exception

### DIFF
--- a/src/JMS/Serializer/SerializerBuilder.php
+++ b/src/JMS/Serializer/SerializerBuilder.php
@@ -464,7 +464,7 @@ class SerializerBuilder
             return;
         }
 
-        if (false === @mkdir($dir, 0777, true)) {
+        if (false === @mkdir($dir, 0777, true) && false === is_dir($dir)) {
             throw new RuntimeException(sprintf('Could not create directory "%s".', $dir));
         }
     }


### PR DESCRIPTION
In heavy load environment each deploy without warmed up cache triggers cache directory to be created. Due to race conditions some of the requests will win, others lose. To avoid 500 errors for others it makes sense to check one more time that directory was not actually created.

I thought about adding test case reproduce but cache directory is being created so deep and there are already checks right before an attempt to create it. So I decided to skip it.

Please let me know about it.