### PR TITLE
Use generic collection interface in handler

### DIFF
--- a/src/JMS/Serializer/Handler/ArrayCollectionHandler.php
+++ b/src/JMS/Serializer/Handler/ArrayCollectionHandler.php
@@ -32,10 +32,7 @@ class ArrayCollectionHandler implements SubscribingHandlerInterface
         $formats = array('json', 'xml', 'yml');
         $collectionTypes = array(
             'ArrayCollection',
-            'Doctrine\Common\Collections\ArrayCollection',
-            'Doctrine\ORM\PersistentCollection',
-            'Doctrine\ODM\MongoDB\PersistentCollection',
-            'Doctrine\ODM\PHPCR\PersistentCollection',
+            'Doctrine\Common\Collections\Collection',
         );
 
         foreach ($collectionTypes as $type) {


### PR DESCRIPTION
I came across this when dealing with custom collections introduced in MongoDB ODM 1.1. The `ArrayCollectionHandler` currently only deals with selected collection classes, the ODM's `PersistentCollection` class being one of them.
With the introduction of custom collections in MongoDB ODM, not all persistent collections are of this class; instead they implement a new `PersistentCollectionInterface`, so that interface should be added to the list of collections in the handler.

When adding this, I thought there was no reason why the handler shouldn't just handle the generic collection interface defined in common, so I used that to avoid having to add new interfaces if implementations change. If you'd rather have me just add the new interface, please let me know.