### PR TITLE
Prevent fatal error when trying to deserialize object

### DIFF
--- a/src/JMS/Serializer/XmlDeserializationVisitor.php
+++ b/src/JMS/Serializer/XmlDeserializationVisitor.php
@@ -362,12 +362,16 @@ class XmlDeserializationVisitor extends AbstractVisitor
     /**
      * Retrieves internalSubset even in bugfixed php versions
      *
-     * @param \DOMDocumentType $child
-     * @param string $data
+     * @param mixed $data
+     *
      * @return string
      */
     private function getDomDocumentTypeEntitySubset($data)
     {
+        if (!is_string($data)) {
+            $data = (string) $data;
+        }
+
         $startPos = $endPos = stripos($data, '<!doctype');
         $braces = 0;
         do {


### PR DESCRIPTION
Fatal error may occur if passed into deserialization value was object, i.e.:
```
Fatal error: Cannot use object of type Guzzle\Http\EntityBody as array in vendor/jms/serializer/src/JMS/Serializer/XmlDeserializationVisitor.php on line 378
```