### PR TITLE
#292 added option to decide to make the deserialisation strict or not

### DIFF
--- a/src/JMS/Serializer/Annotation/Discriminator.php
+++ b/src/JMS/Serializer/Annotation/Discriminator.php
@@ -35,4 +35,7 @@ class Discriminator
 
     /** @var string[] */
     public $groups = array();
+
+    /** @var boolean */
+    public $strictdeserialize = true;
 }

--- a/src/JMS/Serializer/GraphNavigator.php
+++ b/src/JMS/Serializer/GraphNavigator.php
@@ -210,7 +210,13 @@ final class GraphNavigator
                 }
 
                 if ($context instanceof DeserializationContext && ! empty($metadata->discriminatorMap) && $type['name'] === $metadata->discriminatorBaseClass) {
-                    $metadata = $this->resolveMetadata($data, $metadata);
+                    try {
+                        $metadata = $this->resolveMetadata($data, $metadata);
+                    } catch(\LogicException $e) {
+                        if($metadata->discriminatorStrictDeserialize) {
+                            throw $e;
+                        }
+                    }
                 }
 
                 if (null !== $exclusionStrategy && $exclusionStrategy->shouldSkipClass($metadata, $context)) {

--- a/src/JMS/Serializer/Metadata/ClassMetadata.php
+++ b/src/JMS/Serializer/Metadata/ClassMetadata.php
@@ -53,6 +53,7 @@ class ClassMetadata extends MergeableClassMetadata
     public $handlerCallbacks = array();
 
     public $discriminatorDisabled = false;
+    public $discriminatorStrictDeserialize = true;
     public $discriminatorBaseClass;
     public $discriminatorFieldName;
     public $discriminatorValue;
@@ -62,7 +63,7 @@ class ClassMetadata extends MergeableClassMetadata
     public $xmlDiscriminatorAttribute = false;
     public $xmlDiscriminatorCData = true;
 
-    public function setDiscriminator($fieldName, array $map, array $groups = array())
+    public function setDiscriminator($fieldName, array $map, array $groups = array(), $strictdeserialize = true)
     {
         if (empty($fieldName)) {
             throw new \InvalidArgumentException('The $fieldName cannot be empty.');
@@ -76,6 +77,7 @@ class ClassMetadata extends MergeableClassMetadata
         $this->discriminatorFieldName = $fieldName;
         $this->discriminatorMap = $map;
         $this->discriminatorGroups = $groups;
+        $this->discriminatorStrictDeserialize = $strictdeserialize;
     }
 
     /**
@@ -176,6 +178,10 @@ class ClassMetadata extends MergeableClassMetadata
             $this->discriminatorDisabled = $object->discriminatorDisabled;
         }
 
+        if ($object->discriminatorStrictDeserialize !== null) {
+            $this->discriminatorStrictDeserialize = $object->discriminatorStrictDeserialize;
+        }
+
         if ($object->discriminatorMap) {
             $this->discriminatorFieldName = $object->discriminatorFieldName;
             $this->discriminatorMap = $object->discriminatorMap;
@@ -251,6 +257,7 @@ class ClassMetadata extends MergeableClassMetadata
             $this->customOrder,
             $this->handlerCallbacks,
             $this->discriminatorDisabled,
+            $this->discriminatorStrictDeserialize,
             $this->discriminatorBaseClass,
             $this->discriminatorFieldName,
             $this->discriminatorValue,
@@ -279,6 +286,7 @@ class ClassMetadata extends MergeableClassMetadata
             $this->customOrder,
             $this->handlerCallbacks,
             $this->discriminatorDisabled,
+            $this->discriminatorStrictDeserialize,
             $this->discriminatorBaseClass,
             $this->discriminatorFieldName,
             $this->discriminatorValue,

--- a/src/JMS/Serializer/Metadata/Driver/AnnotationDriver.php
+++ b/src/JMS/Serializer/Metadata/Driver/AnnotationDriver.php
@@ -100,7 +100,7 @@ class AnnotationDriver implements DriverInterface
                 if ($annot->disabled) {
                     $classMetadata->discriminatorDisabled = true;
                 } else {
-                    $classMetadata->setDiscriminator($annot->field, $annot->map, $annot->groups);
+                    $classMetadata->setDiscriminator($annot->field, $annot->map, $annot->groups, $annot->strictdeserialize);
                 }
             } elseif ($annot instanceof XmlDiscriminator) {
                 $classMetadata->xmlDiscriminatorAttribute = (bool) $annot->attribute;

--- a/src/JMS/Serializer/Metadata/Driver/XmlDriver.php
+++ b/src/JMS/Serializer/Metadata/Driver/XmlDriver.php
@@ -82,6 +82,10 @@ class XmlDriver extends AbstractFileDriver
             $discriminatorMap[(string) $entry->attributes()->value] = (string) $entry;
         }
 
+        if ('false' === (string) $elem->attributes()->{'discriminator-strict-deserialize'}) {
+            $metadata->discriminatorStrictDeserialize = false;
+        }
+
         if ('true' === (string) $elem->attributes()->{'discriminator-disabled'}) {
             $metadata->discriminatorDisabled = true;
         } elseif ( ! empty($discriminatorFieldName) || ! empty($discriminatorMap)) {

--- a/src/JMS/Serializer/Metadata/Driver/YamlDriver.php
+++ b/src/JMS/Serializer/Metadata/Driver/YamlDriver.php
@@ -284,6 +284,10 @@ class YamlDriver extends AbstractFileDriver
             if (isset($config['discriminator']['disabled']) && true === $config['discriminator']['disabled']) {
                 $metadata->discriminatorDisabled = true;
             } else {
+                if (isset($config['discriminator']['strict_deserialize'])) {
+                    $metadata->discriminatorStrictDeserialize = $config['discriminator']['strict_deserialize'];
+                }
+
                 if ( ! isset($config['discriminator']['field_name'])) {
                     throw new RuntimeException('The "field_name" attribute must be set for discriminators.');
                 }


### PR DESCRIPTION
Serializer requires an type attribute to be able to deserialize data when a discriminator map is used. this makes not always sense if the filed only contains a referenced id to an existing object. This option enables to set the strict type checking to true/false on the discriminator map.