### PR TITLE
Allow to configure the doctrine object constructor

### DIFF
--- a/src/JMS/Serializer/Construction/DoctrineObjectConstructor.php
+++ b/src/JMS/Serializer/Construction/DoctrineObjectConstructor.php
@@ -19,28 +19,40 @@
 namespace JMS\Serializer\Construction;
 
 use Doctrine\Common\Persistence\ManagerRegistry;
-use JMS\Serializer\VisitorInterface;
-use JMS\Serializer\Metadata\ClassMetadata;
 use JMS\Serializer\DeserializationContext;
+use JMS\Serializer\Exception\InvalidArgumentException;
+use JMS\Serializer\Exception\ObjectConstructionException;
+use JMS\Serializer\Metadata\ClassMetadata;
+use JMS\Serializer\VisitorInterface;
 
 /**
  * Doctrine object constructor for new (or existing) objects during deserialization.
  */
 class DoctrineObjectConstructor implements ObjectConstructorInterface
 {
+    const ON_MISSING_NULL = 'null';
+    const ON_MISSING_EXCEPTION = 'exception';
+    const ON_MISSING_FALLBACK = 'fallback';
+    /**
+     * @var string
+     */
+    private $fallbackStrategy;
+
     private $managerRegistry;
     private $fallbackConstructor;
 
     /**
      * Constructor.
      *
-     * @param ManagerRegistry            $managerRegistry     Manager registry
+     * @param ManagerRegistry $managerRegistry Manager registry
      * @param ObjectConstructorInterface $fallbackConstructor Fallback object constructor
+     * @param string $fallbackStrategy
      */
-    public function __construct(ManagerRegistry $managerRegistry, ObjectConstructorInterface $fallbackConstructor)
+    public function __construct(ManagerRegistry $managerRegistry, ObjectConstructorInterface $fallbackConstructor, $fallbackStrategy = self::ON_MISSING_NULL)
     {
         $this->managerRegistry     = $managerRegistry;
         $this->fallbackConstructor = $fallbackConstructor;
+        $this->fallbackStrategy = $fallbackStrategy;
     }
 
     /**
@@ -84,6 +96,19 @@ class DoctrineObjectConstructor implements ObjectConstructorInterface
 
         // Entity update, load it from database
         $object = $objectManager->find($metadata->name, $identifierList);
+
+        if (null === $object) {
+            switch ($this->fallbackStrategy) {
+                case self::ON_MISSING_NULL:
+                    return null;
+                case self::ON_MISSING_EXCEPTION:
+                    throw new ObjectConstructionException(sprintf("Entity %s can not be found", $metadata->name));
+                case self::ON_MISSING_FALLBACK:
+                    return $this->fallbackConstructor->construct($visitor, $metadata, $data, $type, $context);
+                default:
+                    throw new InvalidArgumentException("The provided fallback strategy for the object constructor is not valid");
+            }
+        }
 
         $objectManager->initializeObject($object);
 

--- a/src/JMS/Serializer/Exception/ObjectConstructionException.php
+++ b/src/JMS/Serializer/Exception/ObjectConstructionException.php
@@ -1,0 +1,28 @@
+<?php
+
+/*
+ * Copyright 2016 Johannes M. Schmitt <schmittjoh@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace JMS\Serializer\Exception;
+
+/**
+ * InvalidArgumentException for the Serializer.
+ *
+ * @author Asmir Mustafic <goetas@gmail.com>
+ */
+class ObjectConstructionException extends RuntimeException implements Exception
+{
+}

--- a/tests/JMS/Serializer/Tests/Fixtures/Doctrine/Author.php
+++ b/tests/JMS/Serializer/Tests/Fixtures/Doctrine/Author.php
@@ -37,9 +37,10 @@ class Author
      */
     private $name;
 
-    public function __construct($name)
+    public function __construct($name, $id = null)
     {
         $this->name = $name;
+        $this->id = $id;
     }
 
     public function getName()

--- a/tests/JMS/Serializer/Tests/Serializer/Doctrine/ObjectConstructorTest.php
+++ b/tests/JMS/Serializer/Tests/Serializer/Doctrine/ObjectConstructorTest.php
@@ -1,0 +1,280 @@
+<?php
+
+namespace JMS\Serializer\Tests\Serializer\Doctrine;
+
+use Doctrine\Common\Annotations\AnnotationReader;
+use Doctrine\Common\Annotations\Reader;
+use Doctrine\Common\Persistence\AbstractManagerRegistry;
+use Doctrine\Common\Persistence\ManagerRegistry;
+use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\DriverManager;
+use Doctrine\ORM\Configuration;
+use Doctrine\ORM\EntityManager;
+use Doctrine\ORM\Mapping\Driver\AnnotationDriver;
+use Doctrine\ORM\ORMException;
+use Doctrine\ORM\Tools\SchemaTool;
+use JMS\Serializer\Builder\CallbackDriverFactory;
+use JMS\Serializer\Builder\DefaultDriverFactory;
+use JMS\Serializer\Construction\DoctrineObjectConstructor;
+use JMS\Serializer\Construction\ObjectConstructorInterface;
+use JMS\Serializer\DeserializationContext;
+use JMS\Serializer\Metadata\ClassMetadata;
+use JMS\Serializer\Metadata\Driver\DoctrineTypeDriver;
+use JMS\Serializer\Serializer;
+use JMS\Serializer\SerializerBuilder;
+use JMS\Serializer\Tests\Fixtures\Doctrine\Author;
+use JMS\Serializer\Tests\Fixtures\Doctrine\SingleTableInheritance\Excursion;
+use JMS\Serializer\VisitorInterface;
+
+class ObjectConstructorTest extends \PHPUnit_Framework_TestCase
+{
+    /** @var ManagerRegistry */
+    private $registry;
+
+    /** @var Serializer */
+    private $serializer;
+
+    /** @var VisitorInterface */
+    private $visitor;
+
+    /** @var DeserializationContext */
+    private $context;
+
+    public function testFindEntity()
+    {
+        $em = $this->registry->getManager();
+
+        $author = new Author('John', 5);
+        $em->persist($author);
+        $em->flush();
+        $em->clear();
+
+        $fallback = $this->getMockBuilder(ObjectConstructorInterface::class)->getMock();
+
+        $type = array('name' => Author::class, 'params' => array());
+        $class = new ClassMetadata(Author::class);
+
+        $constructor = new DoctrineObjectConstructor($this->registry, $fallback);
+        $authorFetched = $constructor->construct($this->visitor, $class, ['id' => 5], $type, $this->context);
+
+        $this->assertEquals($author, $authorFetched);
+    }
+
+    public function testFindManagedEntity()
+    {
+        $em = $this->registry->getManager();
+
+        $author = new Author('John', 5);
+        $em->persist($author);
+        $em->flush();
+
+        $fallback = $this->getMockBuilder(ObjectConstructorInterface::class)->getMock();
+
+        $type = array('name' => Author::class, 'params' => array());
+        $class = new ClassMetadata(Author::class);
+
+        $constructor = new DoctrineObjectConstructor($this->registry, $fallback);
+        $authorFetched = $constructor->construct($this->visitor, $class, ['id' => 5], $type, $this->context);
+
+        $this->assertSame($author, $authorFetched);
+    }
+
+    public function testMissingAuthor()
+    {
+        $fallback = $this->getMockBuilder(ObjectConstructorInterface::class)->getMock();
+
+        $type = array('name' => Author::class, 'params' => array());
+        $class = new ClassMetadata(Author::class);
+
+        $constructor = new DoctrineObjectConstructor($this->registry, $fallback);
+        $author = $constructor->construct($this->visitor, $class, ['id' => 5], $type, $this->context);
+        $this->assertNull($author);
+    }
+
+    public function testMissingAuthorFallback()
+    {
+        $author = new Author('John');
+
+        $fallback = $this->getMockBuilder(ObjectConstructorInterface::class)->getMock();
+        $fallback->expects($this->once())->method('construct')->willReturn($author);
+
+        $type = array('name' => Author::class, 'params' => array());
+        $class = new ClassMetadata(Author::class);
+
+        $constructor = new DoctrineObjectConstructor($this->registry, $fallback, DoctrineObjectConstructor::ON_MISSING_FALLBACK);
+        $authorFetched = $constructor->construct($this->visitor, $class, ['id' => 5], $type, $this->context);
+        $this->assertSame($author, $authorFetched);
+    }
+
+    /**
+     * @expectedException \JMS\Serializer\Exception\ObjectConstructionException
+     */
+    public function testMissingAuthorException()
+    {
+        $fallback = $this->getMockBuilder(ObjectConstructorInterface::class)->getMock();
+
+        $type = array('name' => Author::class, 'params' => array());
+        $class = new ClassMetadata(Author::class);
+
+        $constructor = new DoctrineObjectConstructor($this->registry, $fallback, DoctrineObjectConstructor::ON_MISSING_EXCEPTION);
+        $constructor->construct($this->visitor, $class, ['id' => 5], $type, $this->context);
+    }
+
+    /**
+     * @expectedException \JMS\Serializer\Exception\InvalidArgumentException
+     */
+    public function testInvalidArg()
+    {
+        $fallback = $this->getMockBuilder(ObjectConstructorInterface::class)->getMock();
+
+        $type = array('name' => Author::class, 'params' => array());
+        $class = new ClassMetadata(Author::class);
+
+        $constructor = new DoctrineObjectConstructor($this->registry, $fallback, 'foo');
+        $constructor->construct($this->visitor, $class, ['id' => 5], $type, $this->context);
+    }
+
+    public function testMissingData()
+    {
+        $author = new Author('John');
+
+        $fallback = $this->getMockBuilder(ObjectConstructorInterface::class)->getMock();
+        $fallback->expects($this->once())->method('construct')->willReturn($author);
+
+        $type = array('name' => Author::class, 'params' => array());
+        $class = new ClassMetadata(Author::class);
+
+        $constructor = new DoctrineObjectConstructor($this->registry, $fallback, 'foo');
+        $authorFetched = $constructor->construct($this->visitor, $class, ['foo' => 5], $type, $this->context);
+        $this->assertSame($author, $authorFetched);
+    }
+
+    protected function setUp()
+    {
+        $this->visitor = $this->getMockBuilder('JMS\Serializer\VisitorInterface')->getMock();
+        $this->context = $this->getMockBuilder('JMS\Serializer\DeserializationContext')->getMock();
+
+        $connection = $this->createConnection();
+        $entityManager = $this->createEntityManager($connection);
+
+        $this->registry = $registry = new SimpleBaseManagerRegistry(
+            function ($id) use ($connection, $entityManager) {
+                switch ($id) {
+                    case 'default_connection':
+                        return $connection;
+
+                    case 'default_manager':
+                        return $entityManager;
+
+                    default:
+                        throw new \RuntimeException(sprintf('Unknown service id "%s".', $id));
+                }
+            }
+        );
+
+        $this->serializer = SerializerBuilder::create()
+            ->setMetadataDriverFactory(new CallbackDriverFactory(
+                function (array $metadataDirs, Reader $annotationReader) use ($registry) {
+                    $defaultFactory = new DefaultDriverFactory();
+
+                    return new DoctrineTypeDriver($defaultFactory->createDriver($metadataDirs, $annotationReader), $registry);
+                }
+            ))
+            ->build();
+
+        $this->prepareDatabase();
+    }
+
+    private function prepareDatabase()
+    {
+        /** @var EntityManager $em */
+        $em = $this->registry->getManager();
+
+        $tool = new SchemaTool($em);
+        $tool->createSchema($em->getMetadataFactory()->getAllMetadata());
+    }
+
+    private function createConnection()
+    {
+        $con = DriverManager::getConnection(array(
+            'driver' => 'pdo_sqlite',
+            'memory' => true,
+        ));
+
+        return $con;
+    }
+
+    private function createEntityManager(Connection $con)
+    {
+        $cfg = new Configuration();
+        $cfg->setMetadataDriverImpl(new AnnotationDriver(new AnnotationReader(), array(
+            __DIR__ . '/../../Fixtures/Doctrine',
+        )));
+        $cfg->setAutoGenerateProxyClasses(true);
+        $cfg->setProxyNamespace('JMS\Serializer\DoctrineProxy');
+        $cfg->setProxyDir(sys_get_temp_dir() . '/serializer-test-proxies');
+
+        $em = EntityManager::create($con, $cfg);
+
+        return $em;
+    }
+}
+
+\Doctrine\DBAL\Types\Type::addType('Author', 'Doctrine\DBAL\Types\StringType');
+\Doctrine\DBAL\Types\Type::addType('some_custom_type', 'Doctrine\DBAL\Types\StringType');
+
+class SimpleBaseManagerRegistry extends AbstractManagerRegistry
+{
+    private $services = array();
+    private $serviceCreator;
+
+    public function __construct($serviceCreator, $name = 'anonymous', array $connections = array('default' => 'default_connection'), array $managers = array('default' => 'default_manager'), $defaultConnection = null, $defaultManager = null, $proxyInterface = 'Doctrine\Common\Persistence\Proxy')
+    {
+        if (null === $defaultConnection) {
+            list($defaultConnection,) = each($connections);
+        }
+        if (null === $defaultManager) {
+            list($defaultManager,) = each($managers);
+        }
+
+        parent::__construct($name, $connections, $managers, $defaultConnection, $defaultManager, $proxyInterface);
+
+        if (!is_callable($serviceCreator)) {
+            throw new \InvalidArgumentException('$serviceCreator must be a valid callable.');
+        }
+        $this->serviceCreator = $serviceCreator;
+    }
+
+    public function getService($name)
+    {
+        if (isset($this->services[$name])) {
+            return $this->services[$name];
+        }
+
+        return $this->services[$name] = call_user_func($this->serviceCreator, $name);
+    }
+
+    public function resetService($name)
+    {
+        unset($this->services[$name]);
+    }
+
+    public function getAliasNamespace($alias)
+    {
+        foreach (array_keys($this->getManagers()) as $name) {
+            $manager = $this->getManager($name);
+
+            if ($manager instanceof EntityManager) {
+                try {
+                    return $manager->getConfiguration()->getEntityNamespace($alias);
+                } catch (ORMException $ex) {
+                    // Probably mapped by another entity manager, or invalid, just ignore this here.
+                }
+            } else {
+                throw new \LogicException(sprintf('Unsupported manager type "%s".', get_class($manager)));
+            }
+        }
+
+        throw new \RuntimeException(sprintf('The namespace alias "%s" is not known to any manager.', $alias));
+    }
+}


### PR DESCRIPTION
Allows to decide what should happen if an entity is not found in the database. Possible options:

- `ON_MISSING_NULL`: return null (current behavior)
- `ON_MISSING_EXCEPTION`: throw an excpetion
- `ON_MISSING_FALLBACK`: fallback to the standard object constructor

Closes https://github.com/schmittjoh/serializer/issues/216
Closes https://github.com/schmittjoh/serializer/issues/492
Closes https://github.com/schmittjoh/serializer/issues/670