### PR TITLE
Allow namespaced XML element discriminator

### DIFF
--- a/doc/reference/annotations.rst
+++ b/doc/reference/annotations.rst
@@ -497,6 +497,8 @@ Available Options:
 +-------------------------------------+--------------------------------------------------+
 | cdata                               | render child node content with or without cdata  |
 +-------------------------------------+--------------------------------------------------+
+| namespace                           | render child node using the specified namespace  |
++-------------------------------------+--------------------------------------------------+
 
 Example for "attribute":
 .. code-block :: php

--- a/doc/reference/xml_reference.rst
+++ b/doc/reference/xml_reference.rst
@@ -9,7 +9,7 @@ XML Reference
             accessor-order="custom" custom-accessor-order="propertyName1,propertyName2,...,propertyNameN"
             access-type="public_method" discriminator-field-name="type" discriminator-disabled="false" read-only="false">
             <xml-namespace prefix="atom" uri="http://www.w3.org/2005/Atom"/>
-            <xml-discriminator attribute="true" cdata="false"/>
+            <xml-discriminator attribute="true" cdata="false" namespace=""/>
             <discriminator-class value="some-value">ClassName</discriminator-class>
             <discriminator-groups>
                 <group>foo</group>

--- a/doc/reference/yml_reference.rst
+++ b/doc/reference/yml_reference.rst
@@ -21,6 +21,7 @@ YAML Reference
             xml_attribute: true
             xml_element:
                 cdata: false
+                namespace: http://www.w3.org/2005/Atom
         virtual_properties:
             getSomeProperty:
                 serialized_name: foo

--- a/src/JMS/Serializer/Annotation/XmlDiscriminator.php
+++ b/src/JMS/Serializer/Annotation/XmlDiscriminator.php
@@ -34,4 +34,9 @@ class XmlDiscriminator
      * @var boolean
      */
     public $cdata = true;
+
+    /**
+     * @var string
+     */
+    public $namespace;
 }

--- a/src/JMS/Serializer/GraphNavigator.php
+++ b/src/JMS/Serializer/GraphNavigator.php
@@ -287,6 +287,12 @@ final class GraphNavigator
                 $typeValue = (string) $data[$metadata->discriminatorFieldName];
                 break;
 
+            // Check XML element with namespace for discriminatorFieldName
+            case is_object($data) && !$metadata->xmlDiscriminatorAttribute && null !== $metadata->xmlDiscriminatorNamespace  && isset($data->children($metadata->xmlDiscriminatorNamespace)->{$metadata->discriminatorFieldName}):
+                $typeValue = (string) $data->children($metadata->xmlDiscriminatorNamespace)->{$metadata->discriminatorFieldName};
+                break;
+
+            // Check XML element for discriminatorFieldName
             case is_object($data) && isset($data->{$metadata->discriminatorFieldName}):
                 $typeValue = (string) $data->{$metadata->discriminatorFieldName};
                 break;

--- a/src/JMS/Serializer/Metadata/ClassMetadata.php
+++ b/src/JMS/Serializer/Metadata/ClassMetadata.php
@@ -61,6 +61,7 @@ class ClassMetadata extends MergeableClassMetadata
 
     public $xmlDiscriminatorAttribute = false;
     public $xmlDiscriminatorCData = true;
+    public $xmlDiscriminatorNamespace;
 
     public function setDiscriminator($fieldName, array $map, array $groups = array())
     {
@@ -212,6 +213,7 @@ class ClassMetadata extends MergeableClassMetadata
             $discriminatorProperty->serializedName = $this->discriminatorFieldName;
             $discriminatorProperty->xmlAttribute = $this->xmlDiscriminatorAttribute;
             $discriminatorProperty->xmlElementCData = $this->xmlDiscriminatorCData;
+            $discriminatorProperty->xmlNamespace = $this->xmlDiscriminatorNamespace;
             $this->propertyMetadata[$this->discriminatorFieldName] = $discriminatorProperty;
         }
 
@@ -261,6 +263,7 @@ class ClassMetadata extends MergeableClassMetadata
             'xmlDiscriminatorAttribute' => $this->xmlDiscriminatorAttribute,
             'xmlDiscriminatorCData' => $this->xmlDiscriminatorCData,
             'usingExpression' => $this->usingExpression,
+            'xmlDiscriminatorNamespace' => $this->xmlDiscriminatorNamespace,
         ));
     }
 
@@ -296,6 +299,10 @@ class ClassMetadata extends MergeableClassMetadata
 
         if (isset($deserializedData['xmlDiscriminatorAttribute'])) {
             $this->xmlDiscriminatorAttribute = $deserializedData['xmlDiscriminatorAttribute'];
+        }
+
+        if (isset($deserializedData['xmlDiscriminatorNamespace'])) {
+            $this->xmlDiscriminatorNamespace = $deserializedData['xmlDiscriminatorNamespace'];
         }
 
         if (isset($deserializedData['xmlDiscriminatorCData'])) {

--- a/src/JMS/Serializer/Metadata/Driver/AnnotationDriver.php
+++ b/src/JMS/Serializer/Metadata/Driver/AnnotationDriver.php
@@ -105,6 +105,7 @@ class AnnotationDriver implements DriverInterface
             } elseif ($annot instanceof XmlDiscriminator) {
                 $classMetadata->xmlDiscriminatorAttribute = (bool) $annot->attribute;
                 $classMetadata->xmlDiscriminatorCData = (bool) $annot->cdata;
+                $classMetadata->xmlDiscriminatorNamespace = $annot->namespace ? (string) $annot->namespace : null;
             } elseif ($annot instanceof VirtualProperty) {
                 $virtualPropertyMetadata = new ExpressionPropertyMetadata($name, $annot->name, $annot->exp);
                 $propertiesMetadata[] = $virtualPropertyMetadata;

--- a/src/JMS/Serializer/Metadata/Driver/XmlDriver.php
+++ b/src/JMS/Serializer/Metadata/Driver/XmlDriver.php
@@ -114,6 +114,9 @@ class XmlDriver extends AbstractFileDriver
             if (isset($xmlDiscriminator->attributes()->cdata)) {
                 $metadata->xmlDiscriminatorCData = (string) $xmlDiscriminator->attributes()->cdata === 'true';
             }
+            if (isset($xmlDiscriminator->attributes()->namespace)) {
+                $metadata->xmlDiscriminatorNamespace = (string) $xmlDiscriminator->attributes()->namespace;
+            }
         }
 
         foreach ($elem->xpath('./virtual-property') as $method) {

--- a/src/JMS/Serializer/Metadata/Driver/YamlDriver.php
+++ b/src/JMS/Serializer/Metadata/Driver/YamlDriver.php
@@ -301,6 +301,9 @@ class YamlDriver extends AbstractFileDriver
                     if (isset($config['discriminator']['xml_element']['cdata'])) {
                         $metadata->xmlDiscriminatorCData = (bool) $config['discriminator']['xml_element']['cdata'];
                     }
+                    if (isset($config['discriminator']['xml_element']['namespace'])) {
+                        $metadata->xmlDiscriminatorNamespace = (string) $config['discriminator']['xml_element']['namespace'];
+                    }
                 }
 
             }

--- a/tests/JMS/Serializer/Tests/Fixtures/Discriminator/ObjectWithXmlNamespaceDiscriminatorChild.php
+++ b/tests/JMS/Serializer/Tests/Fixtures/Discriminator/ObjectWithXmlNamespaceDiscriminatorChild.php
@@ -1,0 +1,23 @@
+<?php
+
+/*
+ * Copyright 2016 Björn Bösel <bjoern.boesel@twt.de>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace JMS\Serializer\Tests\Fixtures\Discriminator;
+
+class ObjectWithXmlNamespaceDiscriminatorChild extends ObjectWithXmlNamespaceDiscriminatorParent
+{
+}

--- a/tests/JMS/Serializer/Tests/Fixtures/Discriminator/ObjectWithXmlNamespaceDiscriminatorParent.php
+++ b/tests/JMS/Serializer/Tests/Fixtures/Discriminator/ObjectWithXmlNamespaceDiscriminatorParent.php
@@ -1,0 +1,33 @@
+<?php
+
+/*
+ * Copyright 2016 Björn Bösel <bjoern.boesel@twt.de>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace JMS\Serializer\Tests\Fixtures\Discriminator;
+
+use JMS\Serializer\Annotation as Serializer;
+
+/**
+ * @Serializer\Discriminator(field = "type", map = {
+ *    "child": "JMS\Serializer\Tests\Fixtures\Discriminator\ObjectWithXmlNamespaceDiscriminatorChild"
+ * })
+ * @Serializer\XmlDiscriminator(namespace="http://example.com/", cdata=false)
+ * @Serializer\XmlNamespace(prefix="foo", uri="http://example.com/")
+ */
+class ObjectWithXmlNamespaceDiscriminatorParent
+{
+
+}

--- a/tests/JMS/Serializer/Tests/Metadata/Driver/BaseDriverTest.php
+++ b/tests/JMS/Serializer/Tests/Metadata/Driver/BaseDriverTest.php
@@ -25,6 +25,8 @@ use JMS\Serializer\Metadata\PropertyMetadata;
 use JMS\Serializer\Metadata\VirtualPropertyMetadata;
 use JMS\Serializer\Tests\Fixtures\Discriminator\ObjectWithXmlAttributeDiscriminatorChild;
 use JMS\Serializer\Tests\Fixtures\Discriminator\ObjectWithXmlAttributeDiscriminatorParent;
+use JMS\Serializer\Tests\Fixtures\Discriminator\ObjectWithXmlNamespaceDiscriminatorChild;
+use JMS\Serializer\Tests\Fixtures\Discriminator\ObjectWithXmlNamespaceDiscriminatorParent;
 use Metadata\Driver\DriverInterface;
 
 abstract class BaseDriverTest extends \PHPUnit_Framework_TestCase
@@ -210,6 +212,23 @@ abstract class BaseDriverTest extends \PHPUnit_Framework_TestCase
         );
         $this->assertTrue($m->xmlDiscriminatorAttribute);
         $this->assertFalse($m->xmlDiscriminatorCData);
+    }
+
+    public function testLoadXmlDiscriminatorWithNamespaces()
+    {
+        /** @var $m ClassMetadata */
+        $m = $this->getDriver()->loadMetadataForClass(new \ReflectionClass(ObjectWithXmlNamespaceDiscriminatorParent::class));
+
+        $this->assertNotNull($m);
+        $this->assertEquals('type', $m->discriminatorFieldName);
+        $this->assertEquals($m->name, $m->discriminatorBaseClass);
+        $this->assertEquals(
+            array(
+                'child' => ObjectWithXmlNamespaceDiscriminatorChild::class,
+            ),
+            $m->discriminatorMap
+        );
+        $this->assertEquals('http://example.com/', $m->xmlDiscriminatorNamespace);
     }
 
     public function testLoadDiscriminatorWithGroup()

--- a/tests/JMS/Serializer/Tests/Metadata/Driver/php/Discriminator.ObjectWithXmlNamespaceDiscriminatorParent.php
+++ b/tests/JMS/Serializer/Tests/Metadata/Driver/php/Discriminator.ObjectWithXmlNamespaceDiscriminatorParent.php
@@ -1,0 +1,11 @@
+<?php
+
+use JMS\Serializer\Metadata\ClassMetadata;
+
+$metadata = new ClassMetadata('JMS\Serializer\Tests\Fixtures\Discriminator\ObjectWithXmlNamespaceDiscriminatorParent');
+$metadata->setDiscriminator('type', array(
+    'child' => 'JMS\Serializer\Tests\Fixtures\Discriminator\ObjectWithXmlNamespaceDiscriminatorChild'
+));
+$metadata->xmlDiscriminatorNamespace = 'http://example.com/';
+
+return $metadata;

--- a/tests/JMS/Serializer/Tests/Metadata/Driver/xml/Discriminator.ObjectWithXmlNamespaceDiscriminatorParent.xml
+++ b/tests/JMS/Serializer/Tests/Metadata/Driver/xml/Discriminator.ObjectWithXmlNamespaceDiscriminatorParent.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<serializer>
+    <class name="JMS\Serializer\Tests\Fixtures\Discriminator\ObjectWithXmlNamespaceDiscriminatorParent"
+           discriminator-field-name="type"
+    >
+        <discriminator-class value="child">JMS\Serializer\Tests\Fixtures\Discriminator\ObjectWithXmlNamespaceDiscriminatorChild</discriminator-class>
+        <xml-discriminator namespace="http://example.com/" />
+    </class>
+</serializer>

--- a/tests/JMS/Serializer/Tests/Metadata/Driver/yml/Discriminator.ObjectWithXmlNamespaceDiscriminatorParent.yml
+++ b/tests/JMS/Serializer/Tests/Metadata/Driver/yml/Discriminator.ObjectWithXmlNamespaceDiscriminatorParent.yml
@@ -1,0 +1,7 @@
+JMS\Serializer\Tests\Fixtures\Discriminator\ObjectWithXmlNamespaceDiscriminatorParent:
+    discriminator:
+        field_name: type
+        map:
+            child: JMS\Serializer\Tests\Fixtures\Discriminator\ObjectWithXmlNamespaceDiscriminatorChild
+        xml_element:
+            namespace: http://example.com/

--- a/tests/JMS/Serializer/Tests/Serializer/XmlSerializationTest.php
+++ b/tests/JMS/Serializer/Tests/Serializer/XmlSerializationTest.php
@@ -29,6 +29,8 @@ use JMS\Serializer\Metadata\StaticPropertyMetadata;
 use JMS\Serializer\SerializationContext;
 use JMS\Serializer\Serializer;
 use JMS\Serializer\Tests\Fixtures\Discriminator\ObjectWithXmlAttributeDiscriminatorParent;
+use JMS\Serializer\Tests\Fixtures\Discriminator\ObjectWithXmlNamespaceDiscriminatorChild;
+use JMS\Serializer\Tests\Fixtures\Discriminator\ObjectWithXmlNamespaceDiscriminatorParent;
 use JMS\Serializer\Tests\Fixtures\Discriminator\ObjectWithXmlNotCDataDiscriminatorChild;
 use JMS\Serializer\Tests\Fixtures\Discriminator\ObjectWithXmlNotCDataDiscriminatorParent;
 use JMS\Serializer\Tests\Fixtures\InvalidUsageOfXmlValue;
@@ -449,6 +451,20 @@ class XmlSerializationTest extends BaseSerializationTest
             $this->deserialize(
                 $xml,
                 ObjectWithXmlNotCDataDiscriminatorParent::class
+            )
+        );
+    }
+
+    public function testDiscriminatorWithNamespace()
+    {
+        $xml = $this->serialize(new ObjectWithXmlNamespaceDiscriminatorChild());
+        $this->assertEquals($this->getContent('xml_discriminator_namespace'), $xml);
+
+        $this->assertInstanceOf(
+            ObjectWithXmlNamespaceDiscriminatorChild::class,
+            $this->deserialize(
+                $xml,
+                ObjectWithXmlNamespaceDiscriminatorParent::class
             )
         );
     }

--- a/tests/JMS/Serializer/Tests/Serializer/xml/xml_discriminator_namespace.xml
+++ b/tests/JMS/Serializer/Tests/Serializer/xml/xml_discriminator_namespace.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<result xmlns:foo="http://example.com/">
+  <foo:type>child</foo:type>
+</result>


### PR DESCRIPTION
Allows to :

```php

use JMS\Serializer\Annotation as Serializer;
/**
 * @Serializer\Discriminator(field = "type", map = {
 *    "tiger": "Ns\Tiger"
 * })
 * @Serializer\XmlDiscriminator(namespace="http://example.com/", cdata=false)
 * @Serializer\XmlNamespace(prefix="foo", uri="http://example.com/")
 */
class Animal
{

}


$serializer->serialize(new Tiger());
```

```xml
<result xmlns:foo="http://example.com/">
  <foo:type>tiger</foo:type>
</result>
```