### PR TITLE
Allow for setExpressionEvaluator usage to be chainable

### DIFF
--- a/src/JMS/Serializer/SerializerBuilder.php
+++ b/src/JMS/Serializer/SerializerBuilder.php
@@ -129,6 +129,8 @@ class SerializerBuilder
     public function setExpressionEvaluator(ExpressionEvaluatorInterface $expressionEvaluator)
     {
         $this->expressionEvaluator = $expressionEvaluator;
+        
+        return $this;
     }
 
     public function setAnnotationReader(Reader $reader)


### PR DESCRIPTION
Currently all other setters implement this logic but this one doesnt have it for some reason.