### PR TITLE
Skip doctrine proxy initializations when exclusion strategy will exclude it 

### DIFF
--- a/src/JMS/Serializer/Handler/ArrayCollectionHandler.php
+++ b/src/JMS/Serializer/Handler/ArrayCollectionHandler.php
@@ -26,6 +26,16 @@ use Doctrine\Common\Collections\Collection;
 
 class ArrayCollectionHandler implements SubscribingHandlerInterface
 {
+    /**
+     * @var bool
+     */
+    private $initializeExcluded = true;
+
+    public function __construct($initializeExcluded = true)
+    {
+        $this->initializeExcluded = $initializeExcluded;
+    }
+
     public static function getSubscribingMethods()
     {
         $methods = array();
@@ -63,6 +73,13 @@ class ArrayCollectionHandler implements SubscribingHandlerInterface
     {
         // We change the base type, and pass through possible parameters.
         $type['name'] = 'array';
+
+        if ($this->initializeExcluded === false) {
+            $exclusionStrategy = $context->getExclusionStrategy();
+            if ($exclusionStrategy !== null && $exclusionStrategy->shouldSkipClass($context->getMetadataFactory()->getMetadataForClass(get_class($collection)), $context)) {
+                return $visitor->visitArray([], $type, $context);
+            }
+        }
 
         return $visitor->visitArray($collection->toArray(), $type, $context);
     }

--- a/tests/JMS/Serializer/Tests/Fixtures/ExclusionStrategy/AlwaysExcludeExclusionStrategy.php
+++ b/tests/JMS/Serializer/Tests/Fixtures/ExclusionStrategy/AlwaysExcludeExclusionStrategy.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace JMS\Serializer\Tests\Fixtures\ExclusionStrategy;
+
+use JMS\Serializer\Context;
+use JMS\Serializer\Exclusion\ExclusionStrategyInterface;
+use JMS\Serializer\Metadata\ClassMetadata;
+use JMS\Serializer\Metadata\PropertyMetadata;
+
+class AlwaysExcludeExclusionStrategy implements ExclusionStrategyInterface
+{
+    public function shouldSkipClass(ClassMetadata $metadata, Context $context)
+    {
+        return true;
+    }
+
+    public function shouldSkipProperty(PropertyMetadata $property, Context $context)
+    {
+        return false;
+    }
+}

--- a/tests/JMS/Serializer/Tests/Handler/ArrayCollectionHandlerTest.php
+++ b/tests/JMS/Serializer/Tests/Handler/ArrayCollectionHandlerTest.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace JMS\Serializer\Tests\Handler;
+
+use Doctrine\Common\Collections\ArrayCollection;
+use JMS\Serializer\Handler\ArrayCollectionHandler;
+use JMS\Serializer\Metadata\ClassMetadata;
+use JMS\Serializer\SerializationContext;
+use JMS\Serializer\Tests\Fixtures\ExclusionStrategy\AlwaysExcludeExclusionStrategy;
+use JMS\Serializer\VisitorInterface;
+use Metadata\MetadataFactoryInterface;
+
+class ArrayCollectionHandlerTest extends \PHPUnit_Framework_TestCase
+{
+    public function testSerializeArray()
+    {
+        $handler = new ArrayCollectionHandler();
+
+        $visitor = $this->getMockBuilder(VisitorInterface::class)->getMock();
+        $visitor->method('visitArray')->with(['foo'])->willReturn(['foo']);
+
+        $context = $this->getMockBuilder(SerializationContext::class)->getMock();
+        $type = ['name' => 'ArrayCollection', 'params' => []];
+
+        $collection = new ArrayCollection(['foo']);
+
+        $handler->serializeCollection($visitor, $collection, $type, $context);
+    }
+
+    public function testSerializeArraySkipByExclusionStrategy()
+    {
+        $handler = new ArrayCollectionHandler(false);
+
+        $visitor = $this->getMockBuilder(VisitorInterface::class)->getMock();
+        $visitor->method('visitArray')->with([])->willReturn([]);
+
+        $context = $this->getMockBuilder(SerializationContext::class)->getMock();
+
+        $factoryMock = $this->getMockBuilder(MetadataFactoryInterface::class)->getMock();
+        $factoryMock->method('getMetadataForClass')->willReturn(new ClassMetadata(ArrayCollection::class));
+
+        $context->method('getExclusionStrategy')->willReturn(new AlwaysExcludeExclusionStrategy());
+        $context->method('getMetadataFactory')->willReturn($factoryMock);
+
+
+        $type = ['name' => 'ArrayCollection', 'params' => []];
+
+        $collection = new ArrayCollection(['foo']);
+
+        $handler->serializeCollection($visitor, $collection, $type, $context);
+    }
+}


### PR DESCRIPTION
Skip doctrine proxy initializations when exclusion strategy will exclude it.

In some situations (when using max-depth exclusion strategy especially) allows to save up to 50% of doctrine queries.

In an app I'm developing, to render an api result, the query count was 135, and with this feature enabled is 85 (having the same output result).