### PR TITLE
Fix xml deserialization when xsi:nil="true" is set

### DIFF
--- a/src/AbstractVisitor.php
+++ b/src/AbstractVisitor.php
@@ -62,14 +62,4 @@ abstract class AbstractVisitor implements VisitorInterface
             return $typeArray['params'][0];
         }
     }
-
-    /**
-     * @param mixed $data
-     *
-     * @return bool
-     */
-    public function isNullData($data)
-    {
-        return $data === null;
-    }
 }

--- a/src/AbstractVisitor.php
+++ b/src/AbstractVisitor.php
@@ -63,4 +63,13 @@ abstract class AbstractVisitor implements VisitorInterface
         }
     }
 
+    /**
+     * @param mixed $data
+     *
+     * @return bool
+     */
+    public function isNullData($data)
+    {
+        return $data === null;
+    }
 }

--- a/src/GraphNavigator.php
+++ b/src/GraphNavigator.php
@@ -119,10 +119,18 @@ final class GraphNavigator
 
             $type = array('name' => $typeName, 'params' => array());
         }
-
         // If the data is null, we have to force the type to null regardless of the input in order to
         // guarantee correct handling of null values, and not have any internal auto-casting behavior.
-        if ($visitor instanceof VisitorInterface && true === $visitor->isNullData($data)) {
+        else if ($context instanceof SerializationContext && null === $data) {
+            $type = array('name' => 'NULL', 'params' => array());
+        }
+
+        // Sometimes data can convey null but is not of a null type.
+        // Visitors can have the power to add this custom null evaluation
+        if ($visitor instanceof VisitorInterface
+            && $visitor instanceof NullEvaluatorInterface
+            && $visitor->evaluatesToNull($data) === true
+        ) {
             $type = array('name' => 'NULL', 'params' => array());
         }
 

--- a/src/GraphNavigator.php
+++ b/src/GraphNavigator.php
@@ -119,9 +119,10 @@ final class GraphNavigator
 
             $type = array('name' => $typeName, 'params' => array());
         }
+
         // If the data is null, we have to force the type to null regardless of the input in order to
         // guarantee correct handling of null values, and not have any internal auto-casting behavior.
-        else if ($context instanceof SerializationContext && null === $data) {
+        if ($visitor instanceof VisitorInterface && true === $visitor->isNullData($data)) {
             $type = array('name' => 'NULL', 'params' => array());
         }
 

--- a/src/NullEvaluatorInterface.php
+++ b/src/NullEvaluatorInterface.php
@@ -1,0 +1,32 @@
+<?php
+
+/*
+ * Copyright 2016 Johannes M. Schmitt <schmittjoh@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace JMS\Serializer;
+
+interface NullEvaluatorInterface
+{
+    /**
+     * Determine if a value conveys a null value.
+     * An example could be an xml element (Dom, SimpleXml, ...) that is tagged with a xsi:nil attribute
+     *
+     * @param mixed $value
+     *
+     * @return bool
+     */
+    public function evaluatesToNull($value);
+}

--- a/src/VisitorInterface.php
+++ b/src/VisitorInterface.php
@@ -138,14 +138,4 @@ interface VisitorInterface
      * @return object|array|scalar
      */
     public function getResult();
-
-    /**
-     * Determine if the value evaluates to null.
-     * Used by the navigator to determine the correct data type.
-     *
-     * @param mixed $data
-     *
-     * @return bool
-     */
-    public function isNullData($data);
 }

--- a/src/VisitorInterface.php
+++ b/src/VisitorInterface.php
@@ -138,4 +138,14 @@ interface VisitorInterface
      * @return object|array|scalar
      */
     public function getResult();
+
+    /**
+     * Determine if the value evaluates to null.
+     * Used by the navigator to determine the correct data type.
+     *
+     * @param mixed $data
+     *
+     * @return bool
+     */
+    public function isNullData($data);
 }

--- a/src/XmlDeserializationVisitor.php
+++ b/src/XmlDeserializationVisitor.php
@@ -25,7 +25,7 @@ use JMS\Serializer\Exception\XmlErrorException;
 use JMS\Serializer\Metadata\ClassMetadata;
 use JMS\Serializer\Metadata\PropertyMetadata;
 
-class XmlDeserializationVisitor extends AbstractVisitor
+class XmlDeserializationVisitor extends AbstractVisitor implements NullEvaluatorInterface
 {
     private $objectStack;
     private $metadataStack;
@@ -389,17 +389,14 @@ class XmlDeserializationVisitor extends AbstractVisitor
     }
 
     /**
-     * Consider xml element value null if the xsi:nil attribute is set and therefore can't have a value
-     * @see https://www.w3.org/TR/xmlschema-1/#xsi_nil
-     *
-     * @param $data
+     * @param mixed $value
      *
      * @return bool
      */
-    public function isNullData($data)
+    public function evaluatesToNull($value)
     {
-        if ($data instanceof \SimpleXMLElement) {
-            $xsiAttributes = $data->attributes('http://www.w3.org/2001/XMLSchema-instance');
+        if ($value instanceof \SimpleXMLElement) {
+            $xsiAttributes = $value->attributes('http://www.w3.org/2001/XMLSchema-instance');
 
             //We have to keep the isset quiet, some tests give error: `Node no longer exists`; even though it evaluates to false
             if (@isset($xsiAttributes['nil']) && (string) $xsiAttributes['nil'] === 'true') {
@@ -407,6 +404,6 @@ class XmlDeserializationVisitor extends AbstractVisitor
             }
         }
 
-        return $data === null;
+        return $value === null;
     }
 }

--- a/src/XmlDeserializationVisitor.php
+++ b/src/XmlDeserializationVisitor.php
@@ -387,4 +387,26 @@ class XmlDeserializationVisitor extends AbstractVisitor
 
         return $internalSubset;
     }
+
+    /**
+     * Consider xml element value null if the xsi:nil attribute is set and therefore can't have a value
+     * @see https://www.w3.org/TR/xmlschema-1/#xsi_nil
+     *
+     * @param $data
+     *
+     * @return bool
+     */
+    public function isNullData($data)
+    {
+        if ($data instanceof \SimpleXMLElement) {
+            $xsiAttributes = $data->attributes('http://www.w3.org/2001/XMLSchema-instance');
+
+            //We have to keep the isset quiet, some tests give error: `Node no longer exists`; even though it evaluates to false
+            if (@isset($xsiAttributes['nil']) && (string) $xsiAttributes['nil'] === 'true') {
+                return true;
+            }
+        }
+
+        return $data === null;
+    }
 }

--- a/tests/Fixtures/ObjectWithNullProperty.php
+++ b/tests/Fixtures/ObjectWithNullProperty.php
@@ -18,7 +18,21 @@
 
 namespace JMS\Serializer\Tests\Fixtures;
 
+use JMS\Serializer\Annotation\Type;
+
 class ObjectWithNullProperty extends SimpleObject
 {
+    /**
+     * @var null
+     * @Type("string")
+     */
     private $nullProperty = null;
+
+    /**
+     * @return null
+     */
+    public function getNullProperty()
+    {
+        return $this->nullProperty;
+    }
 }

--- a/tests/Serializer/BaseSerializationTest.php
+++ b/tests/Serializer/BaseSerializationTest.php
@@ -1364,19 +1364,6 @@ abstract class BaseSerializationTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($this->getContent('nullable_arrays'), $this->serializer->serialize($object, $this->getFormat()));
     }
 
-    public function testIsNullDataWithNull()
-    {
-        /** @var VisitorInterface $visitor */
-        foreach ($this->serializationVisitors as $visitor) {
-            $this->assertTrue($visitor->isNullData(null));
-        }
-
-        /** @var VisitorInterface $visitor */
-        foreach ($this->deserializationVisitors as $visitor) {
-            $this->assertTrue($visitor->isNullData(null));
-        }
-    }
-
     abstract protected function getContent($key);
 
     abstract protected function getFormat();

--- a/tests/Serializer/BaseSerializationTest.php
+++ b/tests/Serializer/BaseSerializationTest.php
@@ -166,6 +166,25 @@ abstract class BaseSerializationTest extends \PHPUnit_Framework_TestCase
         );
     }
 
+    public function testDeserializeNullObject()
+    {
+        if (!$this->hasDeserializer()) {
+            $this->markTestSkipped(sprintf('No deserializer available for format `%s`', $this->getFormat()));
+        }
+
+        $obj = new ObjectWithNullProperty('foo', 'bar');
+
+        /** @var ObjectWithNullProperty $dObj */
+        $dObj = $this->serializer->deserialize(
+            $this->getContent('simple_object_nullable'),
+            ObjectWithNullProperty::class,
+            $this->getFormat()
+        );
+
+        $this->assertEquals($obj, $dObj);
+        $this->assertNull($dObj->getNullProperty());
+    }
+
     /**
      * @dataProvider getTypes
      */
@@ -1343,6 +1362,19 @@ abstract class BaseSerializationTest extends \PHPUnit_Framework_TestCase
     {
         $object = new ObjectWithEmptyNullableAndEmptyArrays();
         $this->assertEquals($this->getContent('nullable_arrays'), $this->serializer->serialize($object, $this->getFormat()));
+    }
+
+    public function testIsNullDataWithNull()
+    {
+        /** @var VisitorInterface $visitor */
+        foreach ($this->serializationVisitors as $visitor) {
+            $this->assertTrue($visitor->isNullData(null));
+        }
+
+        /** @var VisitorInterface $visitor */
+        foreach ($this->deserializationVisitors as $visitor) {
+            $this->assertTrue($visitor->isNullData(null));
+        }
     }
 
     abstract protected function getContent($key);

--- a/tests/Serializer/XmlSerializationTest.php
+++ b/tests/Serializer/XmlSerializationTest.php
@@ -490,13 +490,14 @@ class XmlSerializationTest extends BaseSerializationTest
         $this->deserialize('', 'stdClass');
     }
 
-    public function testIsNullDataWithXSINilLabeledElement()
+    public function testEvaluatesToNull()
     {
         $namingStrategy = $this->getMockBuilder(PropertyNamingStrategyInterface::class)->getMock();
         $visitor = new XmlDeserializationVisitor($namingStrategy);
         $element = simplexml_load_string('<empty xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>');
 
-        $this->assertTrue($visitor->isNullData($element));
+        $this->assertTrue($visitor->evaluatesToNull($element));
+        $this->assertTrue($visitor->evaluatesToNull(null));
     }
 
     private function xpathFirstToString(\SimpleXMLElement $xml, $xpath)

--- a/tests/Serializer/XmlSerializationTest.php
+++ b/tests/Serializer/XmlSerializationTest.php
@@ -26,6 +26,7 @@ use JMS\Serializer\Handler\DateHandler;
 use JMS\Serializer\Handler\HandlerRegistry;
 use JMS\Serializer\Metadata\StaticPropertyMetadata;
 use JMS\Serializer\Naming\CamelCaseNamingStrategy;
+use JMS\Serializer\Naming\PropertyNamingStrategyInterface;
 use JMS\Serializer\Naming\SerializedNameAnnotationStrategy;
 use JMS\Serializer\SerializationContext;
 use JMS\Serializer\Serializer;
@@ -52,6 +53,7 @@ use JMS\Serializer\Tests\Fixtures\PersonLocation;
 use JMS\Serializer\Tests\Fixtures\SimpleClassObject;
 use JMS\Serializer\Tests\Fixtures\SimpleObject;
 use JMS\Serializer\Tests\Fixtures\SimpleSubClassObject;
+use JMS\Serializer\XmlDeserializationVisitor;
 use JMS\Serializer\XmlSerializationVisitor;
 use PhpCollection\Map;
 
@@ -486,6 +488,15 @@ class XmlSerializationTest extends BaseSerializationTest
     public function testDeserializeEmptyString()
     {
         $this->deserialize('', 'stdClass');
+    }
+
+    public function testIsNullDataWithXSINilLabeledElement()
+    {
+        $namingStrategy = $this->getMockBuilder(PropertyNamingStrategyInterface::class)->getMock();
+        $visitor = new XmlDeserializationVisitor($namingStrategy);
+        $element = simplexml_load_string('<empty xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>');
+
+        $this->assertTrue($visitor->isNullData($element));
     }
 
     private function xpathFirstToString(\SimpleXMLElement $xml, $xpath)


### PR DESCRIPTION
Add xml deserialization null check based on xsi:nil
Expand visitor interface with a null data detect function
Add default implementation for null detection in abstract visitor
Add round-trip test for serializing ad de-serializing null object

(Silence operator had to be used - even a count() on the attributes resulted in this error)