### PR TITLE
Added trim to xml metadata reader for groups parameter, and added support for groups element

### DIFF
--- a/doc/reference/xml_reference.rst
+++ b/doc/reference/xml_reference.rst
@@ -42,6 +42,10 @@ XML Reference
                 <xml-list inline="true" entry-name="foobar" />
                 <xml-map inline="true" key-attribute-name="foo" entry-name="bar" namespace="http://www.w3.org/2005/Atom" />
                 <xml-element cdata="false" namespace="http://www.w3.org/2005/Atom"/>
+                <groups>
+                    <value>foo</value>
+                    <value>bar</value>
+                </groups>
             </property>
             <callback-method name="foo" type="pre-serialize" />
             <callback-method name="bar" type="post-serialize" />
@@ -91,6 +95,10 @@ XML Reference
                 <!-- You can also specify the type as element which is necessary if
                      your type contains "<" or ">" characters. -->
                 <type><![CDATA[]]></type>
+                <groups>
+                    <value>foo</value>
+                    <value>bar</value>
+                </groups>
                 <xml-list inline="true" entry-name="foobar" />
                 <xml-map inline="true" key-attribute-name="foo" entry-name="bar" />
             </virtual-property>

--- a/src/Metadata/Driver/XmlDriver.php
+++ b/src/Metadata/Driver/XmlDriver.php
@@ -196,7 +196,9 @@ class XmlDriver extends AbstractFileDriver
                     }
 
                     if (null !== $groups = $pElem->attributes()->groups) {
-                        $pMetadata->groups = preg_split('/\s*,\s*/', (string)$groups);
+                        $pMetadata->groups = preg_split('/\s*,\s*/', (string) trim($groups));
+                    } elseif (isset($pElem->groups)) {
+                        $pMetadata->groups = (array) $pElem->groups->value;
                     }
 
                     if (isset($pElem->{'xml-list'})) {

--- a/tests/Fixtures/GroupsTrim.php
+++ b/tests/Fixtures/GroupsTrim.php
@@ -1,0 +1,51 @@
+<?php
+
+/*
+ * Copyright 2016 Johannes M. Schmitt <schmittjoh@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace JMS\Serializer\Tests\Fixtures;
+
+use JMS\Serializer\Annotation\Type;
+use JMS\Serializer\Annotation\Groups;
+
+class GroupsTrim
+{
+    /**
+     * @var int
+     */
+    private $amount;
+
+    /**
+     * @var string
+     */
+    private $currency;
+
+    public function __construct($amount, $currency)
+    {
+        $this->amount = (int) $amount;
+        $this->currency = $currency;
+    }
+
+    public function getAmount()
+    {
+        return $this->amount;
+    }
+
+    public function getCurrency()
+    {
+        return $this->currency;
+    }
+}

--- a/tests/Fixtures/MultilineGroupsFormat.php
+++ b/tests/Fixtures/MultilineGroupsFormat.php
@@ -1,0 +1,51 @@
+<?php
+
+/*
+ * Copyright 2016 Johannes M. Schmitt <schmittjoh@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace JMS\Serializer\Tests\Fixtures;
+
+use JMS\Serializer\Annotation\Type;
+use JMS\Serializer\Annotation\Groups;
+
+class MultilineGroupsFormat
+{
+    /**
+     * @var int
+     */
+    private $amount;
+
+    /**
+     * @var string
+     */
+    private $currency;
+
+    public function __construct($amount, $currency)
+    {
+        $this->amount = (int) $amount;
+        $this->currency = $currency;
+    }
+
+    public function getAmount()
+    {
+        return $this->amount;
+    }
+
+    public function getCurrency()
+    {
+        return $this->currency;
+    }
+}

--- a/tests/Metadata/Driver/XmlDriverTest.php
+++ b/tests/Metadata/Driver/XmlDriverTest.php
@@ -82,6 +82,22 @@ class XmlDriverTest extends BaseDriverTest
         $this->assertEquals($p, $m->propertyMetadata['name']);
     }
 
+    public function testGroupsTrim()
+    {
+        $first = $this->getDriver()->loadMetadataForClass(new \ReflectionClass('JMS\Serializer\Tests\Fixtures\GroupsTrim'));
+
+        $this->assertArrayHasKey('amount', $first->propertyMetadata);
+        $this->assertArraySubset(['first.test.group', 'second.test.group'], $first->propertyMetadata['currency']->groups);
+    }
+
+    public function testMultilineGroups()
+    {
+        $first = $this->getDriver()->loadMetadataForClass(new \ReflectionClass('JMS\Serializer\Tests\Fixtures\MultilineGroupsFormat'));
+
+        $this->assertArrayHasKey('amount', $first->propertyMetadata);
+        $this->assertArraySubset(['first.test.group', 'second.test.group'], $first->propertyMetadata['currency']->groups);
+    }
+
     protected function getDriver()
     {
         $append = '';

--- a/tests/Metadata/Driver/xml/GroupsTrim.xml
+++ b/tests/Metadata/Driver/xml/GroupsTrim.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<serializer>
+    <class name="JMS\Serializer\Tests\Fixtures\GroupsTrim"
+           exclusion-policy="all"
+           read-only="true"
+    >
+        <virtual-property method="getAmount" type="integer" serialized-name="amount" groups="
+            first.test.group
+        "
+        />
+        <virtual-property method="getCurrency" type="string" serialized-name="currency" groups="
+            first.test.group,
+            second.test.group
+        "
+        />
+    </class>
+</serializer>

--- a/tests/Metadata/Driver/xml/MultilineGroupsFormat.xml
+++ b/tests/Metadata/Driver/xml/MultilineGroupsFormat.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<serializer>
+    <class name="JMS\Serializer\Tests\Fixtures\MultilineGroupsFormat"
+           exclusion-policy="all"
+           read-only="true"
+    >
+        <virtual-property method="getAmount" type="integer" serialized-name="amount">
+            <groups>
+                <value>first.test.group</value>
+            </groups>
+        </virtual-property>
+        <virtual-property method="getCurrency" type="string" serialized-name="currency">
+            <groups>
+                <value>first.test.group</value>
+                <value>second.test.group</value>
+            </groups>
+        </virtual-property>
+    </class>
+</serializer>


### PR DESCRIPTION
Hello,

In my project, my and my team use serialization groups a lot, and it is a little hard to use it in an easy way.
In our standard use, each of our properties has about 5 serialization groups, it looks ugly, but it was enough for us, till now.
Till now we have long strings, which looks like:
```
groups="api.response.product.list,api.response.product.details"
```
and so one.
But supporting serialization groups in one line string is a little hard, so we decided to explode it into the multiline string like:
```
groups="
    api.response.product.list,
    api.response.product.details
"
```
But unfortunately, serializer didn't trim groups, so when we had split groups string, we had to use `    api.response.product.list` with spaces before string - this fix for you can find on `XmlDriver.php:199`
After I created this fix, I thought - maybe we can use xml elements instead attributes, so this proposition you can find on `XmlDrvier.php:201`

Please let me know what do you think about my propositions.
Best regards.