### PR TITLE
Added support for a third deserialize parameter for the DateTime type

### DIFF
--- a/doc/reference/annotations.rst
+++ b/doc/reference/annotations.rst
@@ -357,7 +357,9 @@ Available Types:
 | DateTime<'format', 'zone'>                               | PHP's DateTime object (custom format/timezone)   |
 +----------------------------------------------------------+--------------------------------------------------+
 | DateTime<'format', 'zone', 'deserializeFormat'>          | PHP's DateTime object (custom format/timezone,   |
-|                                                          | deserialize format)                              |
+|                                                          | deserialize format). If you do not want to       |
+|                                                          | specify a specific timezone, use an empty        |
+|                                                          | string ('').                                     |
 +----------------------------------------------------------+--------------------------------------------------+
 | DateTimeImmutable                                        | PHP's DateTimeImmutable object (default format/  |
 |                                                          | timezone)                                        |
@@ -369,7 +371,9 @@ Available Types:
 |                                                          | timezone)                                        |
 +----------------------------------------------------------+--------------------------------------------------+
 | DateTimeImmutable<'format', 'zone', 'deserializeFormat'> | PHP's DateTimeImmutable object (custom format/   |
-|                                                          | timezone/deserialize format)                     |
+|                                                          | timezone/deserialize format). If you do not want |
+|                                                          | to specify a specific timezone, use an empty     |
+|                                                          | string ('').                                     |
 +----------------------------------------------------------+--------------------------------------------------+
 | DateInterval                                             | PHP's DateInterval object using ISO 8601 format  |
 +----------------------------------------------------------+--------------------------------------------------+

--- a/doc/reference/annotations.rst
+++ b/doc/reference/annotations.rst
@@ -324,57 +324,63 @@ to the least super type::
 This annotation can be defined on a property to specify the type of that property.
 For deserialization, this annotation must be defined. For serialization, you may
 define it in order to enhance the produced output; for example, you may want to
-force a certain format to be used for DateTime types.
+force a certain (deserialize)format to be used for DateTime types.
 
 Available Types:
 
-+-------------------------------------+--------------------------------------------------+
-| Type                                | Description                                      |
-+=====================================+==================================================+
-| boolean                             | Primitive boolean                                |
-+-------------------------------------+--------------------------------------------------+
-| integer or int                      | Primitive integer                                |
-+-------------------------------------+--------------------------------------------------+
-| double or float                     | Primitive double                                 |
-+-------------------------------------+--------------------------------------------------+
-| string                              | Primitive string                                 |
-+-------------------------------------+--------------------------------------------------+
-| array                               | An array with arbitrary keys, and values.        |
-+-------------------------------------+--------------------------------------------------+
-| array<T>                            | A list of type T (T can be any available type).  |
-|                                     | Examples:                                        |
-|                                     | array<string>, array<MyNamespace\MyObject>, etc. |
-+-------------------------------------+--------------------------------------------------+
-| array<K, V>                         | A map of keys of type K to values of type V.     |
-|                                     | Examples: array<string, string>,                 |
-|                                     | array<string, MyNamespace\MyObject>, etc.        |
-+-------------------------------------+--------------------------------------------------+
-| DateTime                            | PHP's DateTime object (default format/timezone)  |
-+-------------------------------------+--------------------------------------------------+
-| DateTime<'format'>                  | PHP's DateTime object (custom format/default     |
-|                                     | timezone)                                        |
-+-------------------------------------+--------------------------------------------------+
-| DateTime<'format', 'zone'>          | PHP's DateTime object (custom format/timezone)   |
-+-------------------------------------+--------------------------------------------------+
-| DateTimeImmutable                   | PHP's DateTimeImmutable object (default format/  |
-|                                     | timezone)                                        |
-+-------------------------------------+--------------------------------------------------+
-| DateTimeImmutable<'format'>         | PHP's DateTimeImmutable object (custom format/   |
-|                                     | default timezone)                                |
-+-------------------------------------+--------------------------------------------------+
-| DateTimeImmutable<'format', 'zone'> | PHP's DateTimeImmutable object (custom format/   |
-|                                     | timezone)                                        |
-+-------------------------------------+--------------------------------------------------+
-| DateInterval                        | PHP's DateInterval object using ISO 8601 format  |
-+-------------------------------------+--------------------------------------------------+
-| T                                   | Where T is a fully qualified class name.         |
-+-------------------------------------+--------------------------------------------------+
-| ArrayCollection<T>                  | Similar to array<T>, but will be deserialized    |
-|                                     | into Doctrine's ArrayCollection class.           |
-+-------------------------------------+--------------------------------------------------+
-| ArrayCollection<K, V>               | Similar to array<K, V>, but will be deserialized |
-|                                     | into Doctrine's ArrayCollection class.           |
-+-------------------------------------+--------------------------------------------------+
++----------------------------------------------------------+--------------------------------------------------+
+| Type                                                     | Description                                      |
++==========================================================+==================================================+
+| boolean                                                  | Primitive boolean                                |
++----------------------------------------------------------+--------------------------------------------------+
+| integer or int                                           | Primitive integer                                |
++----------------------------------------------------------+--------------------------------------------------+
+| double or float                                          | Primitive double                                 |
++----------------------------------------------------------+--------------------------------------------------+
+| string                                                   | Primitive string                                 |
++----------------------------------------------------------+--------------------------------------------------+
+| array                                                    | An array with arbitrary keys, and values.        |
++----------------------------------------------------------+--------------------------------------------------+
+| array<T>                                                 | A list of type T (T can be any available type).  |
+|                                                          | Examples:                                        |
+|                                                          | array<string>, array<MyNamespace\MyObject>, etc. |
++----------------------------------------------------------+--------------------------------------------------+
+| array<K, V>                                              | A map of keys of type K to values of type V.     |
+|                                                          | Examples: array<string, string>,                 |
+|                                                          | array<string, MyNamespace\MyObject>, etc.        |
++----------------------------------------------------------+--------------------------------------------------+
+| DateTime                                                 | PHP's DateTime object (default format/timezone)  |
++----------------------------------------------------------+--------------------------------------------------+
+| DateTime<'format'>                                       | PHP's DateTime object (custom format/default     |
+|                                                          | timezone)                                        |
++----------------------------------------------------------+--------------------------------------------------+
+| DateTime<'format', 'zone'>                               | PHP's DateTime object (custom format/timezone)   |
++----------------------------------------------------------+--------------------------------------------------+
+| DateTime<'format', 'zone', 'deserializeFormat'>          | PHP's DateTime object (custom format/timezone,   |
+|                                                          | deserialize format)                              |
++----------------------------------------------------------+--------------------------------------------------+
+| DateTimeImmutable                                        | PHP's DateTimeImmutable object (default format/  |
+|                                                          | timezone)                                        |
++----------------------------------------------------------+--------------------------------------------------+
+| DateTimeImmutable<'format'>                              | PHP's DateTimeImmutable object (custom format/   |
+|                                                          | default timezone)                                |
++----------------------------------------------------------+--------------------------------------------------+
+| DateTimeImmutable<'format', 'zone'>                      | PHP's DateTimeImmutable object (custom format/   |
+|                                                          | timezone)                                        |
++----------------------------------------------------------+--------------------------------------------------+
+| DateTimeImmutable<'format', 'zone', 'deserializeFormat'> | PHP's DateTimeImmutable object (custom format/   |
+|                                                          | timezone/deserialize format)                     |
++----------------------------------------------------------+--------------------------------------------------+
+| DateInterval                                             | PHP's DateInterval object using ISO 8601 format  |
++----------------------------------------------------------+--------------------------------------------------+
+| T                                                        | Where T is a fully qualified class name.         |
++----------------------------------------------------------+--------------------------------------------------+
+| ArrayCollection<T>                                       | Similar to array<T>, but will be deserialized    |
+|                                                          | into Doctrine's ArrayCollection class.           |
++----------------------------------------------------------+--------------------------------------------------+
+| ArrayCollection<K, V>                                    | Similar to array<K, V>, but will be deserialized |
+|                                                          | into Doctrine's ArrayCollection class.           |
++----------------------------------------------------------+--------------------------------------------------+
 
 Examples:
 

--- a/src/Handler/DateHandler.php
+++ b/src/Handler/DateHandler.php
@@ -175,8 +175,8 @@ class DateHandler implements SubscribingHandlerInterface
 
     private function parseDateTime($data, array $type, $immutable = false)
     {
-        $timezone = isset($type['params'][1]) ? new \DateTimeZone($type['params'][1]) : $this->defaultTimezone;
-        $format = $this->getFormat($type);
+        $timezone = isset($type['params'][1]) && $type['params'][1] != "" ? new \DateTimeZone($type['params'][1]) : $this->defaultTimezone;
+        $format = $this->getFormat($type, true);
 
         if ($immutable) {
             $datetime = \DateTimeImmutable::createFromFormat($format, (string)$data, $timezone);
@@ -206,9 +206,13 @@ class DateHandler implements SubscribingHandlerInterface
     /**
      * @return string
      * @param array $type
+     * @param bool $deserialize
      */
-    private function getFormat(array $type)
+    private function getFormat(array $type, $deserialize = false)
     {
+        if ($deserialize && isset($type['params'][2])){
+          return $type['params'][2];
+        }
         return isset($type['params'][0]) ? $type['params'][0] : $this->defaultFormat;
     }
 

--- a/src/Handler/DateHandler.php
+++ b/src/Handler/DateHandler.php
@@ -175,7 +175,7 @@ class DateHandler implements SubscribingHandlerInterface
 
     private function parseDateTime($data, array $type, $immutable = false)
     {
-        $timezone = isset($type['params'][1]) && $type['params'][1] != "" ? new \DateTimeZone($type['params'][1]) : $this->defaultTimezone;
+        $timezone = !empty($type['params'][1]) ? new \DateTimeZone($type['params'][1]) : $this->defaultTimezone;
         $format = $this->getFormat($type, true);
 
         if ($immutable) {
@@ -210,8 +210,8 @@ class DateHandler implements SubscribingHandlerInterface
      */
     private function getFormat(array $type, $deserialize = false)
     {
-        if ($deserialize && isset($type['params'][2])){
-          return $type['params'][2];
+        if ($deserialize && isset($type['params'][2])) {
+            return $type['params'][2];
         }
         return isset($type['params'][0]) ? $type['params'][0] : $this->defaultFormat;
     }

--- a/tests/Handler/DateHandlerTest.php
+++ b/tests/Handler/DateHandlerTest.php
@@ -1,0 +1,74 @@
+<?php
+
+namespace JMS\Serializer\Tests\Handler;
+
+use Doctrine\Common\Collections\ArrayCollection;
+use JMS\Serializer\Handler\DateHandler;
+use JMS\Serializer\JsonDeserializationVisitor;
+use JMS\Serializer\SerializationContext;
+use JMS\Serializer\VisitorInterface;
+use Metadata\MetadataFactoryInterface;
+
+class DateHandlerTest extends \PHPUnit_Framework_TestCase
+{
+
+    private $date = '2017-06-18';
+
+    public function testSerializeDate()
+    {
+        $handler = new DateHandler();
+        $timezone = new \DateTimeZone('UTC');
+        $datetime = \DateTime::createFromFormat('Y-m-d|', $this->date, $timezone);
+
+        $visitor = $this->getMockBuilder(VisitorInterface::class)->getMock();
+        $visitor->method('visitString')->with($this->date)->willReturn($this->date);
+        $context = $this->getMockBuilder(SerializationContext::class)->getMock();
+
+        // Test with type only
+        $type = ['name' => 'DateTime', 'params' => ['Y-m-d']];
+        $this->assertEquals(
+            $this->date,
+            $handler->serializeDateTime($visitor, $datetime, $type, $context)
+        );
+
+        // Test with deserialize type and empty timezone
+        $type = ['name' => 'DateTime', 'params' => ['Y-m-d', '', 'Y-m-d|']];
+        $this->assertEquals(
+            $this->date,
+            $handler->serializeDateTime($visitor, $datetime, $type, $context)
+        );
+
+        // Test with other deserialize type and empty timezone
+        $type = ['name' => 'DateTime', 'params' => ['Y-m-d', '', 'Y']];
+        $this->assertEquals(
+            $this->date,
+            $handler->serializeDateTime($visitor, $datetime, $type, $context)
+        );
+    }
+
+    public function testDeserializeDate()
+    {
+        $handler = new DateHandler();
+        $timezone = new \DateTimeZone('UTC');
+        $datetime = \DateTime::createFromFormat('Y-m-d|', $this->date, $timezone);
+
+        $visitor = $this->getMockBuilder(JsonDeserializationVisitor::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        // Test with type only
+        // Might fail if the time is exactly 00:00:00.0000
+        $type = ['name' => 'DateTime', 'params' => ['Y-m-d']];
+        $this->assertNotEquals(
+            $datetime,
+            $handler->deserializeDateTimeFromJson($visitor, $this->date, $type)
+        );
+
+        // Test with deserialize type and empty timezone
+        $type = ['name' => 'DateTime', 'params' => ['Y-m-d', '', 'Y-m-d|']];
+        $this->assertEquals(
+            $datetime,
+            $handler->deserializeDateTimeFromJson($visitor, $this->date, $type)
+        );
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| Doc updated   | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | https://github.com/schmittjoh/JMSSerializerBundle/issues/582
| License       | Apache-2.0

This PR adds an third parameter to the DateTime format for the Type annotation, allowing to use a different deserialization type. This can be useful when only serializing dates in a custom format and you need to have the other fields all zeroed. 