### PR TITLE
Detect XML xsi:nil="true" to null when deserializing

### DIFF
--- a/src/AbstractVisitor.php
+++ b/src/AbstractVisitor.php
@@ -62,5 +62,4 @@ abstract class AbstractVisitor implements VisitorInterface
             return $typeArray['params'][0];
         }
     }
-
 }

--- a/src/GraphNavigator.php
+++ b/src/GraphNavigator.php
@@ -125,6 +125,15 @@ final class GraphNavigator
             $type = array('name' => 'NULL', 'params' => array());
         }
 
+        // Sometimes data can convey null but is not of a null type.
+        // Visitors can have the power to add this custom null evaluation
+        if ($visitor instanceof VisitorInterface
+            && $visitor instanceof NullEvaluatorInterface
+            && $visitor->evaluatesToNull($data) === true
+        ) {
+            $type = array('name' => 'NULL', 'params' => array());
+        }
+
         switch ($type['name']) {
             case 'NULL':
                 return $visitor->visitNull($data, $type, $context);

--- a/src/GraphNavigator.php
+++ b/src/GraphNavigator.php
@@ -124,13 +124,9 @@ final class GraphNavigator
         else if ($context instanceof SerializationContext && null === $data) {
             $type = array('name' => 'NULL', 'params' => array());
         }
-
         // Sometimes data can convey null but is not of a null type.
         // Visitors can have the power to add this custom null evaluation
-        if ($visitor instanceof VisitorInterface
-            && $visitor instanceof NullEvaluatorInterface
-            && $visitor->evaluatesToNull($data) === true
-        ) {
+        if ($visitor instanceof NullAwareVisitorInterface && $visitor->isNull($data) === true) {
             $type = array('name' => 'NULL', 'params' => array());
         }
 

--- a/src/NullAwareVisitorInterface.php
+++ b/src/NullAwareVisitorInterface.php
@@ -18,7 +18,7 @@
 
 namespace JMS\Serializer;
 
-interface NullEvaluatorInterface
+interface NullAwareVisitorInterface extends VisitorInterface
 {
     /**
      * Determine if a value conveys a null value.
@@ -28,5 +28,5 @@ interface NullEvaluatorInterface
      *
      * @return bool
      */
-    public function evaluatesToNull($value);
+    public function isNull($value);
 }

--- a/src/NullEvaluatorInterface.php
+++ b/src/NullEvaluatorInterface.php
@@ -16,23 +16,17 @@
  * limitations under the License.
  */
 
-namespace JMS\Serializer\Tests\Fixtures;
+namespace JMS\Serializer;
 
-use JMS\Serializer\Annotation\Type;
-
-class ObjectWithNullProperty extends SimpleObject
+interface NullEvaluatorInterface
 {
     /**
-     * @var null
-     * @Type("string")
+     * Determine if a value conveys a null value.
+     * An example could be an xml element (Dom, SimpleXml, ...) that is tagged with a xsi:nil attribute
+     *
+     * @param mixed $value
+     *
+     * @return bool
      */
-    private $nullProperty = null;
-
-    /**
-     * @return null
-     */
-    public function getNullProperty()
-    {
-        return $this->nullProperty;
-    }
+    public function evaluatesToNull($value);
 }

--- a/src/XmlDeserializationVisitor.php
+++ b/src/XmlDeserializationVisitor.php
@@ -25,7 +25,7 @@ use JMS\Serializer\Exception\XmlErrorException;
 use JMS\Serializer\Metadata\ClassMetadata;
 use JMS\Serializer\Metadata\PropertyMetadata;
 
-class XmlDeserializationVisitor extends AbstractVisitor implements NullEvaluatorInterface
+class XmlDeserializationVisitor extends AbstractVisitor implements NullAwareVisitorInterface
 {
     private $objectStack;
     private $metadataStack;
@@ -393,7 +393,7 @@ class XmlDeserializationVisitor extends AbstractVisitor implements NullEvaluator
      *
      * @return bool
      */
-    public function evaluatesToNull($value)
+    public function isNull($value)
     {
         if ($value instanceof \SimpleXMLElement) {
             $xsiAttributes = $value->attributes('http://www.w3.org/2001/XMLSchema-instance');

--- a/src/XmlDeserializationVisitor.php
+++ b/src/XmlDeserializationVisitor.php
@@ -25,7 +25,7 @@ use JMS\Serializer\Exception\XmlErrorException;
 use JMS\Serializer\Metadata\ClassMetadata;
 use JMS\Serializer\Metadata\PropertyMetadata;
 
-class XmlDeserializationVisitor extends AbstractVisitor
+class XmlDeserializationVisitor extends AbstractVisitor implements NullEvaluatorInterface
 {
     private $objectStack;
     private $metadataStack;
@@ -386,5 +386,24 @@ class XmlDeserializationVisitor extends AbstractVisitor
         $internalSubset = str_replace(array("[ <!", "> ]>"), array('[<!', '>]>'), $internalSubset);
 
         return $internalSubset;
+    }
+
+    /**
+     * @param mixed $value
+     *
+     * @return bool
+     */
+    public function evaluatesToNull($value)
+    {
+        if ($value instanceof \SimpleXMLElement) {
+            $xsiAttributes = $value->attributes('http://www.w3.org/2001/XMLSchema-instance');
+
+            //We have to keep the isset quiet, some tests give error: `Node no longer exists`; even though it evaluates to false
+            if (@isset($xsiAttributes['nil']) && (string) $xsiAttributes['nil'] === 'true') {
+                return true;
+            }
+        }
+
+        return $value === null;
     }
 }

--- a/tests/Serializer/BaseSerializationTest.php
+++ b/tests/Serializer/BaseSerializationTest.php
@@ -166,6 +166,25 @@ abstract class BaseSerializationTest extends \PHPUnit_Framework_TestCase
         );
     }
 
+    public function testDeserializeNullObject()
+    {
+        if (!$this->hasDeserializer()) {
+            $this->markTestSkipped(sprintf('No deserializer available for format `%s`', $this->getFormat()));
+        }
+
+        $obj = new ObjectWithNullProperty('foo', 'bar');
+
+        /** @var ObjectWithNullProperty $dObj */
+        $dObj = $this->serializer->deserialize(
+            $this->getContent('simple_object_nullable'),
+            ObjectWithNullProperty::class,
+            $this->getFormat()
+        );
+
+        $this->assertEquals($obj, $dObj);
+        $this->assertNull($dObj->getNullProperty());
+    }
+
     /**
      * @dataProvider getTypes
      */

--- a/tests/Serializer/XmlSerializationTest.php
+++ b/tests/Serializer/XmlSerializationTest.php
@@ -26,6 +26,7 @@ use JMS\Serializer\Handler\DateHandler;
 use JMS\Serializer\Handler\HandlerRegistry;
 use JMS\Serializer\Metadata\StaticPropertyMetadata;
 use JMS\Serializer\Naming\CamelCaseNamingStrategy;
+use JMS\Serializer\Naming\PropertyNamingStrategyInterface;
 use JMS\Serializer\Naming\SerializedNameAnnotationStrategy;
 use JMS\Serializer\SerializationContext;
 use JMS\Serializer\Serializer;
@@ -52,6 +53,7 @@ use JMS\Serializer\Tests\Fixtures\PersonLocation;
 use JMS\Serializer\Tests\Fixtures\SimpleClassObject;
 use JMS\Serializer\Tests\Fixtures\SimpleObject;
 use JMS\Serializer\Tests\Fixtures\SimpleSubClassObject;
+use JMS\Serializer\XmlDeserializationVisitor;
 use JMS\Serializer\XmlSerializationVisitor;
 use PhpCollection\Map;
 
@@ -486,6 +488,16 @@ class XmlSerializationTest extends BaseSerializationTest
     public function testDeserializeEmptyString()
     {
         $this->deserialize('', 'stdClass');
+    }
+
+    public function testEvaluatesToNull()
+    {
+        $namingStrategy = $this->getMockBuilder(PropertyNamingStrategyInterface::class)->getMock();
+        $visitor = new XmlDeserializationVisitor($namingStrategy);
+        $element = simplexml_load_string('<empty xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>');
+
+        $this->assertTrue($visitor->evaluatesToNull($element));
+        $this->assertTrue($visitor->evaluatesToNull(null));
     }
 
     private function xpathFirstToString(\SimpleXMLElement $xml, $xpath)

--- a/tests/Serializer/XmlSerializationTest.php
+++ b/tests/Serializer/XmlSerializationTest.php
@@ -496,8 +496,8 @@ class XmlSerializationTest extends BaseSerializationTest
         $visitor = new XmlDeserializationVisitor($namingStrategy);
         $element = simplexml_load_string('<empty xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>');
 
-        $this->assertTrue($visitor->evaluatesToNull($element));
-        $this->assertTrue($visitor->evaluatesToNull(null));
+        $this->assertTrue($visitor->isNull($element));
+        $this->assertTrue($visitor->isNull(null));
     }
 
     private function xpathFirstToString(\SimpleXMLElement $xml, $xpath)


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| Doc updated   | -
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | https://github.com/schmittjoh/serializer/pull/771
| License       | Apache-2.0

This is an alternative implementation of #771 

The main difference is that the "null aware" interface is a visitor.

