### PR TITLE
Use AbstractVisitor for type hinting DateHandler

### DIFF
--- a/src/Handler/DateHandler.php
+++ b/src/Handler/DateHandler.php
@@ -18,12 +18,11 @@
 
 namespace JMS\Serializer\Handler;
 
+use JMS\Serializer\AbstractVisitor;
 use JMS\Serializer\Context;
 use JMS\Serializer\Exception\RuntimeException;
 use JMS\Serializer\GraphNavigator;
-use JMS\Serializer\JsonDeserializationVisitor;
 use JMS\Serializer\VisitorInterface;
-use JMS\Serializer\XmlDeserializationVisitor;
 use JMS\Serializer\XmlSerializationVisitor;
 
 class DateHandler implements SubscribingHandlerInterface
@@ -119,7 +118,7 @@ class DateHandler implements SubscribingHandlerInterface
         return isset($attributes['nil'][0]) && (string)$attributes['nil'][0] === 'true';
     }
 
-    public function deserializeDateTimeFromXml(XmlDeserializationVisitor $visitor, $data, array $type)
+    public function deserializeDateTimeFromXml(AbstractVisitor $visitor, $data, array $type)
     {
         if ($this->isDataXmlNull($data)) {
             return null;
@@ -128,7 +127,7 @@ class DateHandler implements SubscribingHandlerInterface
         return $this->parseDateTime($data, $type);
     }
 
-    public function deserializeDateTimeImmutableFromXml(XmlDeserializationVisitor $visitor, $data, array $type)
+    public function deserializeDateTimeImmutableFromXml(AbstractVisitor $visitor, $data, array $type)
     {
         if ($this->isDataXmlNull($data)) {
             return null;
@@ -137,7 +136,7 @@ class DateHandler implements SubscribingHandlerInterface
         return $this->parseDateTime($data, $type, true);
     }
 
-    public function deserializeDateIntervalFromXml(XmlDeserializationVisitor $visitor, $data, array $type)
+    public function deserializeDateIntervalFromXml(AbstractVisitor $visitor, $data, array $type)
     {
         if ($this->isDataXmlNull($data)) {
             return null;
@@ -146,7 +145,7 @@ class DateHandler implements SubscribingHandlerInterface
         return $this->parseDateInterval($data);
     }
 
-    public function deserializeDateTimeFromJson(JsonDeserializationVisitor $visitor, $data, array $type)
+    public function deserializeDateTimeFromJson(AbstractVisitor $visitor, $data, array $type)
     {
         if (null === $data) {
             return null;
@@ -155,7 +154,7 @@ class DateHandler implements SubscribingHandlerInterface
         return $this->parseDateTime($data, $type);
     }
 
-    public function deserializeDateTimeImmutableFromJson(JsonDeserializationVisitor $visitor, $data, array $type)
+    public function deserializeDateTimeImmutableFromJson(AbstractVisitor $visitor, $data, array $type)
     {
         if (null === $data) {
             return null;
@@ -164,7 +163,7 @@ class DateHandler implements SubscribingHandlerInterface
         return $this->parseDateTime($data, $type, true);
     }
 
-    public function deserializeDateIntervalFromJson(JsonDeserializationVisitor $visitor, $data, array $type)
+    public function deserializeDateIntervalFromJson(AbstractVisitor $visitor, $data, array $type)
     {
         if (null === $data) {
             return null;

--- a/tests/Handler/DateHandlerTest.php
+++ b/tests/Handler/DateHandlerTest.php
@@ -2,6 +2,7 @@
 
 namespace JMS\Serializer\Tests\Handler;
 
+use JMS\Serializer\AbstractVisitor;
 use JMS\Serializer\Handler\DateHandler;
 use JMS\Serializer\JsonDeserializationVisitor;
 use JMS\Serializer\SerializationContext;
@@ -64,7 +65,7 @@ class DateHandlerTest extends \PHPUnit_Framework_TestCase
 
     public function testTimePartGetsPreserved()
     {
-        $visitor = $this->getMockBuilder(JsonDeserializationVisitor::class)
+        $visitor = $this->getMockBuilder(AbstractVisitor::class)
             ->disableOriginalConstructor()
             ->getMock();
 


### PR DESCRIPTION
instead of the concrete implementations (XmlDeserializationVisitor,
JsonDeserializationVisitor). This offers more flexibility, as using
custom deserialization visitors that extend the abstract class causes
problems now.
Also updated test to use a mock of the AbstractVisitor class instead
of the conrete implementations.

| Q             | A
| ------------- | ---
| Bug fix?      |no
| New feature?  |no
| Doc updated   |no
| BC breaks?    |no
| Deprecations? |no
| Tests pass?   | yes
| Fixed tickets | #... 
| License       | Apache-2.0

