### PR TITLE
Added mapping for guid type

### DIFF
--- a/src/JMS/Serializer/Metadata/Driver/AbstractDoctrineTypeDriver.php
+++ b/src/JMS/Serializer/Metadata/Driver/AbstractDoctrineTypeDriver.php
@@ -41,6 +41,7 @@ abstract class AbstractDoctrineTypeDriver implements DriverInterface
         'string' => 'string',
         'text' => 'string',
         'blob' => 'string',
+        'guid' => 'string',
 
         'integer' => 'integer',
         'smallint' => 'integer',

--- a/tests/Fixtures/Doctrine/BlogPost.php
+++ b/tests/Fixtures/Doctrine/BlogPost.php
@@ -35,7 +35,7 @@ use JMS\Serializer\Annotation\XmlRoot;
 class BlogPost
 {
     /**
-     * @ORM\Id @ORM\Column(type="integer")
+     * @ORM\Id @ORM\Column(type="guid") @ORM\GeneratedValue(strategy="UUID")
      */
     protected $id;
 

--- a/tests/Metadata/Driver/DoctrineDriverTest.php
+++ b/tests/Metadata/Driver/DoctrineDriverTest.php
@@ -106,6 +106,16 @@ class DoctrineDriverTest extends \PHPUnit_Framework_TestCase
         $this->assertNull($doctrineMetadata->propertyMetadata['ref']->type);
     }
 
+    public function testGuidPropertyIsGivenStringType()
+    {
+        $metadata = $this->getMetadata();
+
+        $this->assertEquals(
+            array('name' => 'string', 'params' => array()),
+            $metadata->propertyMetadata['id']->type
+        );
+    }
+
     protected function getEntityManager()
     {
         $config = new Configuration();


### PR DESCRIPTION
I recognized that my Entites ids, that have alle the type 'guid' are not serialized and shown in the, from NelmioApiDocBundle generated, documentation, but it always serialized in e.g. json output. 

So i dived into the parsers and came up to this file, where guid was not in the fieldMapping 

This little commit gives the possibility to map the guid type, too. 
