### PR TITLE
Use fallback in DoctrineObjectConstructor when identifier is null

### DIFF
--- a/src/JMS/Serializer/Construction/DoctrineObjectConstructor.php
+++ b/src/JMS/Serializer/Construction/DoctrineObjectConstructor.php
@@ -87,7 +87,7 @@ class DoctrineObjectConstructor implements ObjectConstructorInterface
         $identifierList = array();
 
         foreach ($classMetadata->getIdentifierFieldNames() as $name) {
-            if (!array_key_exists($name, $data)) {
+            if (!isset($data[$name])) {
                 return $this->fallbackConstructor->construct($visitor, $metadata, $data, $type, $context);
             }
 

--- a/tests/Serializer/Doctrine/ObjectConstructorTest.php
+++ b/tests/Serializer/Doctrine/ObjectConstructorTest.php
@@ -106,6 +106,21 @@ class ObjectConstructorTest extends \PHPUnit_Framework_TestCase
         $this->assertSame($author, $authorFetched);
     }
 
+    public function testMissingIdentifierFallback()
+    {
+        $author = new Author('John');
+
+        $fallback = $this->getMockBuilder(ObjectConstructorInterface::class)->getMock();
+        $fallback->expects($this->once())->method('construct')->willReturn($author);
+
+        $type = array('name' => Author::class, 'params' => array());
+        $class = new ClassMetadata(Author::class);
+
+        $constructor = new DoctrineObjectConstructor($this->registry, $fallback, DoctrineObjectConstructor::ON_MISSING_FALLBACK);
+        $authorFetched = $constructor->construct($this->visitor, $class, ['id' => null], $type, $this->context);
+        $this->assertSame($author, $authorFetched);
+    }
+
     public function testMissingNotManaged()
     {
         $author = new \JMS\Serializer\Tests\Fixtures\DoctrinePHPCR\Author('foo');


### PR DESCRIPTION
In the environment I'm currently working in, the incoming data to be deserialized always includes the identifier field, even if the value is `null` and thus no database record exists.

In such cases the `DoctrineObjectConstructor` is calling the `find` method from the repository regardless, even though the identifiers (primary key) can never be null (at least in all DBMS I've worked with and according to standard SQL).

This will inevitably cause an exception to be raised in Doctrine (see [EntityManager.php](https://github.com/doctrine/doctrine2/blob/a0c0d3bf2a7f49020ad7e54d7d3319a251574230/lib/Doctrine/ORM/EntityManager.php#L404)).

This pull request extends the current behaviour to treat identifiers with `null` values the same way as if they were not given in the data array at all.