### PR TITLE
Groups doctrine deserialization

### DIFF
--- a/src/JMS/Serializer/Construction/DoctrineObjectConstructor.php
+++ b/src/JMS/Serializer/Construction/DoctrineObjectConstructor.php
@@ -135,20 +135,23 @@ class DoctrineObjectConstructor implements ObjectConstructorInterface
         /** @var array $deserializingGroups */
         $deserializingGroups = $context->getGroups()->getOrElse(array());
 
-        // Avoid calling objectManager->find if the deserialization context groups do exclude identification properties
+        // Avoid calling objectManager->find if the deserialization context groups exclude identification properties
         foreach ($classMetadata->getIdentifierFieldNames() as $name) {
             $missingIdentifier = !array_key_exists($name, $data);
 
-            if (0 < count($deserializingGroups)) {
+            if (0 < count($deserializingGroups) && false === $missingIdentifier) {
                 $propertyGroups = $this->getPropertyGroups($context, $metadata->name, $name);
+                $groupForIdentFound = false;
 
                 // group list match on at least one group?
                 foreach ($deserializingGroups as $deserializingGroup) {
                     if (in_array($deserializingGroup, $propertyGroups)) {
-                        $missingIdentifier = false;
+                        $groupForIdentFound = true;
                         break;
                     }
                 }
+
+                $missingIdentifier = $missingIdentifier || (!$groupForIdentFound);
             }
 
             if (true === $missingIdentifier) {

--- a/src/JMS/Serializer/Construction/DoctrineObjectConstructor.php
+++ b/src/JMS/Serializer/Construction/DoctrineObjectConstructor.php
@@ -121,11 +121,10 @@ class DoctrineObjectConstructor implements ObjectConstructorInterface
         $classMetadata  = $objectManager->getClassMetadata($metadata->name);
         $identifierList = array();
         /** @var array $deserializingGroups */
-        $deserializingGroups = ($context->getGroups() instanceof None)? array() : $context->getGroups();
+        $deserializingGroups = $context->getGroups()->getOrElse(array());
 
         foreach ($classMetadata->getIdentifierFieldNames() as $name) {
-            $this->getPropertyGroups($context, $type['name'], $name);
-            $propertyGroups = $this->getPropertyGroups($context, $type['name'], $name);
+            $propertyGroups = $this->getPropertyGroups($context, $metadata->name, $name);
 
             $useFallback = true;
 

--- a/src/JMS/Serializer/Construction/DoctrineObjectConstructor.php
+++ b/src/JMS/Serializer/Construction/DoctrineObjectConstructor.php
@@ -19,40 +19,59 @@
 namespace JMS\Serializer\Construction;
 
 use Doctrine\Common\Persistence\ManagerRegistry;
-use JMS\Serializer\DeserializationContext;
-use JMS\Serializer\Exception\InvalidArgumentException;
-use JMS\Serializer\Exception\ObjectConstructionException;
-use JMS\Serializer\Metadata\ClassMetadata;
 use JMS\Serializer\VisitorInterface;
+use JMS\Serializer\Metadata\ClassMetadata;
+use JMS\Serializer\DeserializationContext;
+use PhpOption\None;
+use JMS\Serializer\Metadata\Driver\AnnotationDriver;
+use JMS\Serializer\Metadata\ClassMetadata as JMSClassMetadata;
+use \Doctrine\Common\Persistence\Mapping\ClassMetadata as DoctrineClassMetadata;
 
 /**
  * Doctrine object constructor for new (or existing) objects during deserialization.
  */
 class DoctrineObjectConstructor implements ObjectConstructorInterface
 {
-    const ON_MISSING_NULL = 'null';
-    const ON_MISSING_EXCEPTION = 'exception';
-    const ON_MISSING_FALLBACK = 'fallback';
-    /**
-     * @var string
-     */
-    private $fallbackStrategy;
-
     private $managerRegistry;
     private $fallbackConstructor;
+
+    /** @var AnnotationDriver */
+    private $annotationDriver;
 
     /**
      * Constructor.
      *
-     * @param ManagerRegistry $managerRegistry Manager registry
+     * @param ManagerRegistry            $managerRegistry     Manager registry
      * @param ObjectConstructorInterface $fallbackConstructor Fallback object constructor
-     * @param string $fallbackStrategy
      */
-    public function __construct(ManagerRegistry $managerRegistry, ObjectConstructorInterface $fallbackConstructor, $fallbackStrategy = self::ON_MISSING_NULL)
+    public function __construct(ManagerRegistry $managerRegistry, ObjectConstructorInterface $fallbackConstructor)
     {
-        $this->managerRegistry = $managerRegistry;
+        $this->managerRegistry     = $managerRegistry;
         $this->fallbackConstructor = $fallbackConstructor;
-        $this->fallbackStrategy = $fallbackStrategy;
+    }
+
+    public function setAnnotationDriver (AnnotationDriver $annotationDriver)
+    {
+        $this->annotationDriver = $annotationDriver;
+    }
+
+    protected function getPropertyGroups(JMSClassMetadata $metadata, $property)
+    {
+        $classMetadata = $this->annotationDriver->loadMetadataForClass($metadata->reflection);
+
+        // up to the hierarchy
+        while ($classMetadata) {
+            // limit case
+            if (array_key_exists($property, $classMetadata->propertyMetadata)) {
+                $propertyGroups = $classMetadata->propertyMetadata[$property]->groups ?? array();
+                return $propertyGroups;
+            }
+
+            $parent = $classMetadata->reflection->getParentClass();
+            $classMetadata = $this->annotationDriver->loadMetadataForClass($parent);
+        }
+
+        return array();
     }
 
     /**
@@ -63,7 +82,7 @@ class DoctrineObjectConstructor implements ObjectConstructorInterface
         // Locate possible ObjectManager
         $objectManager = $this->managerRegistry->getManagerForClass($metadata->name);
 
-        if (!$objectManager) {
+        if (! $objectManager) {
             // No ObjectManager found, proceed with normal deserialization
             return $this->fallbackConstructor->construct($visitor, $metadata, $data, $type, $context);
         }
@@ -77,17 +96,32 @@ class DoctrineObjectConstructor implements ObjectConstructorInterface
         }
 
         // Managed entity, check for proxy load
-        if (!is_array($data)) {
+        if (! is_array($data)) {
             // Single identifier, load proxy
             return $objectManager->getReference($metadata->name, $data);
         }
 
         // Fallback to default constructor if missing identifier(s)
-        $classMetadata = $objectManager->getClassMetadata($metadata->name);
+        /** @var DoctrineClassMetadata $classMetadata*/
+        $classMetadata  = $objectManager->getClassMetadata($metadata->name);
         $identifierList = array();
+        /** @var array $deserializingGroups */
+        $deserializingGroups = ($context->attributes->get('groups') instanceof None)? array() : $context->attributes->get('groups')->get();
 
         foreach ($classMetadata->getIdentifierFieldNames() as $name) {
-            if (!array_key_exists($name, $data)) {
+            $propertyGroups = $this->getPropertyGroups($metadata, $name);
+
+            $useFallback = true;
+
+            // group list match on at least one group?
+            foreach ($deserializingGroups as $deserializingGroup) {
+                if(in_array($deserializingGroup, $propertyGroups)) {
+                    $useFallback = false;
+                    break;
+                }
+            }
+
+            if (! array_key_exists($name, $data) || $useFallback ) {
                 return $this->fallbackConstructor->construct($visitor, $metadata, $data, $type, $context);
             }
 
@@ -97,17 +131,9 @@ class DoctrineObjectConstructor implements ObjectConstructorInterface
         // Entity update, load it from database
         $object = $objectManager->find($metadata->name, $identifierList);
 
-        if (null === $object) {
-            switch ($this->fallbackStrategy) {
-                case self::ON_MISSING_NULL:
-                    return null;
-                case self::ON_MISSING_EXCEPTION:
-                    throw new ObjectConstructionException(sprintf("Entity %s can not be found", $metadata->name));
-                case self::ON_MISSING_FALLBACK:
-                    return $this->fallbackConstructor->construct($visitor, $metadata, $data, $type, $context);
-                default:
-                    throw new InvalidArgumentException("The provided fallback strategy for the object constructor is not valid");
-            }
+        if (! is_object($object)) {
+            // Entity with that identifier didn't exist, create a new Entity
+            return $this->fallbackConstructor->construct($visitor, $metadata, $data, $type, $context);
         }
 
         $objectManager->initializeObject($object);

--- a/src/JMS/Serializer/Construction/DoctrineObjectConstructor.php
+++ b/src/JMS/Serializer/Construction/DoctrineObjectConstructor.php
@@ -22,6 +22,7 @@ use Doctrine\Common\Persistence\ManagerRegistry;
 use JMS\Serializer\VisitorInterface;
 use JMS\Serializer\Metadata\ClassMetadata;
 use JMS\Serializer\DeserializationContext;
+use Metadata\Driver\DriverInterface;
 use PhpOption\None;
 use JMS\Serializer\Metadata\Driver\AnnotationDriver;
 use JMS\Serializer\Metadata\ClassMetadata as JMSClassMetadata;
@@ -50,12 +51,12 @@ class DoctrineObjectConstructor implements ObjectConstructorInterface
         $this->fallbackConstructor = $fallbackConstructor;
     }
 
-    public function setAnnotationDriver (AnnotationDriver $annotationDriver)
-    {
-        $this->annotationDriver = $annotationDriver;
-    }
+//    public function setAnnotationDriver (DriverInterface $annotationDriver)
+//    {
+//        $this->annotationDriver = $annotationDriver;
+//    }
 
-    protected function getPropertyGroups(JMSClassMetadata $metadata, $property)
+    protected function getPropertyGroups(JMSClassMetadata $metadata, $property, DeserializationContext $context)
     {
         $classMetadata = $this->annotationDriver->loadMetadataForClass($metadata->reflection);
 
@@ -63,7 +64,12 @@ class DoctrineObjectConstructor implements ObjectConstructorInterface
         while ($classMetadata) {
             // limit case
             if (array_key_exists($property, $classMetadata->propertyMetadata)) {
-                $propertyGroups = $classMetadata->propertyMetadata[$property]->groups ?? array();
+                $propertyGroups = $classMetadata->propertyMetadata[$property]->groups;
+
+                if (null === $propertyGroups) {
+                    $propertyGroups = array();
+                }
+
                 return $propertyGroups;
             }
 
@@ -109,7 +115,10 @@ class DoctrineObjectConstructor implements ObjectConstructorInterface
         $deserializingGroups = ($context->attributes->get('groups') instanceof None)? array() : $context->attributes->get('groups')->get();
 
         foreach ($classMetadata->getIdentifierFieldNames() as $name) {
-            $propertyGroups = $this->getPropertyGroups($metadata, $name);
+            die(var_dump($context->getMetadataFactory()));
+            $propertyGroups = $context->getMetadataFactory()->getMetadataForClass($type['name']);
+            die(var_dump($propertyGroups));
+//            $propertyGroups = $this->getPropertyGroups($metadata, $name, $context);
 
             $useFallback = true;
 

--- a/src/JMS/Serializer/Context.php
+++ b/src/JMS/Serializer/Context.php
@@ -177,6 +177,14 @@ abstract class Context
         return $this;
     }
 
+    /**
+     * @return \PhpOption\None|\PhpOption\Option|\PhpOption\Some
+     */
+    public function getGroups()
+    {
+        return $this->attributes->get('groups');
+    }
+
     public function enableMaxDepthChecks()
     {
         $this->addExclusionStrategy(new DepthExclusionStrategy());

--- a/tests/Fixtures/Doctrine/Author.php
+++ b/tests/Fixtures/Doctrine/Author.php
@@ -20,18 +20,21 @@ namespace JMS\Serializer\Tests\Fixtures\Doctrine;
 
 use Doctrine\ORM\Mapping as ORM;
 use JMS\Serializer\Annotation\SerializedName;
+use JMS\Serializer\Annotation\Groups;
 
 /** @ORM\Entity */
 class Author
 {
     /**
      * @ORM\Id @ORM\Column(type="integer")
+     * @Groups({"id_group"})
      */
     protected $id;
 
     /**
      * @ORM\Column(type="string")
      * @SerializedName("full_name")
+     * @Groups({"non_id_group"})
      */
     private $name;
 
@@ -44,5 +47,10 @@ class Author
     public function getName()
     {
         return $this->name;
+    }
+
+    public function setId($id)
+    {
+        $this->id = $id;
     }
 }

--- a/tests/Serializer/Doctrine/ObjectConstructorTest.php
+++ b/tests/Serializer/Doctrine/ObjectConstructorTest.php
@@ -192,7 +192,16 @@ class ObjectConstructorTest extends \PHPUnit_Framework_TestCase
 
     public function testDeserializingObjectWithContextGroupsNotIncludingIDs()
     {
-        $context = $this->getMockBuilder('JMS\Serializer\DeserializationContext')->getMock();
+        $context = $this->getMockBuilder('JMS\Serializer\DeserializationContext')
+//            ->disableOriginalConstructor()
+            ->disableOriginalClone()
+            ->disableArgumentCloning()
+            ->disallowMockingUnknownTypes()
+            ->getMock();
+        $context->method('getMetadataFactory')->willReturn('prova');
+
+//        die(var_dump($context->getMetadataFactory()));
+
         $context->attributes->set('groups', array('non_id_group'));
         $fallback = $this->getMockBuilder(ObjectConstructorInterface::class)->getMock();
 
@@ -200,7 +209,7 @@ class ObjectConstructorTest extends \PHPUnit_Framework_TestCase
         $class = new ClassMetadata(Author::class);
 
         $constructor = new DoctrineObjectConstructor($this->registry, $fallback);
-        $authorFetched = $constructor->construct($this->visitor, $class, ['id' => 5, 'full_name' => 'Name to deserialize'], $type, $this->context);
+        $authorFetched = $constructor->construct($this->visitor, $class, ['id' => 5, 'full_name' => 'Name to deserialize'], $type, $context);
 
         $this->assertEquals(\Doctrine\ORM\UnitOfWork::STATE_NEW, $this->registry->getManager()->getUnitOfWork()->getEntityState($authorFetched));
         $this->assertNull($this->accessProtected($authorFetched, 'id'));


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Doc updated   | no
| BC breaks?    | no <!-- don't forget updating UPGRADING.md file -->
| Deprecations? | no <!-- don't forget updating UPGRADING.md file -->
| Tests pass?   | yes
| Fixed tickets | #... <!-- #-prefixed issue number(s), if any -->
| License       | Apache-2.0

Doctrine's ObjectConstructor ignored the Context groups that can be specified when deserializing. An identifier could be sent and it was used to find an entity, irrespective of its group.  This is not a problem if groups are not used while deserializing, but can cause big security concerns if groups are used to not let the user send data that could affect persisted data.
The pull request adds some tests to show it and it tries to fix it without altering the other functionalities. 