### PR TITLE
block doctrine/annotations version to 1.3.x

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
         "jms/parser-lib": "1.*",
         "phpoption/phpoption": "^1.1",
         "phpcollection/phpcollection": "~0.1",
-        "doctrine/annotations": "^1.0",
+        "doctrine/annotations": "~1.3.0",
         "doctrine/instantiator": "^1.0.3"
     },
     "conflict": {


### PR DESCRIPTION
doctrine/annotations requires PHP 7.1. PHP 5.x support was removed in 1.4.

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Doc updated   | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
| License       | Apache-2.0

