### PR TITLE
Allow `getSubscribedEvents` to return a Generator

### DIFF
--- a/src/JMS/Serializer/EventDispatcher/EventSubscriberInterface.php
+++ b/src/JMS/Serializer/EventDispatcher/EventSubscriberInterface.php
@@ -32,7 +32,7 @@ interface EventSubscriberInterface
      * The class may be omitted if the class wants to subscribe to events of all classes.
      * Same goes for the format key.
      *
-     * @return array
+     * @return array|\Generator
      */
     public static function getSubscribedEvents();
 }

--- a/tests/Serializer/EventDispatcher/EventDispatcherTest.php
+++ b/tests/Serializer/EventDispatcher/EventDispatcherTest.php
@@ -156,6 +156,25 @@ class EventDispatcherTest extends \PHPUnit_Framework_TestCase
         ), 'listeners', $this->dispatcher);
     }
 
+    public function testAddSubscriberIsGenerator()
+    {
+        $subscriber = new MockGeneratorSubscriber();
+        MockGeneratorSubscriber::$events = array(
+            array('event' => 'foo.bar_baz', 'format' => 'foo'),
+            array('event' => 'bar', 'method' => 'bar', 'class' => 'foo'),
+        );
+
+        $this->dispatcher->addSubscriber($subscriber);
+        $this->assertAttributeEquals(array(
+            'foo.bar_baz' => array(
+                array(array($subscriber, 'onfoobarbaz'), null, 'foo'),
+            ),
+            'bar' => array(
+                array(array($subscriber, 'bar'), 'foo', null),
+            ),
+        ), 'listeners', $this->dispatcher);
+    }
+
     protected function setUp()
     {
         $this->dispatcher = new EventDispatcher();
@@ -175,6 +194,18 @@ class MockSubscriber implements EventSubscriberInterface
     public static function getSubscribedEvents()
     {
         return self::$events;
+    }
+}
+
+class MockGeneratorSubscriber implements EventSubscriberInterface
+{
+    public static $events = array();
+
+    public static function getSubscribedEvents()
+    {
+        foreach (self::$events as $event) {
+            yield $event;
+        }
     }
 }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      |no
| New feature?  | yes
| Doc updated   |no
| BC breaks?    |no 
| Deprecations? |no 
| Tests pass?   | yes
| Fixed tickets | #832 
| License       | Apache-2.0

