### PR TITLE
Fixed issue where timezone is lost when creating DateTime from unix timestamp

### DIFF
--- a/src/JMS/Serializer/Handler/DateHandler.php
+++ b/src/JMS/Serializer/Handler/DateHandler.php
@@ -188,6 +188,8 @@ class DateHandler implements SubscribingHandlerInterface
             throw new RuntimeException(sprintf('Invalid datetime "%s", expected format %s.', $data, $format));
         }
 
+        $datetime->setTimezone($timezone);
+
         return $datetime;
     }
 

--- a/src/JMS/Serializer/Handler/DateHandler.php
+++ b/src/JMS/Serializer/Handler/DateHandler.php
@@ -188,7 +188,9 @@ class DateHandler implements SubscribingHandlerInterface
             throw new RuntimeException(sprintf('Invalid datetime "%s", expected format %s.', $data, $format));
         }
 
-        $datetime->setTimezone($timezone);
+        if ($format === 'U') {
+            $datetime = $datetime->setTimezone($timezone);
+        }
 
         return $datetime;
     }

--- a/tests/Handler/DateHandlerTest.php
+++ b/tests/Handler/DateHandlerTest.php
@@ -90,4 +90,26 @@ class DateHandlerTest extends \PHPUnit_Framework_TestCase
             $this->handler->deserializeDateTimeFromJson($visitor, '2017-06-18', $type)
         );
     }
+
+    public function testTimeZoneGetsPreserved()
+    {
+        $visitor = $this->getMockBuilder(JsonDeserializationVisitor::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+
+        $timestamp = time();
+        $timezone = 'Europe/Brussels';
+        $type = ['name' => 'DateTime', 'params' => ['U', $timezone]];
+
+        $expectedDateTime = \DateTime::createFromFormat('U', $timestamp);
+        $expectedDateTime->setTimezone(new \DateTimeZone($timezone));
+
+        $actualDateTime = $this->handler->deserializeDateTimeFromJson($visitor, $timestamp, $type);
+
+        $this->assertEquals(
+            $expectedDateTime->format(\DateTime::RFC3339),
+            $actualDateTime->format(\DateTime::RFC3339)
+        );
+    }
 }

--- a/tests/Handler/DateHandlerTest.php
+++ b/tests/Handler/DateHandlerTest.php
@@ -112,4 +112,26 @@ class DateHandlerTest extends \PHPUnit_Framework_TestCase
             $actualDateTime->format(\DateTime::RFC3339)
         );
     }
+
+    public function testImmutableTimeZoneGetsPreservedWithUnixTimestamp()
+    {
+        $visitor = $this->getMockBuilder(JsonDeserializationVisitor::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+
+        $timestamp = time();
+        $timezone = 'Europe/Brussels';
+        $type = ['name' => 'DateTimeImmutable', 'params' => ['U', $timezone]];
+
+        $expectedDateTime = \DateTime::createFromFormat('U', $timestamp);
+        $expectedDateTime->setTimezone(new \DateTimeZone($timezone));
+
+        $actualDateTime = $this->handler->deserializeDateTimeImmutableFromJson($visitor, $timestamp, $type);
+
+        $this->assertEquals(
+            $expectedDateTime->format(\DateTime::RFC3339),
+            $actualDateTime->format(\DateTime::RFC3339)
+        );
+    }
 }

--- a/tests/Handler/DateHandlerTest.php
+++ b/tests/Handler/DateHandlerTest.php
@@ -91,7 +91,7 @@ class DateHandlerTest extends \PHPUnit_Framework_TestCase
         );
     }
 
-    public function testTimeZoneGetsPreserved()
+    public function testTimeZoneGetsPreservedWithUnixTimestamp()
     {
         $visitor = $this->getMockBuilder(JsonDeserializationVisitor::class)
             ->disableOriginalConstructor()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Doc updated   | no
| BC breaks?    | no
| Deprecations? | no <!-- don't forget updating UPGRADING.md file -->
| Tests pass?   | yes
| Fixed tickets | /
| License       | Apache-2.0

Timezone is lost when creating a `DateTime` from a unix timestamp, quote from the [PHP docs](http://php.net/manual/en/datetime.construct.php)

> The $timezone parameter and the current timezone are ignored when the $time parameter either is a UNIX timestamp (e.g. @946684800) or specifies a timezone (e.g. 2010-01-28T15:00:00+02:00).

To fix this, I re-set the timezone after creating the `DateTime` object.


see https://github.com/schmittjoh/serializer/pull/829

