### PR TITLE
Fix documentation syntax errors on available types

### DIFF
--- a/doc/reference/annotations.rst
+++ b/doc/reference/annotations.rst
@@ -351,7 +351,7 @@ Available Types:
 |                                                          | Examples: array<string, string>,                 |
 |                                                          | array<string, MyNamespace\MyObject>, etc.        |
 +----------------------------------------------------------+--------------------------------------------------+
-| DateTime                                                 | PHP's DateTime object (default format*/timezone)  |
+| DateTime                                                 | PHP's DateTime object (default format*/timezone) |
 +----------------------------------------------------------+--------------------------------------------------+
 | DateTime<'format'>                                       | PHP's DateTime object (custom format/default     |
 |                                                          | timezone)                                        |
@@ -363,7 +363,7 @@ Available Types:
 |                                                          | specify a specific timezone, use an empty        |
 |                                                          | string ('').                                     |
 +----------------------------------------------------------+--------------------------------------------------+
-| DateTimeImmutable                                        | PHP's DateTimeImmutable object (default format*/  |
+| DateTimeImmutable                                        | PHP's DateTimeImmutable object (default format*/ |
 |                                                          | timezone)                                        |
 +----------------------------------------------------------+--------------------------------------------------+
 | DateTimeImmutable<'format'>                              | PHP's DateTimeImmutable object (custom format/   |
@@ -388,7 +388,7 @@ Available Types:
 |                                                          | into Doctrine's ArrayCollection class.           |
 +----------------------------------------------------------+--------------------------------------------------+
 
-*) If the standalone jms/serializer is used then default format is `\DateTime::ISO8601` (which is not compatible with ISO-8601 despite the name). For jms/serializer-bundle the default format is `\DateTime::ATOM` (the real ISO-8601 format) but it can be changed in [configuration](https://jmsyst.com/bundles/JMSSerializerBundle/master/configuration#configuration-block-2-0).
+(*) If the standalone jms/serializer is used then default format is `\DateTime::ISO8601` (which is not compatible with ISO-8601 despite the name). For jms/serializer-bundle the default format is `\DateTime::ATOM` (the real ISO-8601 format) but it can be changed in [configuration](https://jmsyst.com/bundles/JMSSerializerBundle/master/configuration#configuration-block-2-0).
 
 Examples:
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Doc updated   | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | no
| Fixed tickets | #838 
| License       | Apache-2.0

The changes committed in https://github.com/schmittjoh/serializer/pull/838 led to the table of available types not rendering (see: https://jmsyst.com/libs/serializer/master/reference/annotations#type).

This just corrects the whitespace so that the types table renders again
