### PR TITLE
support PSR-11 compatible DI containers

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -40,6 +40,8 @@
         "jackalope/jackalope-doctrine-dbal": "^1.1.5",
         "doctrine/phpcr-odm": "^1.3|^2.0",
         "propel/propel1": "~1.7",
+        "psr/container": "^1.0",
+        "symfony/dependency-injection": "^2.7|^3.3|^4.0",
         "symfony/yaml": "^2.1|^3.0",
         "symfony/translation": "^2.1|^3.0",
         "symfony/validator": "^2.2|^3.0",
@@ -60,7 +62,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "1.9-dev"
+            "dev-master": "1.10-dev"
         }
     }
 }

--- a/src/JMS/Serializer/EventDispatcher/LazyEventDispatcher.php
+++ b/src/JMS/Serializer/EventDispatcher/LazyEventDispatcher.php
@@ -18,14 +18,19 @@
 
 namespace JMS\Serializer\EventDispatcher;
 
+use Psr\Container\ContainerInterface as PsrContainerInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
 class LazyEventDispatcher extends EventDispatcher
 {
     private $container;
 
-    public function __construct(ContainerInterface $container)
+    public function __construct($container)
     {
+        if (!$container instanceof PsrContainerInterface && !$container instanceof ContainerInterface) {
+            throw new \InvalidArgumentException(sprintf('The container must be an instance of %s or %s (%s given).', PsrContainerInterface::class, ContainerInterface::class, is_object($container) ? get_class($container) : gettype($container)));
+        }
+
         $this->container = $container;
     }
 

--- a/src/JMS/Serializer/Handler/LazyHandlerRegistry.php
+++ b/src/JMS/Serializer/Handler/LazyHandlerRegistry.php
@@ -18,6 +18,7 @@
 
 namespace JMS\Serializer\Handler;
 
+use Psr\Container\ContainerInterface as PsrContainerInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
 class LazyHandlerRegistry extends HandlerRegistry
@@ -25,8 +26,12 @@ class LazyHandlerRegistry extends HandlerRegistry
     private $container;
     private $initializedHandlers = array();
 
-    public function __construct(ContainerInterface $container, array $handlers = array())
+    public function __construct($container, array $handlers = array())
     {
+        if (!$container instanceof PsrContainerInterface && !$container instanceof ContainerInterface) {
+            throw new \InvalidArgumentException(sprintf('The container must be an instance of %s or %s (%s given).', PsrContainerInterface::class, ContainerInterface::class, is_object($container) ? get_class($container) : gettype($container)));
+        }
+
         parent::__construct($handlers);
         $this->container = $container;
     }

--- a/tests/Handler/HandlerRegistryTest.php
+++ b/tests/Handler/HandlerRegistryTest.php
@@ -1,0 +1,64 @@
+<?php
+
+/*
+ * Copyright 2016 Johannes M. Schmitt <schmittjoh@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace JMS\Serializer\Tests\Handler;
+
+use JMS\Serializer\GraphNavigator;
+use JMS\Serializer\Handler\HandlerRegistry;
+
+class HandlerRegistryTest extends \PHPUnit_Framework_TestCase
+{
+    protected $handlerRegistry;
+
+    protected function setUp()
+    {
+        $this->handlerRegistry = $this->createHandlerRegistry();
+    }
+
+    public function testRegisteredHandlersCanBeRetrieved()
+    {
+        $jsonSerializationHandler = new DummyHandler();
+        $this->handlerRegistry->registerHandler(GraphNavigator::DIRECTION_SERIALIZATION, '\stdClass', 'json', $jsonSerializationHandler);
+
+        $jsonDeserializationHandler = new DummyHandler();
+        $this->handlerRegistry->registerHandler(GraphNavigator::DIRECTION_DESERIALIZATION, '\stdClass', 'json', $jsonDeserializationHandler);
+
+        $xmlSerializationHandler = new DummyHandler();
+        $this->handlerRegistry->registerHandler(GraphNavigator::DIRECTION_SERIALIZATION, '\stdClass', 'xml', $xmlSerializationHandler);
+
+        $xmlDeserializationHandler = new DummyHandler();
+        $this->handlerRegistry->registerHandler(GraphNavigator::DIRECTION_DESERIALIZATION, '\stdClass', 'xml', $xmlDeserializationHandler);
+
+        $this->assertSame($jsonSerializationHandler, $this->handlerRegistry->getHandler(GraphNavigator::DIRECTION_SERIALIZATION, '\stdClass', 'json'));
+        $this->assertSame($jsonDeserializationHandler, $this->handlerRegistry->getHandler(GraphNavigator::DIRECTION_DESERIALIZATION, '\stdClass', 'json'));
+        $this->assertSame($xmlSerializationHandler, $this->handlerRegistry->getHandler(GraphNavigator::DIRECTION_SERIALIZATION, '\stdClass', 'xml'));
+        $this->assertSame($xmlDeserializationHandler, $this->handlerRegistry->getHandler(GraphNavigator::DIRECTION_DESERIALIZATION, '\stdClass', 'xml'));
+    }
+
+    protected function createHandlerRegistry()
+    {
+        return new HandlerRegistry();
+    }
+}
+
+class DummyHandler
+{
+    public function __call($name, $arguments)
+    {
+    }
+}

--- a/tests/Handler/LazyHandlerRegistryTest.php
+++ b/tests/Handler/LazyHandlerRegistryTest.php
@@ -1,0 +1,74 @@
+<?php
+
+/*
+ * Copyright 2016 Johannes M. Schmitt <schmittjoh@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace JMS\Serializer\Tests\Handler;
+
+use JMS\Serializer\GraphNavigator;
+use JMS\Serializer\Handler\LazyHandlerRegistry;
+
+abstract class LazyHandlerRegistryTest extends HandlerRegistryTest
+{
+    protected $container;
+
+    protected function setUp()
+    {
+        $this->container = $this->createContainer();
+
+        parent::setUp();
+    }
+
+    protected function createHandlerRegistry()
+    {
+        return new LazyHandlerRegistry($this->container);
+    }
+
+    public function testRegisteredHandlersCanBeRetrievedWhenBeingDefinedAsServices()
+    {
+        $jsonSerializationHandler = new HandlerService();
+        $this->registerHandlerService('handler.serialization.json', $jsonSerializationHandler);
+        $this->handlerRegistry->registerHandler(GraphNavigator::DIRECTION_SERIALIZATION, '\stdClass', 'json', array('handler.serialization.json', 'handle'));
+
+        $jsonDeserializationHandler = new HandlerService();
+        $this->registerHandlerService('handler.deserialization.json', $jsonDeserializationHandler);
+        $this->handlerRegistry->registerHandler(GraphNavigator::DIRECTION_DESERIALIZATION, '\stdClass', 'json', array('handler.deserialization.json', 'handle'));
+
+        $xmlSerializationHandler = new HandlerService();
+        $this->registerHandlerService('handler.serialization.xml', $xmlSerializationHandler);
+        $this->handlerRegistry->registerHandler(GraphNavigator::DIRECTION_SERIALIZATION, '\stdClass', 'xml', array('handler.serialization.xml', 'handle'));
+
+        $xmlDeserializationHandler = new HandlerService();
+        $this->registerHandlerService('handler.deserialization.xml', $xmlDeserializationHandler);
+        $this->handlerRegistry->registerHandler(GraphNavigator::DIRECTION_DESERIALIZATION, '\stdClass', 'xml', array('handler.deserialization.xml', 'handle'));
+
+        $this->assertSame(array($jsonSerializationHandler, 'handle'), $this->handlerRegistry->getHandler(GraphNavigator::DIRECTION_SERIALIZATION, '\stdClass', 'json'));
+        $this->assertSame(array($jsonDeserializationHandler, 'handle'), $this->handlerRegistry->getHandler(GraphNavigator::DIRECTION_DESERIALIZATION, '\stdClass', 'json'));
+        $this->assertSame(array($xmlSerializationHandler, 'handle'), $this->handlerRegistry->getHandler(GraphNavigator::DIRECTION_SERIALIZATION, '\stdClass', 'xml'));
+        $this->assertSame(array($xmlDeserializationHandler, 'handle'), $this->handlerRegistry->getHandler(GraphNavigator::DIRECTION_DESERIALIZATION, '\stdClass', 'xml'));
+    }
+
+    abstract protected function createContainer();
+
+    abstract protected function registerHandlerService($serviceId, $listener);
+}
+
+class HandlerService
+{
+    public function handle()
+    {
+    }
+}

--- a/tests/Handler/LazyHandlerRegistryWithPsr11ContainerTest.php
+++ b/tests/Handler/LazyHandlerRegistryWithPsr11ContainerTest.php
@@ -1,0 +1,54 @@
+<?php
+
+/*
+ * Copyright 2016 Johannes M. Schmitt <schmittjoh@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace JMS\Serializer\Tests\Handler;
+
+use Psr\Container\ContainerInterface;
+
+class LazyHandlerRegistryWithPsr11ContainerTest extends LazyHandlerRegistryTest
+{
+    protected function createContainer()
+    {
+        return new Psr11Container();
+    }
+
+    protected function registerHandlerService($serviceId, $listener)
+    {
+        $this->container->set($serviceId, $listener);
+    }
+}
+
+class Psr11Container implements ContainerInterface
+{
+    private $services;
+
+    public function get($id)
+    {
+        return $this->services[$id];
+    }
+
+    public function has($id)
+    {
+        return isset($this->services[$id]);
+    }
+
+    public function set($id, $service)
+    {
+        $this->services[$id] = $service;
+    }
+}

--- a/tests/Handler/LazyHandlerRegistryWithSymfonyContainerTest.php
+++ b/tests/Handler/LazyHandlerRegistryWithSymfonyContainerTest.php
@@ -1,0 +1,34 @@
+<?php
+
+/*
+ * Copyright 2016 Johannes M. Schmitt <schmittjoh@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace JMS\Serializer\Tests\Handler;
+
+use Symfony\Component\DependencyInjection\Container;
+
+class LazyHandlerRegistryWithSymfonyContainerTest extends LazyHandlerRegistryTest
+{
+    protected function createContainer()
+    {
+        return new Container();
+    }
+
+    protected function registerHandlerService($serviceId, $listener)
+    {
+        $this->container->set($serviceId, $listener);
+    }
+}

--- a/tests/Serializer/EventDispatcher/EventDispatcherTest.php
+++ b/tests/Serializer/EventDispatcher/EventDispatcherTest.php
@@ -29,8 +29,8 @@ class EventDispatcherTest extends \PHPUnit_Framework_TestCase
     /**
      * @var EventDispatcher
      */
-    private $dispatcher;
-    private $event;
+    protected $dispatcher;
+    protected $event;
 
     public function testHasListeners()
     {
@@ -158,11 +158,16 @@ class EventDispatcherTest extends \PHPUnit_Framework_TestCase
 
     protected function setUp()
     {
-        $this->dispatcher = new EventDispatcher();
+        $this->dispatcher = $this->createEventDispatcher();
         $this->event = new ObjectEvent($this->getMockBuilder('JMS\Serializer\Context')->getMock(), new \stdClass(), array('name' => 'foo', 'params' => array()));
     }
 
-    private function dispatch($eventName, $class = 'Foo', $format = 'json', Event $event = null)
+    protected function createEventDispatcher()
+    {
+        return new EventDispatcher();
+    }
+
+    protected function dispatch($eventName, $class = 'Foo', $format = 'json', Event $event = null)
     {
         $this->dispatcher->dispatch($eventName, $class, $format, $event ?: $this->event);
     }

--- a/tests/Serializer/EventDispatcher/LazyEventDispatcherTest.php
+++ b/tests/Serializer/EventDispatcher/LazyEventDispatcherTest.php
@@ -1,0 +1,78 @@
+<?php
+
+/*
+ * Copyright 2016 Johannes M. Schmitt <schmittjoh@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace JMS\Serializer\Tests\Serializer\EventDispatcher;
+
+use JMS\Serializer\EventDispatcher\LazyEventDispatcher;
+
+abstract class LazyEventDispatcherTest extends EventDispatcherTest
+{
+    protected $container;
+
+    protected function setUp()
+    {
+        $this->container = $this->createContainer();
+
+        parent::setUp();
+    }
+
+    public function testHasListenersWithListenerAsService()
+    {
+        $a = new MockListener();
+        $this->registerListenerService('a', $a);
+
+        $this->assertFalse($this->dispatcher->hasListeners('foo', 'Foo', 'json'));
+        $this->dispatcher->addListener('foo', ['a', 'foo']);
+        $this->assertTrue($this->dispatcher->hasListeners('foo', 'Foo', 'json'));
+    }
+
+    public function testDispatchWithListenerAsService()
+    {
+        $a = new MockListener();
+        $this->registerListenerService('a', $a);
+
+        $this->dispatcher->addListener('foo', ['a', 'foo']);
+        $this->dispatch('bar');
+        $a->_verify('Listener is not called for other event.');
+
+        $b = new MockListener();
+        $this->registerListenerService('b', $b);
+
+        $this->dispatcher->addListener('pre', array('b', 'bar'), 'Bar');
+        $this->dispatcher->addListener('pre', array('b', 'foo'), 'Foo');
+        $this->dispatcher->addListener('pre', array('b', 'all'));
+
+        $b->bar($this->event, 'pre', 'bar', 'json', $this->dispatcher);
+        $b->all($this->event, 'pre', 'bar', 'json', $this->dispatcher);
+        $b->foo($this->event, 'pre', 'foo', 'json', $this->dispatcher);
+        $b->all($this->event, 'pre', 'foo', 'json', $this->dispatcher);
+        $b->_replay();
+        $this->dispatch('pre', 'Bar');
+        $this->dispatch('pre', 'Foo');
+        $b->_verify();
+    }
+
+    protected function createEventDispatcher()
+    {
+        return new LazyEventDispatcher($this->container);
+    }
+
+    abstract protected function createContainer();
+
+    abstract protected function registerListenerService($serviceId, MockListener $listener);
+}

--- a/tests/Serializer/EventDispatcher/LazyEventDispatcherWithPsr11ContainerTest.php
+++ b/tests/Serializer/EventDispatcher/LazyEventDispatcherWithPsr11ContainerTest.php
@@ -1,0 +1,54 @@
+<?php
+
+/*
+ * Copyright 2016 Johannes M. Schmitt <schmittjoh@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace JMS\Serializer\Tests\Serializer\EventDispatcher;
+
+use Psr\Container\ContainerInterface;
+
+class LazyEventDispatcherWithPsr11ContainerTest extends LazyEventDispatcherTest
+{
+    protected function createContainer()
+    {
+        return new Psr11Container();
+    }
+
+    protected function registerListenerService($serviceId, MockListener $listener)
+    {
+        $this->container->set($serviceId, $listener);
+    }
+}
+
+class Psr11Container implements ContainerInterface
+{
+    private $services;
+
+    public function get($id)
+    {
+        return $this->services[$id];
+    }
+
+    public function has($id)
+    {
+        return isset($this->services[$id]);
+    }
+
+    public function set($id, $service)
+    {
+        $this->services[$id] = $service;
+    }
+}

--- a/tests/Serializer/EventDispatcher/LazyEventDispatcherWithSymfonyContainerTest.php
+++ b/tests/Serializer/EventDispatcher/LazyEventDispatcherWithSymfonyContainerTest.php
@@ -1,0 +1,34 @@
+<?php
+
+/*
+ * Copyright 2016 Johannes M. Schmitt <schmittjoh@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace JMS\Serializer\Tests\Serializer\EventDispatcher;
+
+use Symfony\Component\DependencyInjection\Container;
+
+class LazyEventDispatcherWithSymfonyContainerTest extends LazyEventDispatcherTest
+{
+    protected function createContainer()
+    {
+        return new Container();
+    }
+
+    protected function registerListenerService($serviceId, MockListener $listener)
+    {
+        $this->container->set($serviceId, $listener);
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| Doc updated   | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
| License       | Apache-2.0

To be able to use lazily-loaded event dispatchers even with private services in JMSSerializerBundle we can leverage the `ServiceLocator` feature introduced in Symfony 3.3. However, that class does not depend on the `ContainerInterface` from the DI component, but just needs an arbitrary PSR-11 compatible `ContainerInterface` implementation (which the Symfony containers implements too since Symfony 3.3). The same applies to the `LazyHandlerRegistry`.