### PR TITLE
Added Object handler + test

### DIFF
--- a/src/JMS/Serializer/Handler/ObjectHandler.php
+++ b/src/JMS/Serializer/Handler/ObjectHandler.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace JMS\Serializer\Handler;
+
+use JMS\Serializer\Context;
+use JMS\Serializer\Exception\RuntimeException;
+use JMS\Serializer\GraphNavigator;
+use JMS\Serializer\JsonDeserializationVisitor;
+use JMS\Serializer\JsonSerializationVisitor;
+
+class ObjectHandler implements SubscribingHandlerInterface
+{
+    public static function getSubscribingMethods()
+    {
+        $methods = [];
+
+        foreach (array('json', 'xml', 'yml') as $format) {
+            $methods[] = [
+                'direction' => GraphNavigator::DIRECTION_SERIALIZATION,
+                'format' => $format,
+                'type' => 'Object',
+                'method' => 'serializeObject',
+            ];
+            $methods[] = [
+                'direction' => GraphNavigator::DIRECTION_DESERIALIZATION,
+                'format' => $format,
+                'type' => 'Object',
+                'method' => 'deserializeObject',
+            ];
+        }
+
+        return $methods;
+    }
+
+    public function serializeObject(JsonSerializationVisitor $visitor, $object, array $type, Context $context)
+    {
+        if ($object === null) {
+            return null;
+        }
+
+        $class = get_class($object);
+        $type['name'] = $class;
+        $serialisation = $context->getNavigator()->accept($object, $type, $context);
+        $serialisation['::class'] = $class;
+
+        return $serialisation;
+    }
+
+    public function deserializeObject(JsonDeserializationVisitor $visitor, $data, array $type, Context $context)
+    {
+        if ($data === null) {
+            return null;
+        }
+
+        if (!isset($data['::class'])) {
+            throw new RuntimeException('The ::class property was missing for a dynamic object type.');
+        }
+        $type['name'] = $data['::class'];
+        unset($data['::class']);
+        return $context->getNavigator()->accept($data, $type, $context);
+    }
+}

--- a/tests/Fixtures/Handler/DynamicObject.php
+++ b/tests/Fixtures/Handler/DynamicObject.php
@@ -1,0 +1,20 @@
+<?php
+
+
+namespace JMS\Serializer\Tests\Fixtures\Handler;
+
+use JMS\Serializer\Annotation as JMS;
+
+class DynamicObject
+{
+    /**
+     * @var string
+     * @JMS\Type("string")
+     */
+    private $string;
+
+    public function setProperties()
+    {
+        $this->string = 'hello';
+    }
+}

--- a/tests/Fixtures/Handler/ObjectFixture.php
+++ b/tests/Fixtures/Handler/ObjectFixture.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace JMS\Serializer\Tests\Fixtures\Handler;
+
+use JMS\Serializer\Annotation as JMS;
+
+class ObjectFixture
+{
+    /**
+     * @JMS\Type("integer")
+     */
+    private $id;
+
+    /**
+     * @JMS\Type("Object")
+     */
+    private $object;
+
+    public function setProperties()
+    {
+        $this->id = 3;
+        $this->object = new DynamicObject();
+        $this->object->setProperties();
+        return $this;
+    }
+}

--- a/tests/Handler/ObjectHandlerTest.php
+++ b/tests/Handler/ObjectHandlerTest.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace JMS\Serializer\Tests\Handler;
+
+use JMS\Serializer\Handler\HandlerRegistry;
+use JMS\Serializer\Handler\ObjectHandler;
+use JMS\Serializer\Serializer;
+use JMS\Serializer\SerializerBuilder;
+use JMS\Serializer\Tests\Fixtures\Handler\DynamicObject;
+use JMS\Serializer\Tests\Fixtures\Handler\ObjectFixture;
+
+class ObjectHandlerTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @var Serializer
+     */
+    private $serializer;
+
+    public function setUp()
+    {
+        $this->serializer  = SerializerBuilder::create()
+            ->configureHandlers(function (HandlerRegistry $registry) {
+                $registry->registerSubscribingHandler(new ObjectHandler());
+            })
+            ->addDefaultHandlers()
+            ->build();
+    }
+
+    public function testSerializeObject()
+    {
+        $result = $this->serializer->toArray((new ObjectFixture())->setProperties());
+
+        self::assertEquals(
+            ['id' => 3, 'object' => ['string' => 'hello', '::class' => DynamicObject::class]],
+            $result
+        );
+    }
+
+    public function testDeSerializeObject()
+    {
+        $result = $this->serializer->fromArray(
+            ['id' => 3, 'object' => ['string' => 'hello', '::class' => DynamicObject::class]],
+            ObjectFixture::class
+        );
+
+        self::assertEquals(
+            (new ObjectFixture())->setProperties(),
+            $result
+        );
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| Doc updated   | no
| BC breaks?    | no 
| Deprecations? | no
| Tests pass?   | yes
| License       | Apache-2.0

This adds a dynamic Object type for (de)serialization. When serializing, it adds an additional property to the result: '::class' which records the class of the object that is in the property to allow for correct deserialization. 

At the moment this handler isn't registered by default. Should it be?

Docs need updating based on answer to above question.

Future scope for this might be to include a paramter eg Object<Interface> to perform a check that the object is an instance of an interface or extends a base class.

