### PR TITLE
Allow excluded private properties to not have a getter acc…

### DIFF
--- a/src/JMS/Serializer/Handler/DateHandler.php
+++ b/src/JMS/Serializer/Handler/DateHandler.php
@@ -188,6 +188,8 @@ class DateHandler implements SubscribingHandlerInterface
             throw new RuntimeException(sprintf('Invalid datetime "%s", expected format %s.', $data, $format));
         }
 
+        $datetime->setTimezone($timezone);
+
         return $datetime;
     }
 

--- a/src/JMS/Serializer/Handler/DateHandler.php
+++ b/src/JMS/Serializer/Handler/DateHandler.php
@@ -188,7 +188,9 @@ class DateHandler implements SubscribingHandlerInterface
             throw new RuntimeException(sprintf('Invalid datetime "%s", expected format %s.', $data, $format));
         }
 
-        $datetime->setTimezone($timezone);
+        if ($format === 'U') {
+            $datetime = $datetime->setTimezone($timezone);
+        }
 
         return $datetime;
     }

--- a/src/JMS/Serializer/Metadata/Driver/XmlDriver.php
+++ b/src/JMS/Serializer/Metadata/Driver/XmlDriver.php
@@ -160,6 +160,10 @@ class XmlDriver extends AbstractFileDriver
                         $isExclude = 'true' === strtolower($exclude);
                     }
 
+                    if ($isExclude) {
+                        continue;
+                    }
+
                     if (null !== $expose = $pElem->attributes()->expose) {
                         $isExpose = 'true' === strtolower($expose);
                     }

--- a/src/JMS/Serializer/Metadata/Driver/YamlDriver.php
+++ b/src/JMS/Serializer/Metadata/Driver/YamlDriver.php
@@ -91,6 +91,10 @@ class YamlDriver extends AbstractFileDriver
                         $isExclude = (Boolean)$pConfig['exclude'];
                     }
 
+                    if ($isExclude) {
+                        continue;
+                    }
+
                     if (isset($pConfig['expose'])) {
                         $isExpose = (Boolean)$pConfig['expose'];
                     }

--- a/tests/Fixtures/ExcludePublicAccessor.php
+++ b/tests/Fixtures/ExcludePublicAccessor.php
@@ -1,0 +1,50 @@
+<?php
+
+/*
+ * Copyright 2016 Johannes M. Schmitt <schmittjoh@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace JMS\Serializer\Tests\Fixtures;
+
+use JMS\Serializer\Annotation\AccessType;
+use JMS\Serializer\Annotation\Exclude;
+use JMS\Serializer\Annotation\ReadOnly;
+
+/**
+ */
+
+/**
+ * @AccessType("public_method")
+ * @ReadOnly
+ */
+class ExcludePublicAccessor
+{
+    /**
+     * @Exclude
+     *
+     * @var mixed
+     */
+    private $iShallNotBeAccessed;
+
+    /**
+     * @var int
+     */
+    private $id = 1;
+
+    public function getId()
+    {
+        return $this->id;
+    }
+}

--- a/tests/Handler/DateHandlerTest.php
+++ b/tests/Handler/DateHandlerTest.php
@@ -90,4 +90,26 @@ class DateHandlerTest extends \PHPUnit_Framework_TestCase
             $this->handler->deserializeDateTimeFromJson($visitor, '2017-06-18', $type)
         );
     }
+
+    public function testTimeZoneGetsPreserved()
+    {
+        $visitor = $this->getMockBuilder(JsonDeserializationVisitor::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+
+        $timestamp = time();
+        $timezone = 'Europe/Brussels';
+        $type = ['name' => 'DateTime', 'params' => ['U', $timezone]];
+
+        $expectedDateTime = \DateTime::createFromFormat('U', $timestamp);
+        $expectedDateTime->setTimezone(new \DateTimeZone($timezone));
+
+        $actualDateTime = $this->handler->deserializeDateTimeFromJson($visitor, $timestamp, $type);
+
+        $this->assertEquals(
+            $expectedDateTime->format(\DateTime::RFC3339),
+            $actualDateTime->format(\DateTime::RFC3339)
+        );
+    }
 }

--- a/tests/Handler/DateHandlerTest.php
+++ b/tests/Handler/DateHandlerTest.php
@@ -112,4 +112,26 @@ class DateHandlerTest extends \PHPUnit_Framework_TestCase
             $actualDateTime->format(\DateTime::RFC3339)
         );
     }
+
+    public function testImmutableTimeZoneGetsPreservedWithUnixTimestamp()
+    {
+        $visitor = $this->getMockBuilder(JsonDeserializationVisitor::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+
+        $timestamp = time();
+        $timezone = 'Europe/Brussels';
+        $type = ['name' => 'DateTimeImmutable', 'params' => ['U', $timezone]];
+
+        $expectedDateTime = \DateTime::createFromFormat('U', $timestamp);
+        $expectedDateTime->setTimezone(new \DateTimeZone($timezone));
+
+        $actualDateTime = $this->handler->deserializeDateTimeImmutableFromJson($visitor, $timestamp, $type);
+
+        $this->assertEquals(
+            $expectedDateTime->format(\DateTime::RFC3339),
+            $actualDateTime->format(\DateTime::RFC3339)
+        );
+    }
 }

--- a/tests/Handler/DateHandlerTest.php
+++ b/tests/Handler/DateHandlerTest.php
@@ -91,7 +91,7 @@ class DateHandlerTest extends \PHPUnit_Framework_TestCase
         );
     }
 
-    public function testTimeZoneGetsPreserved()
+    public function testTimeZoneGetsPreservedWithUnixTimestamp()
     {
         $visitor = $this->getMockBuilder(JsonDeserializationVisitor::class)
             ->disableOriginalConstructor()

--- a/tests/Metadata/Driver/BaseDriverTest.php
+++ b/tests/Metadata/Driver/BaseDriverTest.php
@@ -477,6 +477,17 @@ abstract class BaseDriverTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($p, $m->propertyMetadata['age']);
     }
 
+    public function testExcludePropertyNoPublicAccessorException()
+    {
+        $first = $this->getDriver()->loadMetadataForClass(new \ReflectionClass('JMS\Serializer\Tests\Fixtures\ExcludePublicAccessor'));
+
+        if ($this instanceof PhpDriverTest) {
+            return;
+        }
+        $this->assertArrayHasKey('id', $first->propertyMetadata);
+        $this->assertArrayNotHasKey('iShallNotBeAccessed', $first->propertyMetadata);
+    }
+
 
     /**
      * @return DriverInterface

--- a/tests/Metadata/Driver/DoctrineDriverTest.php
+++ b/tests/Metadata/Driver/DoctrineDriverTest.php
@@ -100,6 +100,15 @@ class DoctrineDriverTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($plainMetadata, $doctrineMetadata);
     }
 
+    public function testExcludePropertyNoPublicAccessorException()
+    {
+        $first = $this->getAnnotationDriver()
+            ->loadMetadataForClass(new \ReflectionClass('JMS\Serializer\Tests\Fixtures\ExcludePublicAccessor'));
+
+        $this->assertArrayHasKey('id', $first->propertyMetadata);
+        $this->assertArrayNotHasKey('iShallNotBeAccessed', $first->propertyMetadata);
+    }
+
     public function testVirtualPropertiesAreNotModified()
     {
         $doctrineMetadata = $this->getMetadata();

--- a/tests/Metadata/Driver/xml/ExcludePublicAccessor.xml
+++ b/tests/Metadata/Driver/xml/ExcludePublicAccessor.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<serializer>
+    <class name="JMS\Serializer\Tests\Fixtures\ExcludePublicAccessor" access-type="public_method" read-only="true">
+        <property name="iShallNotBeAccessed" exclude="true" />
+    </class>
+</serializer>

--- a/tests/Metadata/Driver/yml/ExcludePublicAccessor.yml
+++ b/tests/Metadata/Driver/yml/ExcludePublicAccessor.yml
@@ -1,0 +1,6 @@
+JMS\Serializer\Tests\Fixtures\ExcludePublicAccessor:
+    access_type: public_method
+    read_only: false
+    properties:
+        iShallNotBeAccessed:
+          exclude: true


### PR DESCRIPTION
…essor

Exception is thrown, if the class accessor is set to public_method, and there is an excluded property with no accessor

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Doc updated   | no
| BC breaks?    | no 
| Deprecations? | no 
| Tests pass?   | yes
| Fixed tickets | #862
| License       | Apache-2.0

