### PR TITLE
Deserialize xmlKeyValuePairs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,18 @@
 # Change Log
 
-## [1.9.2](https://github.com/schmittjoh/serializer/tree/1.9.2) (2017-11-22)
+## [1.10.0](https://github.com/schmittjoh/serializer/tree/1.10.0)
 
+**Implemented enhancements:**
+
+- support PSR-11 compatible DI containers [\#844](https://github.com/schmittjoh/serializer/pull/844) ([xabbuh](https://github.com/xabbuh))
+
+**Closed issues:**
+
+- Serialize using jsonSerialize\(\) if object implements JsonSerializable [\#846](https://github.com/schmittjoh/serializer/issues/846)
+- ExclusionStrategy backward compatibility break [\#843](https://github.com/schmittjoh/serializer/issues/843)
+- @MaxDepth jms/serializer-bundle 2.2 [\#842](https://github.com/schmittjoh/serializer/issues/842)
+
+## [1.9.2](https://github.com/schmittjoh/serializer/tree/1.9.2) (2017-11-22)
 **Fixed bugs:**
 
 - Missing ClassMetadata deserialization data [\#841](https://github.com/schmittjoh/serializer/pull/841) ([TristanMogwai](https://github.com/TristanMogwai))

--- a/src/JMS/Serializer/GraphNavigator.php
+++ b/src/JMS/Serializer/GraphNavigator.php
@@ -150,15 +150,6 @@ final class GraphNavigator
                 return $visitor->visitDouble($data, $type, $context);
 
             case 'array':
-                $metadata = $context->getMetadataStack()->count() ? $context->getMetadataStack()->top() : null;
-                if ($visitor instanceof XmlDeserializationVisitor && null !== $metadata && $metadata->xmlKeyValuePairs) {
-                    $visitor->setCurrentMetadata($metadata);
-                    $result = $visitor->visitArray($data, $type, $context);
-                    $visitor->revertCurrentMetadata();
-
-                    return $result;
-                }
-
                 return $visitor->visitArray($data, $type, $context);
 
             case 'resource':

--- a/src/JMS/Serializer/XmlDeserializationVisitor.php
+++ b/src/JMS/Serializer/XmlDeserializationVisitor.php
@@ -156,6 +156,7 @@ class XmlDeserializationVisitor extends AbstractVisitor implements NullAwareVisi
             if (2 !== count($type['params'])) {
                 throw new RuntimeException('The array type must be specified as "array<K,V>" for Key-Value-Pairs.');
             }
+            $this->revertCurrentMetadata();
 
             list($keyType, $entryType) = $type['params'];
 
@@ -313,6 +314,10 @@ class XmlDeserializationVisitor extends AbstractVisitor implements NullAwareVisi
                 return;
             }
             $node = reset($nodes);
+        }
+
+        if ($metadata->xmlKeyValuePairs) {
+            $this->setCurrentMetadata($metadata);
         }
 
         $v = $this->navigator->accept($node, $metadata->type, $context);

--- a/tests/Fixtures/ObjectWithXmlKeyValuePairsWithObjectType.php
+++ b/tests/Fixtures/ObjectWithXmlKeyValuePairsWithObjectType.php
@@ -1,0 +1,47 @@
+<?php
+
+/*
+ * Copyright 2016 Johannes M. Schmitt <schmittjoh@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace JMS\Serializer\Tests\Fixtures;
+
+use JMS\Serializer\Annotation\Type;
+use JMS\Serializer\Annotation\XmlKeyValuePairs;
+
+class ObjectWithXmlKeyValuePairsWithObjectType
+{
+    /**
+     * @var array
+     * @Type("array<string,JMS\Serializer\Tests\Fixtures\ObjectWithXmlKeyValuePairsWithType>")
+     * @XmlKeyValuePairs
+     */
+    private $list;
+
+    public function __construct(array $list)
+    {
+        $this->list = $list;
+    }
+
+    public static function create1()
+    {
+        return new self(
+            [
+                'key_first' => ObjectWithXmlKeyValuePairsWithType::create1(),
+                'key_second' => ObjectWithXmlKeyValuePairsWithType::create2(),
+            ]
+        );
+    }
+}

--- a/tests/Serializer/XmlSerializationTest.php
+++ b/tests/Serializer/XmlSerializationTest.php
@@ -43,6 +43,7 @@ use JMS\Serializer\Tests\Fixtures\ObjectWithNamespacesAndNestedList;
 use JMS\Serializer\Tests\Fixtures\ObjectWithToString;
 use JMS\Serializer\Tests\Fixtures\ObjectWithVirtualXmlProperties;
 use JMS\Serializer\Tests\Fixtures\ObjectWithXmlKeyValuePairs;
+use JMS\Serializer\Tests\Fixtures\ObjectWithXmlKeyValuePairsWithObjectType;
 use JMS\Serializer\Tests\Fixtures\ObjectWithXmlKeyValuePairsWithType;
 use JMS\Serializer\Tests\Fixtures\ObjectWithXmlNamespaces;
 use JMS\Serializer\Tests\Fixtures\ObjectWithXmlNamespacesAndObjectProperty;
@@ -282,13 +283,24 @@ class XmlSerializationTest extends BaseSerializationTest
     {
         $xml = $this->getContent('array_key_values_with_type_1');
         $result = $this->serializer->deserialize($xml, ObjectWithXmlKeyValuePairsWithType::class, 'xml');
+
         $this->assertInstanceOf(ObjectWithXmlKeyValuePairsWithType::class, $result);
         $this->assertEquals(ObjectWithXmlKeyValuePairsWithType::create1(), $result);
 
         $xml2 = $this->getContent('array_key_values_with_type_2');
         $result2 = $this->serializer->deserialize($xml2, ObjectWithXmlKeyValuePairsWithType::class, 'xml');
+
         $this->assertInstanceOf(ObjectWithXmlKeyValuePairsWithType::class, $result2);
         $this->assertEquals(ObjectWithXmlKeyValuePairsWithType::create2(), $result2);
+    }
+
+    public function testDeserializeTypedAndNestedArrayKeyValues()
+    {
+        $xml = $this->getContent('array_key_values_with_nested_type');
+        $result = $this->serializer->deserialize($xml, ObjectWithXmlKeyValuePairsWithObjectType::class, 'xml');
+
+        $this->assertInstanceOf(ObjectWithXmlKeyValuePairsWithObjectType::class, $result);
+        $this->assertEquals(ObjectWithXmlKeyValuePairsWithObjectType::create1(), $result);
     }
 
     /**

--- a/tests/Serializer/xml/array_key_values_with_nested_type.xml
+++ b/tests/Serializer/xml/array_key_values_with_nested_type.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<result>
+  <list>
+    <key_first>
+        <list>
+          <key-one><![CDATA[foo]]></key-one>
+          <key-two><![CDATA[bar]]></key-two>
+        </list>
+        <list2></list2>
+    </key_first>
+    <key_second>
+        <list>
+          <key_01><![CDATA[One]]></key_01>
+          <key_02><![CDATA[Two]]></key_02>
+          <key_03><![CDATA[Three]]></key_03>
+        </list>
+        <list2>
+          <entry><![CDATA[Four]]></entry>
+        </list2>
+    </key_second>
+  </list>
+</result>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      |no
| New feature?  | yes
| Doc updated   | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #820 schmittjoh/JMSSerializerBundle#521 schmittjoh/JMSSerializerBundle#470 #840
| License       | Apache-2.0

This is an updated version of #840. 

Allows to de serialize xml arrays with tag names as keys.

This version has a cleaner implementation and supports nested key-value objects 

