### PR TITLE
Drop HHVM support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,8 +21,8 @@ matrix:
     fast_finish: true
 
 before_script:
-    - if [[ $TRAVIS_PHP_VERSION  = '5.6' ]]; then PHPUNIT_FLAGS="--coverage-clover clover"; else PHPUNIT_FLAGS=""; fi
-    - if [[ $TRAVIS_PHP_VERSION != '5.6' ]]; then phpenv config-rm xdebug.ini; fi
+    - if [[ $TRAVIS_PHP_VERSION  = '7.0' ]]; then PHPUNIT_FLAGS="--coverage-clover clover"; else PHPUNIT_FLAGS=""; fi
+    - if [[ $TRAVIS_PHP_VERSION != '7.0' ]]; then phpenv config-rm xdebug.ini; fi
     - composer self-update
     - composer update $COMPOSER_FLAGS
 
@@ -33,6 +33,6 @@ script:
     - php tests/benchmark.php xml 10
 
 after_success:
-    - if [[ $TRAVIS_PHP_VERSION = '5.6' ]]; then wget https://scrutinizer-ci.com/ocular.phar; fi
-    - if [[ $TRAVIS_PHP_VERSION = '5.6' ]]; then php ocular.phar code-coverage:upload --format=php-clover clover; fi
+    - if [[ $TRAVIS_PHP_VERSION = '7.0' ]]; then wget https://scrutinizer-ci.com/ocular.phar; fi
+    - if [[ $TRAVIS_PHP_VERSION = '7.0' ]]; then php ocular.phar code-coverage:upload --format=php-clover clover; fi
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,14 +11,6 @@ cache:
 
 matrix:
     include:
-        - php: hhvm
-          sudo: required
-          dist: trusty
-          group: edge
-        - php: hhvm-nightly
-          sudo: required
-          dist: trusty
-          group: edge
         - php: 5.5
         - php: 5.6
         - php: 7.0
@@ -30,7 +22,7 @@ matrix:
 
 before_script:
     - if [[ $TRAVIS_PHP_VERSION  = '5.6' ]]; then PHPUNIT_FLAGS="--coverage-clover clover"; else PHPUNIT_FLAGS=""; fi
-    - if [[ $TRAVIS_PHP_VERSION != '5.6' &&  ! $TRAVIS_PHP_VERSION = hhvm* ]]; then phpenv config-rm xdebug.ini; fi
+    - if [[ $TRAVIS_PHP_VERSION != '5.6' ]]; then phpenv config-rm xdebug.ini; fi
     - composer self-update
     - composer update $COMPOSER_FLAGS
 

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
         }        
     ],
     "require": {
-        "php": ">=5.5.0",
+        "php": "^5.5|^7.0",
         "jms/metadata": "~1.1",
         "jms/parser-lib": "1.*",
         "phpoption/phpoption": "^1.1",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| Doc updated   | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
| License       | Apache-2.0

Most of PHP packages dropped HHVM support. Currently the test suite started to fail because of PHP-HHVM incompatibilities.

So also jms/serializer is dropping HHVM support.

*Thanks HHVM for pushing PHP to become what is PHP today!*
