### PR TITLE
Workaround for Node no longer exists

### DIFF
--- a/src/JMS/Serializer/XmlDeserializationVisitor.php
+++ b/src/JMS/Serializer/XmlDeserializationVisitor.php
@@ -268,11 +268,12 @@ class XmlDeserializationVisitor extends AbstractVisitor implements NullAwareVisi
         }
 
         if ($metadata->xmlAttribute) {
-
-            $attributes = $data->attributes($metadata->xmlNamespace);
-            if (isset($attributes[$name])) {
-                $v = $this->navigator->accept($attributes[$name], $metadata->type, $context);
-                $this->accessor->setValue($this->currentObject, $v, $metadata);
+            if ($data->getName() != "") {
+                $attributes = $data->attributes($metadata->xmlNamespace);
+                if (isset($attributes[$name])) {
+                    $v = $this->navigator->accept($attributes[$name], $metadata->type, $context);
+                    $this->accessor->setValue($this->currentObject, $v, $metadata);
+                }
             }
 
             return;


### PR DESCRIPTION
The `isset($attributes[$name])` sometimes also throws a notice like described in https://bugs.php.net/bug.php?id=75168

This introduces the workaround form #817 also in this place. We cannot use the `isNull` method here because of the todo mark in this method.

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Doc updated   | no
| BC breaks?    | no 
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #817
| License       | Apache-2.0

