### PR TITLE
make xml serializer a bit more configurable

### DIFF
--- a/src/JMS/Serializer/XmlSerializationVisitor.php
+++ b/src/JMS/Serializer/XmlSerializationVisitor.php
@@ -37,6 +37,7 @@ class XmlSerializationVisitor extends AbstractVisitor
     private $navigator;
     private $defaultRootName = 'result';
     private $defaultRootNamespace;
+    private $defaultRootPrefix = '';
     private $defaultVersion = '1.0';
     private $defaultEncoding = 'UTF-8';
     private $stack;
@@ -57,10 +58,11 @@ class XmlSerializationVisitor extends AbstractVisitor
         $this->formatOutput = true;
     }
 
-    public function setDefaultRootName($name, $namespace = null)
+    public function setDefaultRootName($name, $namespace = null, $prefix = '')
     {
         $this->defaultRootName = $name;
         $this->defaultRootNamespace = $namespace;
+        $this->defaultRootPrefix = !empty($prefix)?$prefix.':':'';
     }
 
     /**
@@ -216,7 +218,7 @@ class XmlSerializationVisitor extends AbstractVisitor
             }
 
             if ($rootNamespace) {
-                $this->currentNode = $this->document->createElementNS($rootNamespace, $rootName);
+                $this->currentNode = $this->document->createElementNS($rootNamespace,$this->defaultRootPrefix . $rootName);
             } else {
                 $this->currentNode = $this->document->createElement($rootName);
             }

--- a/src/JMS/Serializer/XmlSerializationVisitor.php
+++ b/src/JMS/Serializer/XmlSerializationVisitor.php
@@ -500,7 +500,7 @@ class XmlSerializationVisitor extends AbstractVisitor
         return $this->document->createElementNS($namespace, $prefix . ':' . $tagName);
     }
 
-    private function setAttributeOnNode(\DOMElement $node, $name, $value, $namespace = null)
+    protected function setAttributeOnNode(\DOMElement $node, $name, $value, $namespace = null)
     {
         if (null !== $namespace) {
             if (!$prefix = $node->lookupPrefix($namespace)) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      |/no
| New feature?  | yes
| Doc updated   | no
| BC breaks?    | no <!-- don't forget updating UPGRADING.md file -->
| Deprecations? | /no <!-- don't forget updating UPGRADING.md file -->
| Tests pass?   | yes/no
| Fixed tickets | #... <!-- #-prefixed issue number(s), if any -->
| License       | Apache-2.0

following scenario was not possible to be achieved with generated yml-metadata (which was not touchable):
* generate serialized xml data where the default namespace elements are prefixed, e.g. with n1
* additionally all attributes needed to have there representative namespace prefix

proposed solution:
* modification of the setDefaultRootName method of XmlSerializationVisitor to add a 3rd parameter prefix, which is added if any rootnamespace is given on dom document creation
* modification of the visibility of the method setAttributeOnNode in order to override the default behavior of the namespace prefixing, e.g.:

`
protected function setAttributeOnNode(\DOMElement $node, $name, $value, $namespace = null)
    {
        if ($namespace===null && $node->namespaceURI!==null) {
            $namespace = $node->namespaceURI;
        }
        parent::setAttributeOnNode($node, $name, $value, $namespace);
    }
`
