### PR TITLE
Added note on SerializedName annotation valididity

### DIFF
--- a/doc/reference/annotations.rst
+++ b/doc/reference/annotations.rst
@@ -45,6 +45,22 @@ This annotation can be defined on a property to define the serialized name for a
 property. If this is not defined, the property will be translated from camel-case
 to a lower-cased underscored name, e.g. camelCase -> camel_case.
 
+Note that this annotation is not used when you're using any other naming 
+stategy than the default configuration (which includes the 
+``SerializedNameAnnotationStrategy``). In order to re-enable the annotation, you
+will need to wrap your custom strategy with the ``SerializedNameAnnotationStrategy``.
+
+.. code-block :: php
+
+    <?php
+    $serializer = \JMS\Serializer\SerializerBuilder::create()
+        ->setPropertyNamingStrategy(
+            new \JMS\Serializer\Naming\SerializedNameAnnotationStrategy(
+                new \JMS\Serializer\Naming\IdenticalPropertyNamingStrategy()
+            )
+        )
+        ->build();
+
 @Since
 ~~~~~~
 This annotation can be defined on a property to specify starting from which


### PR DESCRIPTION
As discussed in https://github.com/schmittjoh/serializer/issues/334, when you're using anything else than the default configuration of the serializer with respect to the naming strategy, you will need to explicitly enable the SerializedNameAnnotationStrategy which wraps your custom naming strategy.

| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| Doc updated   | yes
| BC breaks?    | no <!-- don't forget updating UPGRADING.md file -->
| Deprecations? | no <!-- don't forget updating UPGRADING.md file -->
| Tests pass?   | yes
| Fixed tickets | #334 <!-- #-prefixed issue number(s), if any -->
| License       | Apache-2.0

