### PR TITLE
Discriminator property serialization when parent is in discriminator map

### DIFF
--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -32,6 +32,8 @@ in case you have heavily used internal-api here are the most important the chang
 - Removed `Serializer::setSerializationContextFactory` and `Serializer::setDeserializationContextFactory`
 - Removed `Serializer::getMetadataFactory` 
 - As default now JSON preserve trailing zeros when serializing a float
+- When using a discriminator map, parent class should either be declared abstract, or included into the discriminator
+  map
 
 **Deprecations** (will be removed in 3.0)
 

--- a/src/Metadata/ClassMetadata.php
+++ b/src/Metadata/ClassMetadata.php
@@ -138,7 +138,7 @@ class ClassMetadata extends MergeableClassMetadata
         $this->discriminatorMap = $map;
         $this->discriminatorGroups = $groups;
 
-        $this->setDiscriminatorProperty();
+        $this->handleDiscriminatorProperty();
     }
 
     private function getReflection(): \ReflectionClass
@@ -236,7 +236,7 @@ class ClassMetadata extends MergeableClassMetadata
             $this->discriminatorBaseClass = $object->discriminatorBaseClass;
         }
 
-        $this->setDiscriminatorProperty();
+        $this->handleDiscriminatorProperty();
 
         $this->sortProperties();
     }
@@ -353,7 +353,7 @@ class ClassMetadata extends MergeableClassMetadata
         parent::unserialize($parentStr);
     }
 
-    private function setDiscriminatorProperty()
+    private function handleDiscriminatorProperty(): void
     {
         if ($this->discriminatorMap
             && !$this->getReflection()->isAbstract()
@@ -392,7 +392,6 @@ class ClassMetadata extends MergeableClassMetadata
             $discriminatorProperty->xmlNamespace = $this->xmlDiscriminatorNamespace;
             $this->propertyMetadata[$this->discriminatorFieldName] = $discriminatorProperty;
         }
-
     }
 
     private function sortProperties(): void

--- a/tests/Fixtures/Discriminator/ImagePost.php
+++ b/tests/Fixtures/Discriminator/ImagePost.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace JMS\Serializer\Tests\Fixtures\Discriminator;
+
+class ImagePost extends Post
+{
+}

--- a/tests/Fixtures/Discriminator/ObjectWithXmlAttributeDiscriminatorParent.php
+++ b/tests/Fixtures/Discriminator/ObjectWithXmlAttributeDiscriminatorParent.php
@@ -12,6 +12,6 @@ use JMS\Serializer\Annotation as Serializer;
  * })
  * @Serializer\XmlDiscriminator(attribute=true, cdata=false)
  */
-class ObjectWithXmlAttributeDiscriminatorParent
+abstract class ObjectWithXmlAttributeDiscriminatorParent
 {
 }

--- a/tests/Fixtures/Discriminator/ObjectWithXmlNamespaceAttributeDiscriminatorParent.php
+++ b/tests/Fixtures/Discriminator/ObjectWithXmlNamespaceAttributeDiscriminatorParent.php
@@ -13,6 +13,6 @@ use JMS\Serializer\Annotation as Serializer;
  * @Serializer\XmlDiscriminator(namespace="http://example.com/", attribute=true, cdata=false)
  * @Serializer\XmlNamespace(prefix="foo", uri="http://example.com/")
  */
-class ObjectWithXmlNamespaceAttributeDiscriminatorParent
+abstract class ObjectWithXmlNamespaceAttributeDiscriminatorParent
 {
 }

--- a/tests/Fixtures/Discriminator/ObjectWithXmlNamespaceDiscriminatorParent.php
+++ b/tests/Fixtures/Discriminator/ObjectWithXmlNamespaceDiscriminatorParent.php
@@ -13,6 +13,6 @@ use JMS\Serializer\Annotation as Serializer;
  * @Serializer\XmlDiscriminator(namespace="http://example.com/", cdata=false)
  * @Serializer\XmlNamespace(prefix="foo", uri="http://example.com/")
  */
-class ObjectWithXmlNamespaceDiscriminatorParent
+abstract class ObjectWithXmlNamespaceDiscriminatorParent
 {
 }

--- a/tests/Fixtures/Discriminator/ObjectWithXmlNotCDataDiscriminatorParent.php
+++ b/tests/Fixtures/Discriminator/ObjectWithXmlNotCDataDiscriminatorParent.php
@@ -12,6 +12,6 @@ use JMS\Serializer\Annotation as Serializer;
  * })
  * @Serializer\XmlDiscriminator(cdata=false)
  */
-class ObjectWithXmlNotCDataDiscriminatorParent
+abstract class ObjectWithXmlNotCDataDiscriminatorParent
 {
 }

--- a/tests/Fixtures/Discriminator/Post.php
+++ b/tests/Fixtures/Discriminator/Post.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace JMS\Serializer\Tests\Fixtures\Discriminator;
+
+use JMS\Serializer\Annotation as Serializer;
+
+/**
+ * @Serializer\Discriminator(field = "type", map = {
+ *    "post": "JMS\Serializer\Tests\Fixtures\Discriminator\Post",
+ *    "image_post": "JMS\Serializer\Tests\Fixtures\Discriminator\ImagePost",
+ * })
+ */
+class Post
+{
+    /** @Serializer\Type("string") */
+    public $title;
+
+    public function __construct(string $title)
+    {
+        $this->title = $title;
+    }
+}

--- a/tests/Metadata/Driver/BaseDriverTest.php
+++ b/tests/Metadata/Driver/BaseDriverTest.php
@@ -219,6 +219,23 @@ abstract class BaseDriverTest extends TestCase
         );
     }
 
+    public function testLoadDiscriminatorWhenParentIsInDiscriminatorMap()
+    {
+        /** @var ClassMetadata $m */
+        $m = $this->getDriver()->loadMetadataForClass(new \ReflectionClass('JMS\Serializer\Tests\Fixtures\Discriminator\Post'));
+
+        self::assertNotNull($m);
+        self::assertEquals('type', $m->discriminatorFieldName);
+        self::assertEquals($m->name, $m->discriminatorBaseClass);
+        self::assertEquals(
+            [
+                'post' => 'JMS\Serializer\Tests\Fixtures\Discriminator\Post',
+                'image_post' => 'JMS\Serializer\Tests\Fixtures\Discriminator\ImagePost',
+            ],
+            $m->discriminatorMap
+        );
+    }
+
     public function testLoadXmlDiscriminator()
     {
         /** @var ClassMetadata $m */
@@ -307,6 +324,18 @@ abstract class BaseDriverTest extends TestCase
     {
         /** @var ClassMetadata $m */
         $m = $this->getDriver()->loadMetadataForClass(new \ReflectionClass('JMS\Serializer\Tests\Fixtures\Discriminator\Car'));
+
+        self::assertNotNull($m);
+        self::assertNull($m->discriminatorValue);
+        self::assertNull($m->discriminatorBaseClass);
+        self::assertNull($m->discriminatorFieldName);
+        self::assertEquals([], $m->discriminatorMap);
+    }
+
+    public function testLoadDiscriminatorSubClassWhenParentIsInDiscriminatorMap()
+    {
+        /** @var ClassMetadata $m */
+        $m = $this->getDriver()->loadMetadataForClass(new \ReflectionClass('JMS\Serializer\Tests\Fixtures\Discriminator\ImagePost'));
 
         self::assertNotNull($m);
         self::assertNull($m->discriminatorValue);

--- a/tests/Metadata/Driver/xml/Discriminator.ImagePost.xml
+++ b/tests/Metadata/Driver/xml/Discriminator.ImagePost.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<serializer>
+    <class name="JMS\Serializer\Tests\Fixtures\Discriminator\ImagePost">
+    </class>
+</serializer>

--- a/tests/Metadata/Driver/xml/Discriminator.Post.xml
+++ b/tests/Metadata/Driver/xml/Discriminator.Post.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<serializer>
+    <class name="JMS\Serializer\Tests\Fixtures\Discriminator\Post" discriminator-field-name="type">
+        <discriminator-class value="post">JMS\Serializer\Tests\Fixtures\Discriminator\Post</discriminator-class>
+        <discriminator-class value="image_post">JMS\Serializer\Tests\Fixtures\Discriminator\ImagePost</discriminator-class>
+        <property name="title" type="string" />
+    </class>
+</serializer>

--- a/tests/Metadata/Driver/yml/Discriminator.ImagePost.yml
+++ b/tests/Metadata/Driver/yml/Discriminator.ImagePost.yml
@@ -1,0 +1,1 @@
+JMS\Serializer\Tests\Fixtures\Discriminator\ImagePost: { }

--- a/tests/Metadata/Driver/yml/Discriminator.Post.yml
+++ b/tests/Metadata/Driver/yml/Discriminator.Post.yml
@@ -1,0 +1,10 @@
+JMS\Serializer\Tests\Fixtures\Discriminator\Post:
+    discriminator:
+        field_name: type
+        map:
+            post: JMS\Serializer\Tests\Fixtures\Discriminator\Post
+            image_post: JMS\Serializer\Tests\Fixtures\Discriminator\ImagePost
+
+    properties:
+        title:
+            type: string

--- a/tests/Serializer/BaseSerializationTest.php
+++ b/tests/Serializer/BaseSerializationTest.php
@@ -43,7 +43,9 @@ use JMS\Serializer\Tests\Fixtures\CurrencyAwarePrice;
 use JMS\Serializer\Tests\Fixtures\CustomDeserializationObject;
 use JMS\Serializer\Tests\Fixtures\DateTimeArraysObject;
 use JMS\Serializer\Tests\Fixtures\Discriminator\Car;
+use JMS\Serializer\Tests\Fixtures\Discriminator\ImagePost;
 use JMS\Serializer\Tests\Fixtures\Discriminator\Moped;
+use JMS\Serializer\Tests\Fixtures\Discriminator\Post;
 use JMS\Serializer\Tests\Fixtures\DiscriminatorGroup\Car as DiscriminatorGroupCar;
 use JMS\Serializer\Tests\Fixtures\ExclusionStrategy\AlwaysExcludeExclusionStrategy;
 use JMS\Serializer\Tests\Fixtures\FirstClassListCollection;
@@ -1261,6 +1263,14 @@ abstract class BaseSerializationTest extends TestCase
             $this->getContent('car'),
             $this->serialize(new Car(5))
         );
+        self::assertEquals(
+            $this->getContent('post'),
+            $this->serialize(new Post('Post Title'))
+        );
+        self::assertEquals(
+            $this->getContent('image_post'),
+            $this->serialize(new ImagePost('Image Post Title'))
+        );
 
         if ($this->hasDeserializer()) {
             self::assertEquals(
@@ -1286,6 +1296,33 @@ abstract class BaseSerializationTest extends TestCase
                 $this->deserialize(
                     $this->getContent('car_without_type'),
                     'JMS\Serializer\Tests\Fixtures\Discriminator\Car'
+                ),
+                'Class is resolved correctly when concrete sub-class is used and no type is defined.'
+            );
+
+            self::assertEquals(
+                new Post('Post Title'),
+                $this->deserialize(
+                    $this->getContent('post'),
+                    'JMS\Serializer\Tests\Fixtures\Discriminator\Post'
+                ),
+                'Class is resolved correctly when parent class is used and type is set.'
+            );
+
+            self::assertEquals(
+                new ImagePost('Image Post Title'),
+                $this->deserialize(
+                    $this->getContent('image_post'),
+                    'JMS\Serializer\Tests\Fixtures\Discriminator\Post'
+                ),
+                'Class is resolved correctly when least supertype is used.'
+            );
+
+            self::assertEquals(
+                new ImagePost('Image Post Title'),
+                $this->deserialize(
+                    $this->getContent('image_post'),
+                    'JMS\Serializer\Tests\Fixtures\Discriminator\ImagePost'
                 ),
                 'Class is resolved correctly when concrete sub-class is used and no type is defined.'
             );

--- a/tests/Serializer/JsonSerializationTest.php
+++ b/tests/Serializer/JsonSerializationTest.php
@@ -98,6 +98,9 @@ class JsonSerializationTest extends BaseSerializationTest
             $outputs['date_interval'] = '"PT45M"';
             $outputs['car'] = '{"km":5,"type":"car"}';
             $outputs['car_without_type'] = '{"km":5}';
+            $outputs['post'] = '{"type":"post","title":"Post Title"}';
+            $outputs['image_post'] = '{"type":"image_post","title":"Image Post Title"}';
+            $outputs['image_post_without_type'] = '{"title":"Image Post Title"}';
             $outputs['garage'] = '{"vehicles":[{"km":3,"type":"car"},{"km":1,"type":"moped"}]}';
             $outputs['tree'] = '{"tree":{"children":[{"children":[{"children":[],"foo":"bar"}],"foo":"bar"}],"foo":"bar"}}';
             $outputs['nullable_arrays'] = '{"empty_inline":[],"not_empty_inline":["not_empty_inline"],"empty_not_inline":[],"not_empty_not_inline":["not_empty_not_inline"],"empty_not_inline_skip":[],"not_empty_not_inline_skip":["not_empty_not_inline_skip"]}';

--- a/tests/Serializer/xml/image_post.xml
+++ b/tests/Serializer/xml/image_post.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<result>
+  <type><![CDATA[image_post]]></type>
+  <title><![CDATA[Image Post Title]]></title>
+</result>

--- a/tests/Serializer/xml/image_post_without_type.xml
+++ b/tests/Serializer/xml/image_post_without_type.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<result>
+  <title><![CDATA[Image Post Title]]></title>
+</result>

--- a/tests/Serializer/xml/post.xml
+++ b/tests/Serializer/xml/post.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<result>
+  <type><![CDATA[post]]></type>
+  <title><![CDATA[Post Title]]></title>
+</result>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Doc updated   | no
| BC breaks?    | maybe (see description below)
| Deprecations? | no
| Tests pass?   | yes (fixed)
| Fixed tickets | n/a
| License       | Apache-2.0

Discriminator property was added only when merging class metadata. It covered the cases when discriminated parent class didn't belong to discriminator map, so it kind of assumed that parent isn't going to belong to discriminator map and serialized.

So if parent class is a normal instantiable class and when it belongs to discriminator map, logic adding discriminator property was never executed and it was serialized without discriminator field.
I moved this logic to another method, now it's called when setting discriminator initially and when merging metadata.

Example of an issue:
```
/**
 * @ORM\Entity()
 * @ORM\Table(name="foo_bar_table")
 * @ORM\InheritanceType("SINGLE_TABLE")
 * @ORM\DiscriminatorColumn(name="type", type="string", length=30, fieldName="type")
 * @ORM\DiscriminatorMap({
 *     "foo" = "Foo",
 *     "bar" = "Bar",
 * })
 */
class Foo
{

}
```

```
/**
 * @ORM\Entity()
 */
class Bar extends Foo
{
}
```
### Why this is potentially a BC?
I had to fix a few unit tests by making parent classes abstract. It would be logical for parent class to be abstract since it's not in discriminator map. *This is potentially a BC.*
If parent is not in the map and is not abstract or interface it will throw an exception 'The sub-class "%s" is not listed in the discriminator of the base class "%s".'
It didn't happen before, because this check was never executed for parent class. It shouldn't affect serialization itself, but it will start throwing an exception now if parent isn't abstract and isn't in the map, which is weird from design point of view anyway.