### PR TITLE
AccessType naming

### DIFF
--- a/doc/reference/annotations.rst
+++ b/doc/reference/annotations.rst
@@ -98,6 +98,36 @@ set the value via reflection, but you may change this to use a public method ins
         }
     }
 
+    class Shop
+    {
+        /**
+         * @AccessType("public_method", naming="camel_case")
+         * @ReadOnly
+         */
+        private $full_address;
+
+        public function getFullAddress()
+        {
+            return $this->full_address;
+        }
+    }
+
+
+To use accessors instead of properties by default, modify builder:
+
+.. code-block :: php
+
+    <?php
+    use JMS\Serializer\Accessor\Updater\ClassAccessorUpdater;
+    use JMS\Serializer\SerializerBuilder;
+
+    $serializerBuilder = SerializerBuilder::create()->build();
+    $serializerBuilder->setPropertyUpdater(new ClassAccessorUpdater(
+        PropertyMetadata::ACCESS_TYPE_PUBLIC_METHOD,
+        PropertyMetadata::ACCESS_TYPE_NAMING_CAMEL_CASE
+    ));
+    $serializer = $serializerBuilder->build();
+
 @Accessor
 ~~~~~~~~~
 This annotation can be defined on a property to specify which public method should
@@ -126,7 +156,7 @@ be called to retrieve, or set the value of the given property:
             $this->name = $name;
         }
     }
-    
+
 .. note ::
 
     If you need only to serialize your data, you can avoid providing a setter by

--- a/doc/reference/xml_reference.rst
+++ b/doc/reference/xml_reference.rst
@@ -27,6 +27,7 @@ XML Reference
                       xml-attribute="true"
                       xml-value="true"
                       access-type="public_method"
+                      access-type-naming="camel_case"
                       accessor-getter="getSomeProperty"
                       accessor-setter="setSomeProperty"
                       inline="true"
@@ -102,6 +103,6 @@ XML Reference
                 <xml-list inline="true" entry-name="foobar" namespace="http://www.w3.org/2005/Atom" skip-when-empty="true" />
                 <xml-map inline="true" key-attribute-name="foo" entry-name="bar" namespace="http://www.w3.org/2005/Atom" />
             </virtual-property>
-            
+
         </class>
     </serializer>

--- a/doc/reference/yml_reference.rst
+++ b/doc/reference/yml_reference.rst
@@ -9,7 +9,8 @@ YAML Reference
         xml_root_namespace: http://your.default.namespace
         exclude: true
         read_only: false
-        access_type: public_method # defaults to property
+        access_type: public_method # defaults to 'property'
+        access_type_naming: camel_case # defaults to 'exact'
         accessor_order: custom
         custom_accessor_order: [propertyName1, propertyName2, ..., propertyNameN]
         discriminator:

--- a/src/JMS/Serializer/Accessor/Updater/ClassAccessorUpdater.php
+++ b/src/JMS/Serializer/Accessor/Updater/ClassAccessorUpdater.php
@@ -1,0 +1,173 @@
+<?php
+
+namespace JMS\Serializer\Accessor\Updater;
+
+use JMS\Serializer\Exception\RuntimeException;
+use JMS\Serializer\Metadata\ClassMetadata;
+use JMS\Serializer\Metadata\ClassMetadataUpdaterInterface;
+use JMS\Serializer\Metadata\PropertyMetadata;
+
+/**
+ * Default behaviour is required for propper accessors work.
+ *
+ * For `$person_name` field expected accessors are:
+ * - `getPerson_name()`
+ * - `setPerson_name()`
+ */
+class ClassAccessorUpdater implements ClassMetadataUpdaterInterface
+{
+    /**
+     * @var string
+     */
+    private $defaultType;
+
+    /**
+     * @var string
+     */
+    private $defaultNaming;
+
+    /**
+     * @var array
+     */
+    private $getterPrefixes;
+
+    /**
+     * @var array
+     */
+    private $setterPrefixes;
+
+    public function __construct(
+        $defaultType = PropertyMetadata::ACCESS_TYPE_PROPERTY,
+        $defaultNaming = PropertyMetadata::ACCESS_TYPE_NAMING_EXACT,
+        array $getterPrefixes = ['get', 'is', 'has'],
+        array $setterPrefixes = ['set', 'update']
+    )
+    {
+        $this->defaultType = $defaultType;
+        $this->defaultNaming = $defaultNaming;
+        $this->getterPrefixes = $getterPrefixes;
+        $this->setterPrefixes = $setterPrefixes;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function update(ClassMetadata $classMetadata)
+    {
+        foreach ($classMetadata->propertyMetadata as $propertyMetadata) {
+            $this->updateAccessors($propertyMetadata, $classMetadata);
+        }
+    }
+
+    /**
+     * @param string $accessorPrefix
+     * @param string $propertyName
+     * @param string $naming
+     *
+     * @return string|null
+     */
+    protected function getAccessorName($accessorPrefix, $propertyName, $naming)
+    {
+        switch ($naming) {
+            case PropertyMetadata::ACCESS_TYPE_NAMING_CAMEL_CASE:
+                return $accessorPrefix . preg_replace('/_(\w)/', '\\1', $propertyName) ?: null;
+
+            case PropertyMetadata::ACCESS_TYPE_NAMING_EXACT:
+                return $accessorPrefix . $propertyName;
+        }
+
+        throw new RuntimeException("Undefined naming type '$naming'.");
+    }
+
+    protected function getSetter(PropertyMetadata $metadata, $naming)
+    {
+        if ($metadata->setter || $metadata->readOnly) {
+            return $metadata->setter;
+        }
+
+        $class = $this->getDeclaringClass($metadata);
+        $name = $metadata->name;
+
+        if (null !== $method = $this->findAccessorName($this->setterPrefixes, $name, $class, $naming)) {
+            return $method;
+        }
+
+        throw new RuntimeException("Specify public setter for {$class->getName()}::\${$name} (using $naming naming)");
+    }
+
+    protected function getGetter(PropertyMetadata $metadata, $naming)
+    {
+        if ($metadata->getter) {
+            return $metadata->getter;
+        }
+
+        $class = $this->getDeclaringClass($metadata);
+        $name = $metadata->name;
+
+
+        if (null !== $method = $this->findAccessorName($this->getterPrefixes, $name, $class, $naming)) {
+            return $method;
+        }
+
+        throw new RuntimeException("Specify public getter for {$class->getName()}::\${$name} (using $naming naming)");
+    }
+
+    /**
+     * @param PropertyMetadata $metadata
+     * @return \ReflectionClass
+     */
+    protected function getDeclaringClass(PropertyMetadata $metadata)
+    {
+        return $metadata->getReflection()->getDeclaringClass();
+    }
+
+    /**
+     * @param array $prefixes
+     * @param string $name
+     * @param \ReflectionClass $class
+     * @param string $naming
+     *
+     * @return null|string
+     */
+    protected function findAccessorName(array $prefixes, $name, \ReflectionClass $class, $naming)
+    {
+        foreach ($prefixes as $prefix) {
+            $accessorName = $this->getAccessorName($prefix, $name, $naming);
+            if ($this->hasPublicMethod($class, $accessorName)) {
+                return $accessorName;
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * @param \ReflectionClass $class
+     * @param string $method
+     * @return bool
+     */
+    protected function hasPublicMethod(\ReflectionClass $class, $method)
+    {
+        return $class->hasMethod($method) && $class->getMethod($method)->isPublic();
+    }
+
+    protected function updateAccessors(PropertyMetadata $propertyMetadata, ClassMetadata $classMetadata)
+    {
+        $type =
+            $propertyMetadata->accessType ?:
+                $classMetadata->accessType ?:
+                    $this->defaultType;
+
+        if ($type !== PropertyMetadata::ACCESS_TYPE_PUBLIC_METHOD) {
+            return;
+        }
+
+        $naming =
+            $propertyMetadata->accessTypeNaming ?:
+                $classMetadata->accessTypeNaming ?:
+                    $this->defaultNaming;
+
+        $propertyMetadata->setter = $propertyMetadata->setter ?: $this->getSetter($propertyMetadata, $naming);
+        $propertyMetadata->getter = $propertyMetadata->getter ?: $this->getGetter($propertyMetadata, $naming);
+    }
+}

--- a/src/JMS/Serializer/Accessor/Updater/ClassAccessorUpdater.php
+++ b/src/JMS/Serializer/Accessor/Updater/ClassAccessorUpdater.php
@@ -7,13 +7,6 @@ use JMS\Serializer\Metadata\ClassMetadata;
 use JMS\Serializer\Metadata\ClassMetadataUpdaterInterface;
 use JMS\Serializer\Metadata\PropertyMetadata;
 
-/**
- * Default behaviour is required for propper accessors work.
- *
- * For `$person_name` field expected accessors are:
- * - `getPerson_name()`
- * - `setPerson_name()`
- */
 class ClassAccessorUpdater implements ClassMetadataUpdaterInterface
 {
     /**

--- a/src/JMS/Serializer/Annotation/AccessType.php
+++ b/src/JMS/Serializer/Annotation/AccessType.php
@@ -27,8 +27,12 @@ namespace JMS\Serializer\Annotation;
 final class AccessType
 {
     /**
-     * @Required
      * @var string
      */
     public $type;
+
+    /**
+     * @var string
+     */
+    public $naming;
 }

--- a/src/JMS/Serializer/Builder/CallbackDriverFactory.php
+++ b/src/JMS/Serializer/Builder/CallbackDriverFactory.php
@@ -3,6 +3,7 @@
 namespace JMS\Serializer\Builder;
 
 use Doctrine\Common\Annotations\Reader;
+use JMS\Serializer\Metadata\ClassMetadataUpdaterInterface;
 use Metadata\Driver\DriverInterface;
 
 class CallbackDriverFactory implements DriverFactoryInterface
@@ -17,9 +18,16 @@ class CallbackDriverFactory implements DriverFactoryInterface
         $this->callback = $callable;
     }
 
-    public function createDriver(array $metadataDirs, Reader $reader)
+    /**
+     * {@inheritDoc}
+     */
+    public function createDriver(
+        array $metadataDirs,
+        Reader $reader,
+        ClassMetadataUpdaterInterface $propertyUpdater = null
+    )
     {
-        $driver = \call_user_func($this->callback, $metadataDirs, $reader);
+        $driver = \call_user_func($this->callback, $metadataDirs, $reader, $propertyUpdater);
         if (!$driver instanceof DriverInterface) {
             throw new \LogicException('The callback must return an instance of DriverInterface.');
         }

--- a/src/JMS/Serializer/Builder/DefaultDriverFactory.php
+++ b/src/JMS/Serializer/Builder/DefaultDriverFactory.php
@@ -6,23 +6,29 @@ use Doctrine\Common\Annotations\Reader;
 use JMS\Serializer\Metadata\Driver\AnnotationDriver;
 use JMS\Serializer\Metadata\Driver\XmlDriver;
 use JMS\Serializer\Metadata\Driver\YamlDriver;
+use JMS\Serializer\Metadata\ClassMetadataUpdaterInterface;
 use Metadata\Driver\DriverChain;
 use Metadata\Driver\FileLocator;
 
 class DefaultDriverFactory implements DriverFactoryInterface
 {
-    public function createDriver(array $metadataDirs, Reader $annotationReader)
+    public function createDriver(
+        array $metadataDirs,
+        Reader $annotationReader,
+        ClassMetadataUpdaterInterface $propertyUpdater = null
+    )
     {
-        if (!empty($metadataDirs)) {
-            $fileLocator = new FileLocator($metadataDirs);
-
-            return new DriverChain(array(
-                new YamlDriver($fileLocator),
-                new XmlDriver($fileLocator),
-                new AnnotationDriver($annotationReader),
-            ));
+        $annotationDriver = new AnnotationDriver($annotationReader, $propertyUpdater);
+        if (empty($metadataDirs)) {
+            return $annotationDriver;
         }
 
-        return new AnnotationDriver($annotationReader);
+        $fileLocator = new FileLocator($metadataDirs);
+
+        return new DriverChain(array(
+            new YamlDriver($fileLocator, $propertyUpdater),
+            new XmlDriver($fileLocator, $propertyUpdater),
+            $annotationDriver,
+        ));
     }
 }

--- a/src/JMS/Serializer/Builder/DriverFactoryInterface.php
+++ b/src/JMS/Serializer/Builder/DriverFactoryInterface.php
@@ -3,6 +3,7 @@
 namespace JMS\Serializer\Builder;
 
 use Doctrine\Common\Annotations\Reader;
+use JMS\Serializer\Metadata\ClassMetadataUpdaterInterface;
 use Metadata\Driver\DriverInterface;
 
 interface DriverFactoryInterface
@@ -10,8 +11,13 @@ interface DriverFactoryInterface
     /**
      * @param array $metadataDirs
      * @param Reader $annotationReader
+     * @param ClassMetadataUpdaterInterface|null $propertyUpdater
      *
      * @return DriverInterface
      */
-    public function createDriver(array $metadataDirs, Reader $annotationReader);
+    public function createDriver(
+        array $metadataDirs,
+        Reader $annotationReader,
+        ClassMetadataUpdaterInterface $propertyUpdater = null
+    );
 }

--- a/src/JMS/Serializer/Metadata/ClassMetadata.php
+++ b/src/JMS/Serializer/Metadata/ClassMetadata.php
@@ -63,6 +63,9 @@ class ClassMetadata extends MergeableClassMetadata
     public $xmlDiscriminatorCData = true;
     public $xmlDiscriminatorNamespace;
 
+    public $accessType;
+    public $accessTypeNaming;
+
     public function setDiscriminator($fieldName, array $map, array $groups = array())
     {
         if (empty($fieldName)) {

--- a/src/JMS/Serializer/Metadata/ClassMetadataUpdaterInterface.php
+++ b/src/JMS/Serializer/Metadata/ClassMetadataUpdaterInterface.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace JMS\Serializer\Metadata;
+
+interface ClassMetadataUpdaterInterface
+{
+    /**
+     * @param ClassMetadata $classClassMetadata
+     *
+     * @throws \JMS\Serializer\Exception\RuntimeException
+     */
+    public function update(ClassMetadata $classClassMetadata);
+}

--- a/src/JMS/Serializer/Metadata/Driver/AnnotationDriver.php
+++ b/src/JMS/Serializer/Metadata/Driver/AnnotationDriver.php
@@ -260,8 +260,9 @@ class AnnotationDriver implements DriverInterface
                     $classMetadata->addPropertyMetadata($propertyMetadata);
                 }
             }
-            $this->classUpdater->update($classMetadata);
         }
+
+        $this->classUpdater->update($classMetadata);
 
         return $classMetadata;
     }

--- a/src/JMS/Serializer/Metadata/Driver/AnnotationDriver.php
+++ b/src/JMS/Serializer/Metadata/Driver/AnnotationDriver.php
@@ -19,6 +19,7 @@
 namespace JMS\Serializer\Metadata\Driver;
 
 use Doctrine\Common\Annotations\Reader;
+use JMS\Serializer\Accessor\Updater\ClassAccessorUpdater;
 use JMS\Serializer\Annotation\Accessor;
 use JMS\Serializer\Annotation\AccessorOrder;
 use JMS\Serializer\Annotation\AccessType;
@@ -56,6 +57,7 @@ use JMS\Serializer\GraphNavigator;
 use JMS\Serializer\Metadata\ClassMetadata;
 use JMS\Serializer\Metadata\ExpressionPropertyMetadata;
 use JMS\Serializer\Metadata\PropertyMetadata;
+use JMS\Serializer\Metadata\ClassMetadataUpdaterInterface;
 use JMS\Serializer\Metadata\VirtualPropertyMetadata;
 use Metadata\Driver\DriverInterface;
 use Metadata\MethodMetadata;
@@ -64,9 +66,15 @@ class AnnotationDriver implements DriverInterface
 {
     private $reader;
 
-    public function __construct(Reader $reader)
+    /**
+     * @var ClassMetadataUpdaterInterface
+     */
+    private $classUpdater;
+
+    public function __construct(Reader $reader, ClassMetadataUpdaterInterface $classUpdater = null)
     {
         $this->reader = $reader;
+        $this->classUpdater = $classUpdater ?: new ClassAccessorUpdater();
     }
 
     public function loadMetadataForClass(\ReflectionClass $class)
@@ -79,7 +87,6 @@ class AnnotationDriver implements DriverInterface
 
         $exclusionPolicy = 'NONE';
         $excludeAll = false;
-        $classAccessType = PropertyMetadata::ACCESS_TYPE_PROPERTY;
         $readOnlyClass = false;
         foreach ($this->reader->getClassAnnotations($class) as $annot) {
             if ($annot instanceof ExclusionPolicy) {
@@ -92,7 +99,8 @@ class AnnotationDriver implements DriverInterface
             } elseif ($annot instanceof Exclude) {
                 $excludeAll = true;
             } elseif ($annot instanceof AccessType) {
-                $classAccessType = $annot->type;
+                $classMetadata->accessType = $annot->type;
+                $classMetadata->accessTypeNaming = $annot->naming;
             } elseif ($annot instanceof ReadOnly) {
                 $readOnlyClass = true;
             } elseif ($annot instanceof AccessorOrder) {
@@ -152,12 +160,14 @@ class AnnotationDriver implements DriverInterface
                 $propertiesAnnotations[] = $this->reader->getPropertyAnnotations($property);
             }
 
+            /** @var PropertyMetadata $propertyMetadata */
             foreach ($propertiesMetadata as $propertyKey => $propertyMetadata) {
                 $isExclude = false;
                 $isExpose = $propertyMetadata instanceof VirtualPropertyMetadata
                     || $propertyMetadata instanceof ExpressionPropertyMetadata;
                 $propertyMetadata->readOnly = $propertyMetadata->readOnly || $readOnlyClass;
-                $accessType = $classAccessType;
+                $accessType = null;
+                $accessTypeNaming = null;
                 $accessor = array(null, null);
 
                 $propertyAnnotations = $propertiesAnnotations[$propertyKey];
@@ -212,6 +222,7 @@ class AnnotationDriver implements DriverInterface
                         $propertyMetadata->xmlElementCData = $annot->cdata;
                     } elseif ($annot instanceof AccessType) {
                         $accessType = $annot->type;
+                        $accessTypeNaming = $annot->naming;
                     } elseif ($annot instanceof ReadOnly) {
                         $propertyMetadata->readOnly = $annot->readOnly;
                     } elseif ($annot instanceof Accessor) {
@@ -240,10 +251,16 @@ class AnnotationDriver implements DriverInterface
                 if ((ExclusionPolicy::NONE === $exclusionPolicy && !$isExclude)
                     || (ExclusionPolicy::ALL === $exclusionPolicy && $isExpose)
                 ) {
-                    $propertyMetadata->setAccessor($accessType, $accessor[0], $accessor[1]);
+                    $propertyMetadata->setAccessor(
+                        $accessType,
+                        $accessor[0],
+                        $accessor[1],
+                        $accessTypeNaming
+                    );
                     $classMetadata->addPropertyMetadata($propertyMetadata);
                 }
             }
+            $this->classUpdater->update($classMetadata);
         }
 
         return $classMetadata;

--- a/src/JMS/Serializer/Metadata/ExpressionPropertyMetadata.php
+++ b/src/JMS/Serializer/Metadata/ExpressionPropertyMetadata.php
@@ -41,7 +41,7 @@ class ExpressionPropertyMetadata extends PropertyMetadata
         $this->readOnly = true;
     }
 
-    public function setAccessor($type, $getter = null, $setter = null)
+    public function setAccessor($type, $getter = null, $setter = null, $naming = self::ACCESS_TYPE_NAMING_EXACT)
     {
     }
 

--- a/src/JMS/Serializer/Metadata/PropertyMetadata.php
+++ b/src/JMS/Serializer/Metadata/PropertyMetadata.php
@@ -56,9 +56,7 @@ class PropertyMetadata extends BasePropertyMetadata
 
     /** @deprecated Use getReflection() */
     public $reflection;
-
     public $accessType;
-
     public $accessTypeNaming;
 
     private $closureAccessor;

--- a/src/JMS/Serializer/Metadata/StaticPropertyMetadata.php
+++ b/src/JMS/Serializer/Metadata/StaticPropertyMetadata.php
@@ -41,7 +41,7 @@ class StaticPropertyMetadata extends PropertyMetadata
         throw new \LogicException('StaticPropertyMetadata is immutable.');
     }
 
-    public function setAccessor($type, $getter = null, $setter = null)
+    public function setAccessor($type, $getter = null, $setter = null, $naming = self::ACCESS_TYPE_NAMING_EXACT)
     {
     }
 

--- a/src/JMS/Serializer/Metadata/VirtualPropertyMetadata.php
+++ b/src/JMS/Serializer/Metadata/VirtualPropertyMetadata.php
@@ -39,7 +39,7 @@ class VirtualPropertyMetadata extends PropertyMetadata
         throw new \LogicException('VirtualPropertyMetadata is immutable.');
     }
 
-    public function setAccessor($type, $getter = null, $setter = null)
+    public function setAccessor($type, $getter = null, $setter = null, $naming = self::ACCESS_TYPE_NAMING_EXACT)
     {
     }
 

--- a/tests/Fixtures/GetSetObject.php
+++ b/tests/Fixtures/GetSetObject.php
@@ -23,7 +23,7 @@ use JMS\Serializer\Annotation\Exclude;
 use JMS\Serializer\Annotation\ReadOnly;
 use JMS\Serializer\Annotation\Type;
 
-/** @AccessType("public_method") */
+/** @AccessType("public_method", naming="camel_case") */
 class GetSetObject
 {
     /** @AccessType("property") @Type("integer") */
@@ -43,6 +43,15 @@ class GetSetObject
      */
     private $excludedProperty;
 
+    /** @Type("string") */
+    private $underscored_property;
+
+    /**
+     * @Type("string")
+     * @AccessType(naming="exact")
+     */
+    private $force_underscore;
+
     public function getId()
     {
         throw new \RuntimeException('This should not be called.');
@@ -61,5 +70,25 @@ class GetSetObject
     public function getReadOnlyProperty()
     {
         return $this->readOnlyProperty;
+    }
+
+    public function getUnderscoredProperty()
+    {
+        return $this->underscored_property;
+    }
+
+    public function setUnderscoredProperty($underscored_property)
+    {
+        $this->underscored_property = $underscored_property;
+    }
+
+    public function getForce_Underscore()
+    {
+        return $this->force_underscore;
+    }
+
+    public function setForce_Underscore($force_underscore)
+    {
+        $this->force_underscore = $force_underscore;
     }
 }

--- a/tests/Metadata/ClassMetadataTest.php
+++ b/tests/Metadata/ClassMetadataTest.php
@@ -36,7 +36,7 @@ class ClassMetadataTest extends \PHPUnit_Framework_TestCase
 
     public function testSerialization()
     {
-        $meta = new PropertyMetadata('JMS\Serializer\Tests\Metadata\PropertyMetadataOrder', 'b');
+        $meta = new PropertyMetadata(PropertyMetadataOrder::class, 'b');
         $restoredMeta = unserialize(serialize($meta));
         $this->assertEquals($meta, $restoredMeta);
     }
@@ -68,52 +68,38 @@ class ClassMetadataTest extends \PHPUnit_Framework_TestCase
 
     /**
      * @dataProvider providerPublicMethodData
+     * @param string $property
+     * @param string|null $type
+     * @param string|null $getter
+     * @param string|null $setter
      */
-    public function testAccessorTypePublicMethod($property, $getterInit, $setterInit, $getterName, $setterName)
+    public function testAccessorTypePublicMethod($property, $type, $getter, $setter)
     {
         $object = new PropertyMetadataPublicMethod();
 
         $metadata = new PropertyMetadata(get_class($object), $property);
-        $metadata->setAccessor(PropertyMetadata::ACCESS_TYPE_PUBLIC_METHOD, $getterInit, $setterInit);
+        $metadata->setAccessor($type, $getter, $setter);
 
-        $this->assertEquals($getterName, $metadata->getter);
-        $this->assertEquals($setterName, $metadata->setter);
+        $this->assertEquals($getter, $metadata->getter);
+        $this->assertEquals($setter, $metadata->setter);
+        $this->assertEquals($type, $metadata->accessType);
 
         $metadata->setValue($object, 'x');
 
-        $this->assertEquals(sprintf('%1$s:%1$s:x', strtoupper($property)), $metadata->getValue($object));
-    }
-
-    /**
-     * @dataProvider providerPublicMethodException
-     */
-    public function testAccessorTypePublicMethodException($getter, $setter, $message)
-    {
-        $this->setExpectedException('\JMS\Serializer\Exception\RuntimeException', $message);
-
-        $object = new PropertyMetadataPublicMethod();
-
-        $metadata = new PropertyMetadata(get_class($object), 'e');
-        $metadata->setAccessor(PropertyMetadata::ACCESS_TYPE_PUBLIC_METHOD, $getter, $setter);
+        $this->assertEquals(
+            sprintf('%1$s:%1$s:x', strtoupper($property)),
+            $metadata->getValue($object)
+        );
     }
 
     public function providerPublicMethodData()
     {
-        return array(
-            array('a', null, null, 'geta', 'seta'),
-            array('b', null, null, 'isb', 'setb'),
-            array('c', null, null, 'hasc', 'setc'),
-            array('d', 'fetchd', 'saved', 'fetchd', 'saved')
-        );
-    }
-
-    public function providerPublicMethodException()
-    {
-        return array(
-            array(null, null, 'a public getE method, nor a public isE method, nor a public hasE method in class'),
-            array(null, 'setx', 'a public getE method, nor a public isE method, nor a public hasE method in class'),
-            array('getx', null, 'no public setE method in class'),
-        );
+        return [
+            ['a', PropertyMetadata::ACCESS_TYPE_PROPERTY, 'geta', 'seta'],
+            ['b', PropertyMetadata::ACCESS_TYPE_PUBLIC_METHOD, 'isb', 'setb'],
+            ['c', PropertyMetadata::ACCESS_TYPE_PROPERTY, 'hasc', 'setc'],
+            ['d', PropertyMetadata::ACCESS_TYPE_PUBLIC_METHOD, 'fetchd', 'saved']
+        ];
     }
 }
 

--- a/tests/Metadata/Driver/AnnotationDriverTest.php
+++ b/tests/Metadata/Driver/AnnotationDriverTest.php
@@ -20,11 +20,15 @@ namespace JMS\Serializer\Tests\Metadata\Driver;
 
 use Doctrine\Common\Annotations\AnnotationReader;
 use JMS\Serializer\Metadata\Driver\AnnotationDriver;
+use JMS\Serializer\Metadata\ClassMetadataUpdaterInterface;
 
 class AnnotationDriverTest extends BaseDriverTest
 {
-    protected function getDriver()
+    /**
+     * {@inheritDoc}
+     */
+    protected function getDriver($subFolder = null, ClassMetadataUpdaterInterface $propertyMetadataUpdater = null)
     {
-        return new AnnotationDriver(new AnnotationReader());
+        return new AnnotationDriver(new AnnotationReader(), $propertyMetadataUpdater);
     }
 }

--- a/tests/Metadata/Driver/PhpDriverTest.php
+++ b/tests/Metadata/Driver/PhpDriverTest.php
@@ -18,15 +18,19 @@
 
 namespace JMS\Serializer\Tests\Metadata\Driver;
 
+use JMS\Serializer\Metadata\ClassMetadataUpdaterInterface;
 use JMS\Serializer\Metadata\Driver\PhpDriver;
 use Metadata\Driver\FileLocator;
 
 class PhpDriverTest extends BaseDriverTest
 {
-    protected function getDriver()
+    /**
+     * {@inheritDoc}
+     */
+    protected function getDriver($subFolder = null, ClassMetadataUpdaterInterface $propertyMetadataUpdater = null)
     {
         return new PhpDriver(new FileLocator(array(
-            'JMS\Serializer\Tests\Fixtures' => __DIR__ . '/php',
-        )));
+            'JMS\Serializer\Tests\Fixtures' => __DIR__ . '/php/' . $subFolder,
+        )), $propertyMetadataUpdater);
     }
 }

--- a/tests/Metadata/Driver/XmlDriverTest.php
+++ b/tests/Metadata/Driver/XmlDriverTest.php
@@ -21,7 +21,6 @@ namespace JMS\Serializer\Tests\Metadata\Driver;
 use JMS\Serializer\Metadata\Driver\XmlDriver;
 use JMS\Serializer\Metadata\PropertyMetadata;
 use JMS\Serializer\Metadata\ClassMetadataUpdaterInterface;
-use JMS\Serializer\Tests\Fixtures\GetSetObject;
 use Metadata\Driver\FileLocator;
 
 class XmlDriverTest extends BaseDriverTest

--- a/tests/Metadata/Driver/XmlDriverTest.php
+++ b/tests/Metadata/Driver/XmlDriverTest.php
@@ -20,6 +20,8 @@ namespace JMS\Serializer\Tests\Metadata\Driver;
 
 use JMS\Serializer\Metadata\Driver\XmlDriver;
 use JMS\Serializer\Metadata\PropertyMetadata;
+use JMS\Serializer\Metadata\ClassMetadataUpdaterInterface;
+use JMS\Serializer\Tests\Fixtures\GetSetObject;
 use Metadata\Driver\FileLocator;
 
 class XmlDriverTest extends BaseDriverTest
@@ -98,15 +100,10 @@ class XmlDriverTest extends BaseDriverTest
         $this->assertArraySubset(['first.test.group', 'second.test.group'], $first->propertyMetadata['currency']->groups);
     }
 
-    protected function getDriver()
+    protected function getDriver($subFolder = null, ClassMetadataUpdaterInterface $propertyMetadataUpdater = null)
     {
-        $append = '';
-        if (func_num_args() == 1) {
-            $append = '/' . func_get_arg(0);
-        }
-
         return new XmlDriver(new FileLocator(array(
-            'JMS\Serializer\Tests\Fixtures' => __DIR__ . '/xml' . $append,
-        )));
+            'JMS\Serializer\Tests\Fixtures' => __DIR__ . '/xml/' . $subFolder,
+        )), $propertyMetadataUpdater);
     }
 }

--- a/tests/Metadata/Driver/YamlDriverTest.php
+++ b/tests/Metadata/Driver/YamlDriverTest.php
@@ -20,6 +20,7 @@ namespace JMS\Serializer\Tests\Metadata\Driver;
 
 use JMS\Serializer\Metadata\Driver\YamlDriver;
 use JMS\Serializer\Metadata\PropertyMetadata;
+use JMS\Serializer\Metadata\ClassMetadataUpdaterInterface;
 use Metadata\Driver\FileLocator;
 
 class YamlDriverTest extends BaseDriverTest
@@ -83,15 +84,18 @@ class YamlDriverTest extends BaseDriverTest
         $this->assertEquals($p, $m->propertyMetadata['title']);
     }
 
-    private function getDriverForSubDir($subDir = null)
+    private function getDriverForSubDir($subDir = null, ClassMetadataUpdaterInterface $propertyMetadataUpdater = null)
     {
         return new YamlDriver(new FileLocator(array(
             'JMS\Serializer\Tests\Fixtures' => __DIR__ . '/yml' . ($subDir ? '/' . $subDir : ''),
-        )));
+        )), $propertyMetadataUpdater);
     }
 
-    protected function getDriver()
+    /**
+     * {@inheritDoc}
+     */
+    protected function getDriver($subFolder = null, ClassMetadataUpdaterInterface $propertyMetadataUpdater = null)
     {
-        return $this->getDriverForSubDir();
+        return $this->getDriverForSubDir($subFolder, $propertyMetadataUpdater);
     }
 }

--- a/tests/Metadata/Driver/php/GetSetObject.php
+++ b/tests/Metadata/Driver/php/GetSetObject.php
@@ -1,0 +1,14 @@
+<?php
+
+use JMS\Serializer\Metadata\ClassMetadata;
+use JMS\Serializer\Metadata\PropertyMetadata;
+use JMS\Serializer\Tests\Fixtures\GetSetObject;
+
+$propertyMetadata = new PropertyMetadata(GetSetObject::class, 'underscored_property');
+$propertyMetadata->setType('string');
+
+$classMetadata = new ClassMetadata(GetSetObject::class);
+$classMetadata->addPropertyMetadata($propertyMetadata);
+$classMetadata->accessType = PropertyMetadata::ACCESS_TYPE_PUBLIC_METHOD;
+$classMetadata->accessTypeNaming = PropertyMetadata::ACCESS_TYPE_NAMING_CAMEL_CASE;
+return $classMetadata;

--- a/tests/Metadata/Driver/xml/ExcludePublicAccessor.xml
+++ b/tests/Metadata/Driver/xml/ExcludePublicAccessor.xml
@@ -2,5 +2,6 @@
 <serializer>
     <class name="JMS\Serializer\Tests\Fixtures\ExcludePublicAccessor" access-type="public_method" read-only="true">
         <property name="iShallNotBeAccessed" exclude="true" />
+        <property name="id" read-only="true" />
     </class>
 </serializer>

--- a/tests/Metadata/Driver/xml/GetSetObject.xml
+++ b/tests/Metadata/Driver/xml/GetSetObject.xml
@@ -1,7 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <serializer>
-    <class name="JMS\Serializer\Tests\Fixtures\GetSetObject" access-type="public_method">
+    <class name="JMS\Serializer\Tests\Fixtures\GetSetObject" access-type="public_method" access-type-naming="camel_case">
         <property name="id" type="integer" access-type="property" />
         <property name="name" type="string" accessor-getter="getTrimmedName" accessor-setter="setCapitalizedName" />
+        <property name="underscored_property" type="string"/>
+        <property name="force_underscore" type="string" access-type-naming="exact"/>
+
+        <property name="readOnlyProperty" read-only="true" />
+        <property name="excludedProperty" exclude="true" />
+
     </class>
 </serializer>

--- a/tests/Metadata/Driver/yml/ExcludePublicAccessor.yml
+++ b/tests/Metadata/Driver/yml/ExcludePublicAccessor.yml
@@ -4,3 +4,5 @@ JMS\Serializer\Tests\Fixtures\ExcludePublicAccessor:
     properties:
         iShallNotBeAccessed:
           exclude: true
+        id:
+          read_only: true

--- a/tests/Metadata/Driver/yml/GetSetObject.yml
+++ b/tests/Metadata/Driver/yml/GetSetObject.yml
@@ -1,0 +1,15 @@
+JMS\Serializer\Tests\Fixtures\GetSetObject:
+    access_type_naming: camel_case
+    access_type: public_method
+    properties:
+        underscored_property:
+            type: string
+        id:
+            read_only: true
+        readOnlyProperty:
+            read_only: true
+        excludedProperty:
+            exclude: true
+        force_underscore:
+            type: string
+            access_type_naming: exact

--- a/tests/Serializer/Accessor/ClassAccessorUpdaterTest.php
+++ b/tests/Serializer/Accessor/ClassAccessorUpdaterTest.php
@@ -3,6 +3,7 @@
 namespace JMS\Serializer\Tests\Serializer\Accessor;
 
 use JMS\Serializer\Accessor\Updater\ClassAccessorUpdater;
+use JMS\Serializer\Exception\RuntimeException;
 use JMS\Serializer\Metadata\ClassMetadata;
 use JMS\Serializer\Metadata\PropertyMetadata;
 
@@ -79,7 +80,7 @@ final class ClassAccessorUpdaterTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @expectedException \JMS\Serializer\Exception\RuntimeException
+     * @expectedException RuntimeException
      * @expectedExceptionMessage Undefined naming type 'wrong'.
      */
     public function testUpdateWrongNaming()
@@ -97,7 +98,7 @@ final class ClassAccessorUpdaterTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @expectedException \JMS\Serializer\Exception\RuntimeException
+     * @expectedException RuntimeException
      * @expectedExceptionMessage Specify public setter
      */
     public function testUpdateNoSetter()
@@ -122,8 +123,6 @@ final class ClassAccessorUpdaterTest extends \PHPUnit_Framework_TestCase
     /**
      * @dataProvider provideUpdateErrors
      *
-     * @expectedException \JMS\Serializer\Exception\RuntimeException
-     *
      * @param bool $hasSetterMethod
      * @param bool $hasGetterMethod
      * @param bool $isPublicSetter
@@ -131,7 +130,7 @@ final class ClassAccessorUpdaterTest extends \PHPUnit_Framework_TestCase
      * @param bool $isReadOnly
      * @param $expectedMessage
      */
-    public function testUpdateErrors(
+        public function testUpdateErrors(
         $hasSetterMethod,
         $hasGetterMethod,
         $isPublicSetter,
@@ -154,7 +153,7 @@ final class ClassAccessorUpdaterTest extends \PHPUnit_Framework_TestCase
         $classReflection->method('getMethod')->willReturn($methodReflection);
         $methodReflection->method('isPublic')->willReturnOnConsecutiveCalls($isPublicSetter, $isPublicGetter);
 
-        $this->expectExceptionMessage($expectedMessage);
+        $this->setExpectedException(RuntimeException::class, $expectedMessage);
 
         (new ClassAccessorUpdater(
             PropertyMetadata::ACCESS_TYPE_PUBLIC_METHOD,

--- a/tests/Serializer/Accessor/ClassAccessorUpdaterTest.php
+++ b/tests/Serializer/Accessor/ClassAccessorUpdaterTest.php
@@ -282,7 +282,6 @@ final class ClassAccessorUpdaterTest extends \PHPUnit_Framework_TestCase
             ->disableOriginalConstructor()
             ->disableOriginalClone()
             ->disableArgumentCloning()
-            ->disallowMockingUnknownTypes()
             ->getMock();
     }
 }

--- a/tests/Serializer/Accessor/ClassAccessorUpdaterTest.php
+++ b/tests/Serializer/Accessor/ClassAccessorUpdaterTest.php
@@ -275,4 +275,14 @@ final class ClassAccessorUpdaterTest extends \PHPUnit_Framework_TestCase
             ]
         ];
     }
+
+    protected function createMock($originalClassName)
+    {
+        return $this->getMockBuilder($originalClassName)
+            ->disableOriginalConstructor()
+            ->disableOriginalClone()
+            ->disableArgumentCloning()
+            ->disallowMockingUnknownTypes()
+            ->getMock();
+    }
 }

--- a/tests/Serializer/Accessor/ClassAccessorUpdaterTest.php
+++ b/tests/Serializer/Accessor/ClassAccessorUpdaterTest.php
@@ -1,0 +1,278 @@
+<?php
+
+namespace JMS\Serializer\Tests\Serializer\Accessor;
+
+use JMS\Serializer\Accessor\Updater\ClassAccessorUpdater;
+use JMS\Serializer\Metadata\ClassMetadata;
+use JMS\Serializer\Metadata\PropertyMetadata;
+
+final class ClassAccessorUpdaterTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @dataProvider provideUpdateParameters
+     *
+     * @param string $updaterType
+     * @param string $updaterNaming
+     * @param string $classType
+     * @param string $classNaming
+     * @param string $propertyType
+     * @param string $propertyNaming
+     * @param string $getter
+     * @param string $setter
+     * @param array $getterPrefixes
+     * @param array $setterPrefixes
+     */
+    public function testUpdateParameters(
+        $updaterType,
+        $updaterNaming,
+        $classType,
+        $classNaming,
+        $propertyType,
+        $propertyNaming,
+        $getter,
+        $setter,
+        $getterPrefixes = ['get'],
+        $setterPrefixes = ['set']
+    )
+    {
+        $classMetadata = $this->createMock(ClassMetadata::class);
+        $propertyMetadata = $this->createMock(PropertyMetadata::class);
+        $classMetadata->propertyMetadata = [$propertyMetadata];
+
+        $propertyMetadata->name = 'foo_bar';
+
+        $classMetadata->accessType = $classType;
+        $classMetadata->accessTypeNaming = $classNaming;
+        $propertyMetadata->accessType = $propertyType;
+        $propertyMetadata->accessTypeNaming = $propertyNaming;
+
+        $propertyReflection = $this->createMock(\ReflectionProperty::class);
+        $classReflection = $this->createMock(\ReflectionClass::class);
+        $methodReflection = $this->createMock(\ReflectionMethod::class);
+        $propertyMetadata->method('getReflection')->willReturn($propertyReflection);
+        $propertyReflection->method('getDeclaringClass')->willReturn($classReflection);
+        $classReflection->method('hasMethod')->willReturn(true);
+        $classReflection->method('getMethod')->willReturn($methodReflection);
+        $methodReflection->method('isPublic')->willReturn(true);
+
+        (new ClassAccessorUpdater(
+            $updaterType,
+            $updaterNaming,
+            $getterPrefixes,
+            $setterPrefixes
+        ))->update($classMetadata);
+        $this->assertSame($getter, $propertyMetadata->getter);
+        $this->assertSame($setter, $propertyMetadata->setter);
+    }
+
+    public function testUpdateDoesNothingForProperties()
+    {
+        $classMetadata = $this->createMock(ClassMetadata::class);
+        $propertyMetadata = $this->createMock(PropertyMetadata::class);
+        $classMetadata->propertyMetadata = [$propertyMetadata];
+
+        $propertyMetadata->accessType = PropertyMetadata::ACCESS_TYPE_PROPERTY;
+
+        (new ClassAccessorUpdater())->update($classMetadata);
+        $this->assertNull($propertyMetadata->getter);
+        $this->assertNull($propertyMetadata->setter);
+    }
+
+    /**
+     * @expectedException \JMS\Serializer\Exception\RuntimeException
+     * @expectedExceptionMessage Undefined naming type 'wrong'.
+     */
+    public function testUpdateWrongNaming()
+    {
+        $classMetadata = $this->createMock(ClassMetadata::class);
+        $propertyMetadata = $this->createMock(PropertyMetadata::class);
+        $classMetadata->propertyMetadata = [$propertyMetadata];
+
+        $propertyReflection = $this->createMock(\ReflectionProperty::class);
+        $classReflection = $this->createMock(\ReflectionClass::class);
+        $propertyMetadata->method('getReflection')->willReturn($propertyReflection);
+        $propertyReflection->method('getDeclaringClass')->willReturn($classReflection);
+
+        (new ClassAccessorUpdater(PropertyMetadata::ACCESS_TYPE_PUBLIC_METHOD, 'wrong'))->update($classMetadata);
+    }
+
+    /**
+     * @expectedException \JMS\Serializer\Exception\RuntimeException
+     * @expectedExceptionMessage Specify public setter
+     */
+    public function testUpdateNoSetter()
+    {
+
+        $classMetadata = $this->createMock(ClassMetadata::class);
+        $propertyMetadata = $this->createMock(PropertyMetadata::class);
+        $classMetadata->propertyMetadata = [$propertyMetadata];
+
+        $propertyReflection = $this->createMock(\ReflectionProperty::class);
+        $classReflection = $this->createMock(\ReflectionClass::class);
+        $propertyMetadata->method('getReflection')->willReturn($propertyReflection);
+        $propertyReflection->method('getDeclaringClass')->willReturn($classReflection);
+        $classReflection->method('hasMethod')->willReturn(false);
+
+        (new ClassAccessorUpdater(
+            PropertyMetadata::ACCESS_TYPE_PUBLIC_METHOD,
+            PropertyMetadata::ACCESS_TYPE_NAMING_EXACT
+        ))->update($classMetadata);
+    }
+
+    /**
+     * @dataProvider provideUpdateErrors
+     *
+     * @expectedException \JMS\Serializer\Exception\RuntimeException
+     *
+     * @param bool $hasSetterMethod
+     * @param bool $hasGetterMethod
+     * @param bool $isPublicSetter
+     * @param bool $isPublicGetter
+     * @param bool $isReadOnly
+     * @param $expectedMessage
+     */
+    public function testUpdateErrors(
+        $hasSetterMethod,
+        $hasGetterMethod,
+        $isPublicSetter,
+        $isPublicGetter,
+        $isReadOnly,
+        $expectedMessage
+    )
+    {
+        $classMetadata = $this->createMock(ClassMetadata::class);
+        $propertyMetadata = $this->createMock(PropertyMetadata::class);
+        $classMetadata->propertyMetadata = [$propertyMetadata];
+        $propertyMetadata->readOnly = $isReadOnly;
+
+        $propertyReflection = $this->createMock(\ReflectionProperty::class);
+        $classReflection = $this->createMock(\ReflectionClass::class);
+        $methodReflection = $this->createMock(\ReflectionMethod::class);
+        $propertyMetadata->method('getReflection')->willReturn($propertyReflection);
+        $propertyReflection->method('getDeclaringClass')->willReturn($classReflection);
+        $classReflection->method('hasMethod')->willReturnOnConsecutiveCalls($hasSetterMethod, $hasGetterMethod);
+        $classReflection->method('getMethod')->willReturn($methodReflection);
+        $methodReflection->method('isPublic')->willReturnOnConsecutiveCalls($isPublicSetter, $isPublicGetter);
+
+        $this->expectExceptionMessage($expectedMessage);
+
+        (new ClassAccessorUpdater(
+            PropertyMetadata::ACCESS_TYPE_PUBLIC_METHOD,
+            PropertyMetadata::ACCESS_TYPE_NAMING_EXACT
+        ))->update($classMetadata);
+    }
+
+    public function provideUpdateParameters()
+    {
+        return [
+            'exact defaults' => [
+                'updaterType' => PropertyMetadata::ACCESS_TYPE_PUBLIC_METHOD,
+                'updaterNaming' => PropertyMetadata::ACCESS_TYPE_NAMING_EXACT,
+                'classType' => null,
+                'classNaming' => null,
+                'propertyType' => null,
+                'propertyNaming' => null,
+                'getter' => 'getfoo_bar',
+                'setter' => 'setfoo_bar',
+            ],
+            'camel class' => [
+                'updaterType' => null,
+                'updaterNaming' => null,
+                'classType' => PropertyMetadata::ACCESS_TYPE_PUBLIC_METHOD,
+                'classNaming' => PropertyMetadata::ACCESS_TYPE_NAMING_CAMEL_CASE,
+                'propertyType' => null,
+                'propertyNaming' => null,
+                'getter' => 'getfoobar',
+                'setter' => 'setfoobar',
+            ],
+            'exact property' => [
+                'updaterType' => null,
+                'updaterNaming' => null,
+                'classType' => null,
+                'classNaming' => null,
+                'propertyType' => PropertyMetadata::ACCESS_TYPE_PUBLIC_METHOD,
+                'propertyNaming' => PropertyMetadata::ACCESS_TYPE_NAMING_EXACT,
+                'getter' => 'getfoo_bar',
+                'setter' => 'setfoo_bar',
+            ],
+            'property over class' => [
+                'updaterType' => PropertyMetadata::ACCESS_TYPE_PROPERTY,
+                'updaterNaming' => null,
+                'classType' => PropertyMetadata::ACCESS_TYPE_PUBLIC_METHOD,
+                'classNaming' => PropertyMetadata::ACCESS_TYPE_NAMING_CAMEL_CASE,
+                'propertyType' => PropertyMetadata::ACCESS_TYPE_PUBLIC_METHOD,
+                'propertyNaming' => PropertyMetadata::ACCESS_TYPE_NAMING_EXACT,
+                'getter' => 'getfoo_bar',
+                'setter' => 'setfoo_bar',
+            ],
+            'class over updater' => [
+                'updaterType' => PropertyMetadata::ACCESS_TYPE_PROPERTY,
+                'updaterNaming' => null,
+                'classType' => PropertyMetadata::ACCESS_TYPE_PUBLIC_METHOD,
+                'classNaming' => PropertyMetadata::ACCESS_TYPE_NAMING_CAMEL_CASE,
+                'propertyType' => null,
+                'propertyNaming' => null,
+                'getter' => 'getfoobar',
+                'setter' => 'setfoobar',
+            ],
+            'custom prefixes' => [
+                'updaterType' => null,
+                'updaterNaming' => null,
+                'classType' => null,
+                'classNaming' => null,
+                'propertyType' => PropertyMetadata::ACCESS_TYPE_PUBLIC_METHOD,
+                'propertyNaming' => PropertyMetadata::ACCESS_TYPE_NAMING_CAMEL_CASE,
+                'getter' => 'isfoobar',
+                'setter' => 'updatefoobar',
+                'getterPrefixes' => ['is'],
+                'setterPrefixes' => ['update'],
+            ],
+        ];
+    }
+
+    public function provideUpdateErrors()
+    {
+        return [
+            'no setter' => [
+                'hasSetterMethod' => false,
+                'hasGetterMethod' => null,
+                'isPublicSetter' => null,
+                'isPublicGetter' => null,
+                'isReadOnly' => false,
+                'expectedMessage' => 'Specify public setter',
+            ],
+            'no public setter' => [
+                'hasSetterMethod' => true,
+                'hasGetterMethod' => null,
+                'isPublicSetter' => false,
+                'isPublicGetter' => null,
+                'isReadOnly' => false,
+                'expectedMessage' => 'Specify public setter',
+            ],
+            'no getter' => [
+                'hasSetterMethod' => true,
+                'hasGetterMethod' => false,
+                'isPublicSetter' => true,
+                'isPublicGetter' => null,
+                'isReadOnly' => false,
+                'expectedMessage' => 'Specify public getter',
+            ],
+            'no public getter' => [
+                'hasSetterMethod' => true,
+                'hasGetterMethod' => true,
+                'isPublicSetter' => true,
+                'isPublicGetter' => false,
+                'isReadOnly' => false,
+                'expectedMessage' => 'Specify public getter',
+            ],
+            'no setter for read-only' => [
+                'hasSetterMethod' => null,
+                'hasGetterMethod' => false,
+                'isPublicSetter' => null,
+                'isPublicGetter' => null,
+                'isReadOnly' => true,
+                'expectedMessage' => 'Specify public getter',
+            ]
+        ];
+    }
+}


### PR DESCRIPTION
# New features:
- Added access type naming configuration: with new `naming="camel_case"` for property `$foo_bar` we need `getFooBar()` accessor (instead of `getFoo_Bar()`).
- Now we can require accessors for each class: by modifying builder (default behavour preserved).

| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| Doc updated   | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
| License       | Apache-2.0

