### PR TITLE
Update GenericDeserializationVisitor.php

### DIFF
--- a/src/JMS/Serializer/GenericDeserializationVisitor.php
+++ b/src/JMS/Serializer/GenericDeserializationVisitor.php
@@ -173,7 +173,7 @@ abstract class GenericDeserializationVisitor extends AbstractVisitor
         }
 
         if (!\is_array($data)) {
-            throw new RuntimeException(sprintf('Invalid data "%s"(%s), expected "%s".', $data, $metadata->type['name'], $metadata->reflection->class));
+            throw new RuntimeException(sprintf('Invalid data %s(%s), expected "%s".', json_encode($data), $metadata->type['name'], $metadata->reflection->class));
         }
 
         if (!array_key_exists($name, $data)) {


### PR DESCRIPTION
~Fixes "Object of class stdClass could not be converted to string" (or similar) when trying to throw an exception.~ Throws the correct exception instead of faulting while trying to stringify an arbitrary value.

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Doc updated   | n/a
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | n/a
| License       | Apache-2.0

