### PR TITLE
Explicitly set serialization precision for tests

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -12,6 +12,10 @@
     syntaxCheck                 = "false"
     bootstrap                   = "tests/bootstrap.php"
 >
+    <php>
+        <ini name="serialize_precision" value="14"/>
+    </php>
+
     <testsuites>
         <testsuite name="JMS Serializer Test Suite">
             <directory>./tests</directory>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Doc updated   | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes

On PHP 7.2 tests are failing with the following configuration:
```
$ php -i | grep precision
precision => 14 => 14
serialize_precision => 17 => 17
```

```
There were 2 failures:

1) JMS\Serializer\Tests\Serializer\JsonSerializationTest::testArrayFloats
Failed asserting that two strings are equal.
--- Expected
+++ Actual
@@ @@
-'[1.34,3,6.42]'
+'[1.3400000000000001,3,6.4199999999999999]'

/www/jms/serializer/tests/Serializer/BaseSerializationTest.php:437

2) JMS\Serializer\Tests\Serializer\JsonSerializationTest::testCurrencyAwarePrice
Failed asserting that two strings are equal.
--- Expected
+++ Actual
@@ @@
-'{"currency":"EUR","amount":2.34}'
+'{"currency":"EUR","amount":2.3399999999999999}'

/www/jms/serializer/tests/Serializer/BaseSerializationTest.php:762
```

This explicitly changes precision for tests to avoid surprises (hello float!).