### PR TITLE
Add support for namespaced XML attribute on Discriminator + Tests

### DIFF
--- a/src/JMS/Serializer/GraphNavigator.php
+++ b/src/JMS/Serializer/GraphNavigator.php
@@ -288,9 +288,14 @@ final class GraphNavigator implements GraphNavigatorInterface
                 $typeValue = (string)$data[$metadata->discriminatorFieldName];
                 break;
 
-            // Check XML attribute for discriminatorFieldName
-            case \is_object($data) && $metadata->xmlDiscriminatorAttribute && isset($data[$metadata->discriminatorFieldName]):
-                $typeValue = (string)$data[$metadata->discriminatorFieldName];
+            // Check XML attribute without namespace for discriminatorFieldName
+            case \is_object($data) && $metadata->xmlDiscriminatorAttribute && null === $metadata->xmlDiscriminatorNamespace && isset($data->attributes()->{$metadata->discriminatorFieldName}):
+                $typeValue = (string)$data->attributes()->{$metadata->discriminatorFieldName};
+                break;
+
+            // Check XML attribute with namespace for discriminatorFieldName
+            case \is_object($data) && $metadata->xmlDiscriminatorAttribute && null !== $metadata->xmlDiscriminatorNamespace && isset($data->attributes($metadata->xmlDiscriminatorNamespace)->{$metadata->discriminatorFieldName}):
+                $typeValue = (string)$data->attributes($metadata->xmlDiscriminatorNamespace)->{$metadata->discriminatorFieldName};
                 break;
 
             // Check XML element with namespace for discriminatorFieldName

--- a/tests/Fixtures/Discriminator/ObjectWithXmlNamespaceAttributeDiscriminatorChild.php
+++ b/tests/Fixtures/Discriminator/ObjectWithXmlNamespaceAttributeDiscriminatorChild.php
@@ -1,0 +1,23 @@
+<?php
+
+/*
+ * Copyright 2016 Björn Bösel <bjoern.boesel@twt.de>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace JMS\Serializer\Tests\Fixtures\Discriminator;
+
+class ObjectWithXmlNamespaceAttributeDiscriminatorChild extends ObjectWithXmlNamespaceAttributeDiscriminatorParent
+{
+}

--- a/tests/Fixtures/Discriminator/ObjectWithXmlNamespaceAttributeDiscriminatorParent.php
+++ b/tests/Fixtures/Discriminator/ObjectWithXmlNamespaceAttributeDiscriminatorParent.php
@@ -1,0 +1,33 @@
+<?php
+
+/*
+ * Copyright 2016 Björn Bösel <bjoern.boesel@twt.de>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace JMS\Serializer\Tests\Fixtures\Discriminator;
+
+use JMS\Serializer\Annotation as Serializer;
+
+/**
+ * @Serializer\Discriminator(field = "type", map = {
+ *    "child": "JMS\Serializer\Tests\Fixtures\Discriminator\ObjectWithXmlNamespaceAttributeDiscriminatorChild"
+ * })
+ * @Serializer\XmlDiscriminator(namespace="http://example.com/", attribute=true, cdata=false)
+ * @Serializer\XmlNamespace(prefix="foo", uri="http://example.com/")
+ */
+class ObjectWithXmlNamespaceAttributeDiscriminatorParent
+{
+
+}

--- a/tests/Metadata/Driver/BaseDriverTest.php
+++ b/tests/Metadata/Driver/BaseDriverTest.php
@@ -25,6 +25,8 @@ use JMS\Serializer\Metadata\PropertyMetadata;
 use JMS\Serializer\Metadata\VirtualPropertyMetadata;
 use JMS\Serializer\Tests\Fixtures\Discriminator\ObjectWithXmlAttributeDiscriminatorChild;
 use JMS\Serializer\Tests\Fixtures\Discriminator\ObjectWithXmlAttributeDiscriminatorParent;
+use JMS\Serializer\Tests\Fixtures\Discriminator\ObjectWithXmlNamespaceAttributeDiscriminatorChild;
+use JMS\Serializer\Tests\Fixtures\Discriminator\ObjectWithXmlNamespaceAttributeDiscriminatorParent;
 use JMS\Serializer\Tests\Fixtures\Discriminator\ObjectWithXmlNamespaceDiscriminatorChild;
 use JMS\Serializer\Tests\Fixtures\Discriminator\ObjectWithXmlNamespaceDiscriminatorParent;
 use JMS\Serializer\Tests\Fixtures\ParentSkipWithEmptyChild;
@@ -230,6 +232,25 @@ abstract class BaseDriverTest extends \PHPUnit_Framework_TestCase
             $m->discriminatorMap
         );
         $this->assertEquals('http://example.com/', $m->xmlDiscriminatorNamespace);
+        $this->assertFalse($m->xmlDiscriminatorAttribute);
+    }
+
+    public function testLoadXmlDiscriminatorWithAttributeNamespaces()
+    {
+        /** @var $m ClassMetadata */
+        $m = $this->getDriver()->loadMetadataForClass(new \ReflectionClass(ObjectWithXmlNamespaceAttributeDiscriminatorParent::class));
+
+        $this->assertNotNull($m);
+        $this->assertEquals('type', $m->discriminatorFieldName);
+        $this->assertEquals($m->name, $m->discriminatorBaseClass);
+        $this->assertEquals(
+            array(
+                'child' => ObjectWithXmlNamespaceAttributeDiscriminatorChild::class,
+            ),
+            $m->discriminatorMap
+        );
+        $this->assertEquals('http://example.com/', $m->xmlDiscriminatorNamespace);
+        $this->assertTrue($m->xmlDiscriminatorAttribute);
     }
 
     public function testLoadDiscriminatorWithGroup()

--- a/tests/Metadata/Driver/php/Discriminator.ObjectWithXmlNamespaceAttributeDiscriminatorParent.php
+++ b/tests/Metadata/Driver/php/Discriminator.ObjectWithXmlNamespaceAttributeDiscriminatorParent.php
@@ -1,0 +1,12 @@
+<?php
+
+use JMS\Serializer\Metadata\ClassMetadata;
+
+$metadata = new ClassMetadata('JMS\Serializer\Tests\Fixtures\Discriminator\ObjectWithXmlNamespaceAttributeDiscriminatorParent');
+$metadata->setDiscriminator('type', array(
+    'child' => 'JMS\Serializer\Tests\Fixtures\Discriminator\ObjectWithXmlNamespaceAttributeDiscriminatorChild'
+));
+$metadata->xmlDiscriminatorAttribute = true;
+$metadata->xmlDiscriminatorNamespace = 'http://example.com/';
+
+return $metadata;

--- a/tests/Metadata/Driver/xml/Discriminator.ObjectWithXmlNamespaceAttributeDiscriminatorParent.xml
+++ b/tests/Metadata/Driver/xml/Discriminator.ObjectWithXmlNamespaceAttributeDiscriminatorParent.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<serializer>
+    <class name="JMS\Serializer\Tests\Fixtures\Discriminator\ObjectWithXmlNamespaceAttributeDiscriminatorParent"
+           discriminator-field-name="type"
+    >
+        <discriminator-class value="child">JMS\Serializer\Tests\Fixtures\Discriminator\ObjectWithXmlNamespaceAttributeDiscriminatorChild</discriminator-class>
+        <xml-discriminator namespace="http://example.com/" attribute="true" />
+    </class>
+</serializer>

--- a/tests/Metadata/Driver/yml/Discriminator.ObjectWithXmlNamespaceAttributeDiscriminatorParent.yml
+++ b/tests/Metadata/Driver/yml/Discriminator.ObjectWithXmlNamespaceAttributeDiscriminatorParent.yml
@@ -1,0 +1,8 @@
+JMS\Serializer\Tests\Fixtures\Discriminator\ObjectWithXmlNamespaceAttributeDiscriminatorParent:
+    discriminator:
+        field_name: type
+        map:
+            child: JMS\Serializer\Tests\Fixtures\Discriminator\ObjectWithXmlNamespaceAttributeDiscriminatorChild
+        xml_attribute: true
+        xml_element:
+            namespace: http://example.com/

--- a/tests/Serializer/XmlSerializationTest.php
+++ b/tests/Serializer/XmlSerializationTest.php
@@ -32,6 +32,8 @@ use JMS\Serializer\SerializationContext;
 use JMS\Serializer\Serializer;
 use JMS\Serializer\Tests\Fixtures\Discriminator\ObjectWithXmlAttributeDiscriminatorChild;
 use JMS\Serializer\Tests\Fixtures\Discriminator\ObjectWithXmlAttributeDiscriminatorParent;
+use JMS\Serializer\Tests\Fixtures\Discriminator\ObjectWithXmlNamespaceAttributeDiscriminatorChild;
+use JMS\Serializer\Tests\Fixtures\Discriminator\ObjectWithXmlNamespaceAttributeDiscriminatorParent;
 use JMS\Serializer\Tests\Fixtures\Discriminator\ObjectWithXmlNamespaceDiscriminatorChild;
 use JMS\Serializer\Tests\Fixtures\Discriminator\ObjectWithXmlNamespaceDiscriminatorParent;
 use JMS\Serializer\Tests\Fixtures\Discriminator\ObjectWithXmlNotCDataDiscriminatorChild;
@@ -532,6 +534,20 @@ class XmlSerializationTest extends BaseSerializationTest
             $this->deserialize(
                 $xml,
                 ObjectWithXmlNamespaceDiscriminatorParent::class
+            )
+        );
+    }
+
+    public function testDiscriminatorAsXmlAttributeWithNamespace()
+    {
+        $xml = $this->serialize(new ObjectWithXmlNamespaceAttributeDiscriminatorChild());
+        $this->assertEquals($this->getContent('xml_discriminator_namespace_attribute'), $xml);
+
+        $this->assertInstanceOf(
+            ObjectWithXmlNamespaceAttributeDiscriminatorChild::class,
+            $this->deserialize(
+                $xml,
+                ObjectWithXmlNamespaceAttributeDiscriminatorParent::class
             )
         );
     }

--- a/tests/Serializer/xml/xml_discriminator_namespace_attribute.xml
+++ b/tests/Serializer/xml/xml_discriminator_namespace_attribute.xml
@@ -1,0 +1,2 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<result xmlns:foo="http://example.com/" foo:type="child"/>


### PR DESCRIPTION
In case that we have a XML discrimator attribute but with a namespace, the namespace isn't considered. I fixed this bug in the pull request.

| Q             | A
| ------------- | ---
| Bug fix?      | yes| New feature?  | yes
| Doc updated   | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes + new tests
| Fixed tickets | none
| License       | Apache-2.0

