### PR TITLE
Enable strict mode, fix type juggling and drop some runtime coercion broken by design

### DIFF
--- a/src/AbstractVisitor.php
+++ b/src/AbstractVisitor.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * Copyright 2016 Johannes M. Schmitt <schmittjoh@gmail.com>
  *

--- a/src/Accessor/AccessorStrategyInterface.php
+++ b/src/Accessor/AccessorStrategyInterface.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * Copyright 2016 Johannes M. Schmitt <schmittjoh@gmail.com>
  *

--- a/src/Accessor/DefaultAccessorStrategy.php
+++ b/src/Accessor/DefaultAccessorStrategy.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * Copyright 2016 Johannes M. Schmitt <schmittjoh@gmail.com>
  *

--- a/src/Accessor/ExpressionAccessorStrategy.php
+++ b/src/Accessor/ExpressionAccessorStrategy.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * Copyright 2016 Johannes M. Schmitt <schmittjoh@gmail.com>
  *

--- a/src/Annotation/AccessType.php
+++ b/src/Annotation/AccessType.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * Copyright 2016 Johannes M. Schmitt <schmittjoh@gmail.com>
  *

--- a/src/Annotation/Accessor.php
+++ b/src/Annotation/Accessor.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * Copyright 2016 Johannes M. Schmitt <schmittjoh@gmail.com>
  *

--- a/src/Annotation/AccessorOrder.php
+++ b/src/Annotation/AccessorOrder.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * Copyright 2016 Johannes M. Schmitt <schmittjoh@gmail.com>
  *

--- a/src/Annotation/Discriminator.php
+++ b/src/Annotation/Discriminator.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * Copyright 2016 Johannes M. Schmitt <schmittjoh@gmail.com>
  *

--- a/src/Annotation/Exclude.php
+++ b/src/Annotation/Exclude.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * Copyright 2016 Johannes M. Schmitt <schmittjoh@gmail.com>
  *

--- a/src/Annotation/ExclusionPolicy.php
+++ b/src/Annotation/ExclusionPolicy.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * Copyright 2016 Johannes M. Schmitt <schmittjoh@gmail.com>
  *

--- a/src/Annotation/Expose.php
+++ b/src/Annotation/Expose.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * Copyright 2016 Johannes M. Schmitt <schmittjoh@gmail.com>
  *

--- a/src/Annotation/Groups.php
+++ b/src/Annotation/Groups.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * Copyright 2016 Johannes M. Schmitt <schmittjoh@gmail.com>
  *

--- a/src/Annotation/Inline.php
+++ b/src/Annotation/Inline.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * Copyright 2016 Johannes M. Schmitt <schmittjoh@gmail.com>
  *

--- a/src/Annotation/MaxDepth.php
+++ b/src/Annotation/MaxDepth.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * Copyright 2011 Johannes M. Schmitt <schmittjoh@gmail.com>
  *

--- a/src/Annotation/PostDeserialize.php
+++ b/src/Annotation/PostDeserialize.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * Copyright 2016 Johannes M. Schmitt <schmittjoh@gmail.com>
  *

--- a/src/Annotation/PostSerialize.php
+++ b/src/Annotation/PostSerialize.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * Copyright 2016 Johannes M. Schmitt <schmittjoh@gmail.com>
  *

--- a/src/Annotation/PreSerialize.php
+++ b/src/Annotation/PreSerialize.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * Copyright 2016 Johannes M. Schmitt <schmittjoh@gmail.com>
  *

--- a/src/Annotation/ReadOnly.php
+++ b/src/Annotation/ReadOnly.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * Copyright 2016 Johannes M. Schmitt <schmittjoh@gmail.com>
  *

--- a/src/Annotation/SerializedName.php
+++ b/src/Annotation/SerializedName.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * Copyright 2016 Johannes M. Schmitt <schmittjoh@gmail.com>
  *

--- a/src/Annotation/Since.php
+++ b/src/Annotation/Since.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * Copyright 2016 Johannes M. Schmitt <schmittjoh@gmail.com>
  *

--- a/src/Annotation/SkipWhenEmpty.php
+++ b/src/Annotation/SkipWhenEmpty.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * Copyright 2016 Johannes M. Schmitt <schmittjoh@gmail.com>
  *

--- a/src/Annotation/Type.php
+++ b/src/Annotation/Type.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * Copyright 2016 Johannes M. Schmitt <schmittjoh@gmail.com>
  *

--- a/src/Annotation/Until.php
+++ b/src/Annotation/Until.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * Copyright 2016 Johannes M. Schmitt <schmittjoh@gmail.com>
  *

--- a/src/Annotation/Version.php
+++ b/src/Annotation/Version.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * Copyright 2016 Johannes M. Schmitt <schmittjoh@gmail.com>
  *

--- a/src/Annotation/VirtualProperty.php
+++ b/src/Annotation/VirtualProperty.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * Copyright 2016 Johannes M. Schmitt <schmittjoh@gmail.com>
  *

--- a/src/Annotation/XmlAttribute.php
+++ b/src/Annotation/XmlAttribute.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * Copyright 2016 Johannes M. Schmitt <schmittjoh@gmail.com>
  *

--- a/src/Annotation/XmlAttributeMap.php
+++ b/src/Annotation/XmlAttributeMap.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * Copyright 2016 Johannes M. Schmitt <schmittjoh@gmail.com>
  *

--- a/src/Annotation/XmlCollection.php
+++ b/src/Annotation/XmlCollection.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * Copyright 2016 Johannes M. Schmitt <schmittjoh@gmail.com>
  *

--- a/src/Annotation/XmlDiscriminator.php
+++ b/src/Annotation/XmlDiscriminator.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * Copyright 2016 Björn Bösel <bjoern.boesel@twt.de>
  *

--- a/src/Annotation/XmlElement.php
+++ b/src/Annotation/XmlElement.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * Copyright 2016 Johannes M. Schmitt <schmittjoh@gmail.com>
  *

--- a/src/Annotation/XmlKeyValuePairs.php
+++ b/src/Annotation/XmlKeyValuePairs.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * Copyright 2016 Johannes M. Schmitt <schmittjoh@gmail.com>
  *

--- a/src/Annotation/XmlList.php
+++ b/src/Annotation/XmlList.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * Copyright 2016 Johannes M. Schmitt <schmittjoh@gmail.com>
  *

--- a/src/Annotation/XmlMap.php
+++ b/src/Annotation/XmlMap.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * Copyright 2016 Johannes M. Schmitt <schmittjoh@gmail.com>
  *

--- a/src/Annotation/XmlNamespace.php
+++ b/src/Annotation/XmlNamespace.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * Copyright 2011 Johannes M. Schmitt <schmittjoh@gmail.com>
  *

--- a/src/Annotation/XmlRoot.php
+++ b/src/Annotation/XmlRoot.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * Copyright 2016 Johannes M. Schmitt <schmittjoh@gmail.com>
  *

--- a/src/Annotation/XmlValue.php
+++ b/src/Annotation/XmlValue.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * Copyright 2016 Johannes M. Schmitt <schmittjoh@gmail.com>
  *

--- a/src/ArrayTransformerInterface.php
+++ b/src/ArrayTransformerInterface.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * Copyright 2016 Johannes M. Schmitt <schmittjoh@gmail.com>
  *

--- a/src/Builder/CallbackDriverFactory.php
+++ b/src/Builder/CallbackDriverFactory.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace JMS\Serializer\Builder;
 
 use Doctrine\Common\Annotations\Reader;

--- a/src/Builder/DefaultDriverFactory.php
+++ b/src/Builder/DefaultDriverFactory.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace JMS\Serializer\Builder;
 
 use Doctrine\Common\Annotations\Reader;

--- a/src/Builder/DriverFactoryInterface.php
+++ b/src/Builder/DriverFactoryInterface.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace JMS\Serializer\Builder;
 
 use Doctrine\Common\Annotations\Reader;

--- a/src/Construction/DoctrineObjectConstructor.php
+++ b/src/Construction/DoctrineObjectConstructor.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * Copyright 2016 Johannes M. Schmitt <schmittjoh@gmail.com>
  *

--- a/src/Construction/ObjectConstructorInterface.php
+++ b/src/Construction/ObjectConstructorInterface.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * Copyright 2016 Johannes M. Schmitt <schmittjoh@gmail.com>
  *

--- a/src/Construction/UnserializeObjectConstructor.php
+++ b/src/Construction/UnserializeObjectConstructor.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * Copyright 2016 Johannes M. Schmitt <schmittjoh@gmail.com>
  *

--- a/src/Context.php
+++ b/src/Context.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * Copyright 2016 Johannes M. Schmitt <schmittjoh@gmail.com>
  *

--- a/src/ContextFactory/CallableContextFactory.php
+++ b/src/ContextFactory/CallableContextFactory.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * Copyright 2013 Johannes M. Schmitt <schmittjoh@gmail.com>
  *

--- a/src/ContextFactory/CallableDeserializationContextFactory.php
+++ b/src/ContextFactory/CallableDeserializationContextFactory.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * Copyright 2013 Johannes M. Schmitt <schmittjoh@gmail.com>
  *

--- a/src/ContextFactory/CallableSerializationContextFactory.php
+++ b/src/ContextFactory/CallableSerializationContextFactory.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * Copyright 2013 Johannes M. Schmitt <schmittjoh@gmail.com>
  *

--- a/src/ContextFactory/DefaultDeserializationContextFactory.php
+++ b/src/ContextFactory/DefaultDeserializationContextFactory.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * Copyright 2013 Johannes M. Schmitt <schmittjoh@gmail.com>
  *

--- a/src/ContextFactory/DefaultSerializationContextFactory.php
+++ b/src/ContextFactory/DefaultSerializationContextFactory.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * Copyright 2013 Johannes M. Schmitt <schmittjoh@gmail.com>
  *

--- a/src/ContextFactory/DeserializationContextFactoryInterface.php
+++ b/src/ContextFactory/DeserializationContextFactoryInterface.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * Copyright 2013 Johannes M. Schmitt <schmittjoh@gmail.com>
  *

--- a/src/ContextFactory/SerializationContextFactoryInterface.php
+++ b/src/ContextFactory/SerializationContextFactoryInterface.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * Copyright 2013 Johannes M. Schmitt <schmittjoh@gmail.com>
  *

--- a/src/DeserializationContext.php
+++ b/src/DeserializationContext.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * Copyright 2016 Johannes M. Schmitt <schmittjoh@gmail.com>
  *

--- a/src/DeserializationGraphNavigator.php
+++ b/src/DeserializationGraphNavigator.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * Copyright 2016 Johannes M. Schmitt <schmittjoh@gmail.com>
  *

--- a/src/DeserializationVisitorInterface.php
+++ b/src/DeserializationVisitorInterface.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * Copyright 2016 Johannes M. Schmitt <schmittjoh@gmail.com>
  *

--- a/src/EventDispatcher/Event.php
+++ b/src/EventDispatcher/Event.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * Copyright 2016 Johannes M. Schmitt <schmittjoh@gmail.com>
  *

--- a/src/EventDispatcher/EventDispatcher.php
+++ b/src/EventDispatcher/EventDispatcher.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * Copyright 2016 Johannes M. Schmitt <schmittjoh@gmail.com>
  *

--- a/src/EventDispatcher/EventDispatcherInterface.php
+++ b/src/EventDispatcher/EventDispatcherInterface.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * Copyright 2016 Johannes M. Schmitt <schmittjoh@gmail.com>
  *

--- a/src/EventDispatcher/EventSubscriberInterface.php
+++ b/src/EventDispatcher/EventSubscriberInterface.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * Copyright 2016 Johannes M. Schmitt <schmittjoh@gmail.com>
  *

--- a/src/EventDispatcher/Events.php
+++ b/src/EventDispatcher/Events.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * Copyright 2016 Johannes M. Schmitt <schmittjoh@gmail.com>
  *

--- a/src/EventDispatcher/LazyEventDispatcher.php
+++ b/src/EventDispatcher/LazyEventDispatcher.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * Copyright 2016 Johannes M. Schmitt <schmittjoh@gmail.com>
  *

--- a/src/EventDispatcher/ObjectEvent.php
+++ b/src/EventDispatcher/ObjectEvent.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * Copyright 2016 Johannes M. Schmitt <schmittjoh@gmail.com>
  *

--- a/src/EventDispatcher/PreDeserializeEvent.php
+++ b/src/EventDispatcher/PreDeserializeEvent.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * Copyright 2016 Johannes M. Schmitt <schmittjoh@gmail.com>
  *

--- a/src/EventDispatcher/PreSerializeEvent.php
+++ b/src/EventDispatcher/PreSerializeEvent.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * Copyright 2016 Johannes M. Schmitt <schmittjoh@gmail.com>
  *

--- a/src/EventDispatcher/Subscriber/DoctrineProxySubscriber.php
+++ b/src/EventDispatcher/Subscriber/DoctrineProxySubscriber.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * Copyright 2016 Johannes M. Schmitt <schmittjoh@gmail.com>
  *

--- a/src/EventDispatcher/Subscriber/SymfonyValidatorValidatorSubscriber.php
+++ b/src/EventDispatcher/Subscriber/SymfonyValidatorValidatorSubscriber.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * Copyright 2016 Asmir Mustafic <goetas@gmail.com>
  *

--- a/src/Exception/CircularReferenceDetectedException.php
+++ b/src/Exception/CircularReferenceDetectedException.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * Copyright 2016 Johannes M. Schmitt <schmittjoh@gmail.com>
  *

--- a/src/Exception/Exception.php
+++ b/src/Exception/Exception.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * Copyright 2016 Johannes M. Schmitt <schmittjoh@gmail.com>
  *

--- a/src/Exception/ExcludedClassException.php
+++ b/src/Exception/ExcludedClassException.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * Copyright 2016 Johannes M. Schmitt <schmittjoh@gmail.com>
  *

--- a/src/Exception/ExpressionLanguageRequiredException.php
+++ b/src/Exception/ExpressionLanguageRequiredException.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * Copyright 2016 Johannes M. Schmitt <schmittjoh@gmail.com>
  *

--- a/src/Exception/InvalidArgumentException.php
+++ b/src/Exception/InvalidArgumentException.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * Copyright 2016 Johannes M. Schmitt <schmittjoh@gmail.com>
  *

--- a/src/Exception/LogicException.php
+++ b/src/Exception/LogicException.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * Copyright 2016 Johannes M. Schmitt <schmittjoh@gmail.com>
  *

--- a/src/Exception/NotAcceptableException.php
+++ b/src/Exception/NotAcceptableException.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * Copyright 2016 Johannes M. Schmitt <schmittjoh@gmail.com>
  *

--- a/src/Exception/ObjectConstructionException.php
+++ b/src/Exception/ObjectConstructionException.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * Copyright 2016 Johannes M. Schmitt <schmittjoh@gmail.com>
  *

--- a/src/Exception/RuntimeException.php
+++ b/src/Exception/RuntimeException.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * Copyright 2016 Johannes M. Schmitt <schmittjoh@gmail.com>
  *

--- a/src/Exception/UnsupportedFormatException.php
+++ b/src/Exception/UnsupportedFormatException.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * Copyright 2016 Johannes M. Schmitt <schmittjoh@gmail.com>
  *

--- a/src/Exception/ValidationFailedException.php
+++ b/src/Exception/ValidationFailedException.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * Copyright 2016 Johannes M. Schmitt <schmittjoh@gmail.com>
  *

--- a/src/Exception/XmlErrorException.php
+++ b/src/Exception/XmlErrorException.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * Copyright 2016 Johannes M. Schmitt <schmittjoh@gmail.com>
  *

--- a/src/Exclusion/DepthExclusionStrategy.php
+++ b/src/Exclusion/DepthExclusionStrategy.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * Copyright 2011 Johannes M. Schmitt <schmittjoh@gmail.com>
  *

--- a/src/Exclusion/DisjunctExclusionStrategy.php
+++ b/src/Exclusion/DisjunctExclusionStrategy.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * Copyright 2016 Johannes M. Schmitt <schmittjoh@gmail.com>
  *

--- a/src/Exclusion/ExclusionStrategyInterface.php
+++ b/src/Exclusion/ExclusionStrategyInterface.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * Copyright 2016 Johannes M. Schmitt <schmittjoh@gmail.com>
  *

--- a/src/Exclusion/ExpressionLanguageExclusionStrategy.php
+++ b/src/Exclusion/ExpressionLanguageExclusionStrategy.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * Copyright 2016 Johannes M. Schmitt <schmittjoh@gmail.com>
  *

--- a/src/Exclusion/GroupsExclusionStrategy.php
+++ b/src/Exclusion/GroupsExclusionStrategy.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * Copyright 2013 Johannes M. Schmitt <schmittjoh@gmail.com>
  *

--- a/src/Exclusion/VersionExclusionStrategy.php
+++ b/src/Exclusion/VersionExclusionStrategy.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * Copyright 2016 Johannes M. Schmitt <schmittjoh@gmail.com>
  *

--- a/src/Expression/ExpressionEvaluator.php
+++ b/src/Expression/ExpressionEvaluator.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * Copyright 2016 Johannes M. Schmitt <schmittjoh@gmail.com>
  *

--- a/src/Expression/ExpressionEvaluatorInterface.php
+++ b/src/Expression/ExpressionEvaluatorInterface.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * Copyright 2016 Johannes M. Schmitt <schmittjoh@gmail.com>
  *

--- a/src/GraphNavigatorInterface.php
+++ b/src/GraphNavigatorInterface.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * Copyright 2016 Johannes M. Schmitt <schmittjoh@gmail.com>
  *

--- a/src/Handler/ArrayCollectionHandler.php
+++ b/src/Handler/ArrayCollectionHandler.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * Copyright 2016 Johannes M. Schmitt <schmittjoh@gmail.com>
  *

--- a/src/Handler/ConstraintViolationHandler.php
+++ b/src/Handler/ConstraintViolationHandler.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * Copyright 2016 Johannes M. Schmitt <schmittjoh@gmail.com>
  *

--- a/src/Handler/DateHandler.php
+++ b/src/Handler/DateHandler.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * Copyright 2016 Johannes M. Schmitt <schmittjoh@gmail.com>
  *
@@ -81,7 +83,7 @@ final class DateHandler implements SubscribingHandlerInterface
 
         $format = $this->getFormat($type);
         if ('U' === $format) {
-            return $visitor->visitInteger($date->format($format), $type);
+            return $visitor->visitInteger((int) $date->format($format), $type);
         }
 
         return $visitor->visitString($date->format($this->getFormat($type)), $type);
@@ -143,7 +145,7 @@ final class DateHandler implements SubscribingHandlerInterface
             return null;
         }
 
-        return $this->parseDateInterval($data);
+        return $this->parseDateInterval((string) $data);
     }
 
     public function deserializeDateTimeFromJson(JsonDeserializationVisitor $visitor, $data, array $type)

--- a/src/Handler/FormErrorHandler.php
+++ b/src/Handler/FormErrorHandler.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * Copyright 2016 Johannes M. Schmitt <schmittjoh@gmail.com>
  *

--- a/src/Handler/HandlerRegistry.php
+++ b/src/Handler/HandlerRegistry.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * Copyright 2016 Johannes M. Schmitt <schmittjoh@gmail.com>
  *

--- a/src/Handler/HandlerRegistryInterface.php
+++ b/src/Handler/HandlerRegistryInterface.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * Copyright 2016 Johannes M. Schmitt <schmittjoh@gmail.com>
  *

--- a/src/Handler/LazyHandlerRegistry.php
+++ b/src/Handler/LazyHandlerRegistry.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * Copyright 2016 Johannes M. Schmitt <schmittjoh@gmail.com>
  *

--- a/src/Handler/StdClassHandler.php
+++ b/src/Handler/StdClassHandler.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * Copyright 2016 Johannes M. Schmitt <schmittjoh@gmail.com>
  *

--- a/src/Handler/SubscribingHandlerInterface.php
+++ b/src/Handler/SubscribingHandlerInterface.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * Copyright 2016 Johannes M. Schmitt <schmittjoh@gmail.com>
  *

--- a/src/JsonDeserializationVisitor.php
+++ b/src/JsonDeserializationVisitor.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * Copyright 2016 Johannes M. Schmitt <schmittjoh@gmail.com>
  *

--- a/src/JsonSerializationVisitor.php
+++ b/src/JsonSerializationVisitor.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * Copyright 2016 Johannes M. Schmitt <schmittjoh@gmail.com>
  *

--- a/src/Metadata/ClassMetadata.php
+++ b/src/Metadata/ClassMetadata.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * Copyright 2016 Johannes M. Schmitt <schmittjoh@gmail.com>
  *

--- a/src/Metadata/Driver/AbstractDoctrineTypeDriver.php
+++ b/src/Metadata/Driver/AbstractDoctrineTypeDriver.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * Copyright 2016 Johannes M. Schmitt <schmittjoh@gmail.com>
  *

--- a/src/Metadata/Driver/AnnotationDriver.php
+++ b/src/Metadata/Driver/AnnotationDriver.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * Copyright 2016 Johannes M. Schmitt <schmittjoh@gmail.com>
  *

--- a/src/Metadata/Driver/DoctrinePHPCRTypeDriver.php
+++ b/src/Metadata/Driver/DoctrinePHPCRTypeDriver.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * Copyright 2016 Johannes M. Schmitt <schmittjoh@gmail.com>
  *

--- a/src/Metadata/Driver/DoctrineTypeDriver.php
+++ b/src/Metadata/Driver/DoctrineTypeDriver.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * Copyright 2016 Johannes M. Schmitt <schmittjoh@gmail.com>
  *

--- a/src/Metadata/Driver/NullDriver.php
+++ b/src/Metadata/Driver/NullDriver.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * Copyright 2016 Johannes M. Schmitt <schmittjoh@gmail.com>
  *

--- a/src/Metadata/Driver/XmlDriver.php
+++ b/src/Metadata/Driver/XmlDriver.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * Copyright 2016 Johannes M. Schmitt <schmittjoh@gmail.com>
  *
@@ -67,8 +69,8 @@ class XmlDriver extends AbstractFileDriver
 
         $metadata->fileResources[] = $path;
         $metadata->fileResources[] = $class->getFileName();
-        $exclusionPolicy = strtoupper($elem->attributes()->{'exclusion-policy'}) ?: 'NONE';
-        $excludeAll = null !== ($exclude = $elem->attributes()->exclude) ? 'true' === strtolower($exclude) : false;
+        $exclusionPolicy = strtoupper((string)$elem->attributes()->{'exclusion-policy'}) ?: 'NONE';
+        $excludeAll = null !== ($exclude = $elem->attributes()->exclude) ? 'true' === strtolower((string)$exclude) : false;
         $classAccessType = (string)($elem->attributes()->{'access-type'} ?: PropertyMetadata::ACCESS_TYPE_PROPERTY);
 
         $propertiesMetadata = array();
@@ -86,7 +88,7 @@ class XmlDriver extends AbstractFileDriver
             $metadata->xmlRootNamespace = (string)$xmlRootNamespace;
         }
 
-        $readOnlyClass = 'true' === strtolower($elem->attributes()->{'read-only'});
+        $readOnlyClass = 'true' === strtolower((string)$elem->attributes()->{'read-only'});
 
         $discriminatorFieldName = (string)$elem->attributes()->{'discriminator-field-name'};
         $discriminatorMap = array();
@@ -173,7 +175,7 @@ class XmlDriver extends AbstractFileDriver
                 if (!empty($pElem)) {
 
                     if (null !== $exclude = $pElem->attributes()->exclude) {
-                        $isExclude = 'true' === strtolower($exclude);
+                        $isExclude = 'true' === strtolower((string)$exclude);
                     }
 
                     if ($isExclude) {
@@ -181,19 +183,19 @@ class XmlDriver extends AbstractFileDriver
                     }
 
                     if (null !== $expose = $pElem->attributes()->expose) {
-                        $isExpose = 'true' === strtolower($expose);
+                        $isExpose = 'true' === strtolower((string)$expose);
                     }
 
                     if (null !== $excludeIf = $pElem->attributes()->{'exclude-if'}) {
-                        $pMetadata->excludeIf = $excludeIf;
+                        $pMetadata->excludeIf = (string)$excludeIf;
                     }
 
                     if (null !== $skip = $pElem->attributes()->{'skip-when-empty'}) {
-                        $pMetadata->skipWhenEmpty = 'true' === strtolower($skip);
+                        $pMetadata->skipWhenEmpty = 'true' === strtolower((string)$skip);
                     }
 
                     if (null !== $excludeIf = $pElem->attributes()->{'expose-if'}) {
-                        $pMetadata->excludeIf = "!(" . $excludeIf . ")";
+                        $pMetadata->excludeIf = "!(" . (string)$excludeIf . ")";
                         $isExpose = true;
                     }
 
@@ -216,7 +218,7 @@ class XmlDriver extends AbstractFileDriver
                     }
 
                     if (null !== $groups = $pElem->attributes()->groups) {
-                        $pMetadata->groups = preg_split('/\s*,\s*/', (string) trim($groups));
+                        $pMetadata->groups = preg_split('/\s*,\s*/', trim((string)$groups));
                     } elseif (isset($pElem->groups)) {
                         $pMetadata->groups = (array) $pElem->groups->value;
                     }
@@ -299,7 +301,7 @@ class XmlDriver extends AbstractFileDriver
 
                     //we need read-only before setter and getter set, because that method depends on flag being set
                     if (null !== $readOnly = $pElem->attributes()->{'read-only'}) {
-                        $pMetadata->readOnly = 'true' === strtolower($readOnly);
+                        $pMetadata->readOnly = 'true' === strtolower((string)$readOnly);
                     } else {
                         $pMetadata->readOnly = $pMetadata->readOnly || $readOnlyClass;
                     }
@@ -313,7 +315,7 @@ class XmlDriver extends AbstractFileDriver
                     );
 
                     if (null !== $inline = $pElem->attributes()->inline) {
-                        $pMetadata->inline = 'true' === strtolower($inline);
+                        $pMetadata->inline = 'true' === strtolower((string)$inline);
                     }
                 }
 

--- a/src/Metadata/Driver/YamlDriver.php
+++ b/src/Metadata/Driver/YamlDriver.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * Copyright 2016 Johannes M. Schmitt <schmittjoh@gmail.com>
  *

--- a/src/Metadata/ExpressionPropertyMetadata.php
+++ b/src/Metadata/ExpressionPropertyMetadata.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * Copyright 2016 Johannes M. Schmitt <schmittjoh@gmail.com>
  *

--- a/src/Metadata/PropertyMetadata.php
+++ b/src/Metadata/PropertyMetadata.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * Copyright 2016 Johannes M. Schmitt <schmittjoh@gmail.com>
  *

--- a/src/Metadata/StaticPropertyMetadata.php
+++ b/src/Metadata/StaticPropertyMetadata.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * Copyright 2016 Johannes M. Schmitt <schmittjoh@gmail.com>
  *

--- a/src/Metadata/VirtualPropertyMetadata.php
+++ b/src/Metadata/VirtualPropertyMetadata.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * Copyright 2016 Johannes M. Schmitt <schmittjoh@gmail.com>
  *

--- a/src/Naming/CamelCaseNamingStrategy.php
+++ b/src/Naming/CamelCaseNamingStrategy.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * Copyright 2016 Johannes M. Schmitt <schmittjoh@gmail.com>
  *

--- a/src/Naming/IdenticalPropertyNamingStrategy.php
+++ b/src/Naming/IdenticalPropertyNamingStrategy.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * Copyright 2016 Johannes M. Schmitt <schmittjoh@gmail.com>
  *

--- a/src/Naming/PropertyNamingStrategyInterface.php
+++ b/src/Naming/PropertyNamingStrategyInterface.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * Copyright 2016 Johannes M. Schmitt <schmittjoh@gmail.com>
  *

--- a/src/Naming/SerializedNameAnnotationStrategy.php
+++ b/src/Naming/SerializedNameAnnotationStrategy.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * Copyright 2016 Johannes M. Schmitt <schmittjoh@gmail.com>
  *

--- a/src/NullAwareVisitorInterface.php
+++ b/src/NullAwareVisitorInterface.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * Copyright 2016 Johannes M. Schmitt <schmittjoh@gmail.com>
  *

--- a/src/SerializationContext.php
+++ b/src/SerializationContext.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * Copyright 2016 Johannes M. Schmitt <schmittjoh@gmail.com>
  *

--- a/src/SerializationGraphNavigator.php
+++ b/src/SerializationGraphNavigator.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * Copyright 2016 Johannes M. Schmitt <schmittjoh@gmail.com>
  *
@@ -108,22 +110,22 @@ final class SerializationGraphNavigator implements GraphNavigatorInterface
                 return $visitor->visitNull($data, $type);
 
             case 'string':
-                return $visitor->visitString($data, $type);
+                return $visitor->visitString((string)$data, $type);
 
             case 'int':
             case 'integer':
-                return $visitor->visitInteger($data, $type);
+                return $visitor->visitInteger((int)$data, $type);
 
             case 'bool':
             case 'boolean':
-                return $visitor->visitBoolean($data, $type);
+                return $visitor->visitBoolean((bool)$data, $type);
 
             case 'double':
             case 'float':
-                return $visitor->visitDouble($data, $type);
+                return $visitor->visitDouble((float)$data, $type);
 
             case 'array':
-                return $visitor->visitArray($data, $type);
+                return $visitor->visitArray((array)$data, $type);
 
             case 'resource':
                 $msg = 'Resources are not supported in serialized data.';

--- a/src/SerializationVisitorInterface.php
+++ b/src/SerializationVisitorInterface.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * Copyright 2016 Johannes M. Schmitt <schmittjoh@gmail.com>
  *

--- a/src/Serializer.php
+++ b/src/Serializer.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * Copyright 2016 Johannes M. Schmitt <schmittjoh@gmail.com>
  *

--- a/src/SerializerBuilder.php
+++ b/src/SerializerBuilder.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * Copyright 2016 Johannes M. Schmitt <schmittjoh@gmail.com>
  *

--- a/src/SerializerInterface.php
+++ b/src/SerializerInterface.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * Copyright 2016 Johannes M. Schmitt <schmittjoh@gmail.com>
  *

--- a/src/Twig/SerializerExtension.php
+++ b/src/Twig/SerializerExtension.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * Copyright 2016 Johannes M. Schmitt <schmittjoh@gmail.com>
  *

--- a/src/Twig/SerializerRuntimeExtension.php
+++ b/src/Twig/SerializerRuntimeExtension.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * Copyright 2016 Johannes M. Schmitt <schmittjoh@gmail.com>
  *

--- a/src/Twig/SerializerRuntimeHelper.php
+++ b/src/Twig/SerializerRuntimeHelper.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * Copyright 2016 Johannes M. Schmitt <schmittjoh@gmail.com>
  *

--- a/src/TypeParser.php
+++ b/src/TypeParser.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * Copyright 2016 Johannes M. Schmitt <schmittjoh@gmail.com>
  *

--- a/src/VisitorFactory/DeserializationVisitorFactory.php
+++ b/src/VisitorFactory/DeserializationVisitorFactory.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * Copyright 2016 Johannes M. Schmitt <schmittjoh@gmail.com>
  *

--- a/src/VisitorFactory/JsonDeserializationVisitorFactory.php
+++ b/src/VisitorFactory/JsonDeserializationVisitorFactory.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * Copyright 2016 Johannes M. Schmitt <schmittjoh@gmail.com>
  *

--- a/src/VisitorFactory/JsonSerializationVisitorFactory.php
+++ b/src/VisitorFactory/JsonSerializationVisitorFactory.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * Copyright 2016 Johannes M. Schmitt <schmittjoh@gmail.com>
  *

--- a/src/VisitorFactory/SerializationVisitorFactory.php
+++ b/src/VisitorFactory/SerializationVisitorFactory.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * Copyright 2016 Johannes M. Schmitt <schmittjoh@gmail.com>
  *

--- a/src/VisitorFactory/XmlDeserializationVisitorFactory.php
+++ b/src/VisitorFactory/XmlDeserializationVisitorFactory.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * Copyright 2016 Johannes M. Schmitt <schmittjoh@gmail.com>
  *

--- a/src/VisitorFactory/XmlSerializationVisitorFactory.php
+++ b/src/VisitorFactory/XmlSerializationVisitorFactory.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * Copyright 2016 Johannes M. Schmitt <schmittjoh@gmail.com>
  *

--- a/src/XmlDeserializationVisitor.php
+++ b/src/XmlDeserializationVisitor.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * Copyright 2016 Johannes M. Schmitt <schmittjoh@gmail.com>
  *

--- a/src/XmlSerializationVisitor.php
+++ b/src/XmlSerializationVisitor.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * Copyright 2016 Johannes M. Schmitt <schmittjoh@gmail.com>
  *
@@ -165,7 +167,7 @@ class XmlSerializationVisitor extends AbstractVisitor implements SerializationVi
                 continue;
             }
 
-            $tagName = (null !== $this->currentMetadata && $this->currentMetadata->xmlKeyValuePairs && $this->isElementNameValid($k)) ? $k : $entryName;
+            $tagName = (null !== $this->currentMetadata && $this->currentMetadata->xmlKeyValuePairs && $this->isElementNameValid((string)$k)) ? $k : $entryName;
 
             $entryNode = $this->createElement($tagName, $namespace);
             $this->currentNode->appendChild($entryNode);

--- a/tests/Exclusion/DisjunctExclusionStrategyTest.php
+++ b/tests/Exclusion/DisjunctExclusionStrategyTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * Copyright 2016 Johannes M. Schmitt <schmittjoh@gmail.com>
  *

--- a/tests/Exclusion/ExpressionLanguageExclusionStrategyTest.php
+++ b/tests/Exclusion/ExpressionLanguageExclusionStrategyTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * Copyright 2016 Johannes M. Schmitt <schmittjoh@gmail.com>
  *

--- a/tests/Exclusion/GroupsExclusionStrategyTest.php
+++ b/tests/Exclusion/GroupsExclusionStrategyTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * Copyright 2016 Johannes M. Schmitt <schmittjoh@gmail.com>
  *

--- a/tests/Fixtures/AccessorOrderChild.php
+++ b/tests/Fixtures/AccessorOrderChild.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * Copyright 2016 Johannes M. Schmitt <schmittjoh@gmail.com>
  *

--- a/tests/Fixtures/AccessorOrderMethod.php
+++ b/tests/Fixtures/AccessorOrderMethod.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * Copyright 2016 Johannes M. Schmitt <schmittjoh@gmail.com>
  *

--- a/tests/Fixtures/AccessorOrderParent.php
+++ b/tests/Fixtures/AccessorOrderParent.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * Copyright 2016 Johannes M. Schmitt <schmittjoh@gmail.com>
  *

--- a/tests/Fixtures/AccessorSetter.php
+++ b/tests/Fixtures/AccessorSetter.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace JMS\Serializer\Tests\Fixtures;
 
 use JMS\Serializer\Annotation as Serializer;

--- a/tests/Fixtures/AllExcludedObject.php
+++ b/tests/Fixtures/AllExcludedObject.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * Copyright 2016 Johannes M. Schmitt <schmittjoh@gmail.com>
  *

--- a/tests/Fixtures/Author.php
+++ b/tests/Fixtures/Author.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * Copyright 2016 Johannes M. Schmitt <schmittjoh@gmail.com>
  *

--- a/tests/Fixtures/AuthorExpressionAccess.php
+++ b/tests/Fixtures/AuthorExpressionAccess.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * Copyright 2016 Johannes M. Schmitt <schmittjoh@gmail.com>
  *

--- a/tests/Fixtures/AuthorList.php
+++ b/tests/Fixtures/AuthorList.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * Copyright 2016 Johannes M. Schmitt <schmittjoh@gmail.com>
  *

--- a/tests/Fixtures/AuthorReadOnly.php
+++ b/tests/Fixtures/AuthorReadOnly.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * Copyright 2016 Johannes M. Schmitt <schmittjoh@gmail.com>
  *

--- a/tests/Fixtures/AuthorReadOnlyPerClass.php
+++ b/tests/Fixtures/AuthorReadOnlyPerClass.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * Copyright 2016 Johannes M. Schmitt <schmittjoh@gmail.com>
  *

--- a/tests/Fixtures/BlogPost.php
+++ b/tests/Fixtures/BlogPost.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * Copyright 2016 Johannes M. Schmitt <schmittjoh@gmail.com>
  *

--- a/tests/Fixtures/CircularReferenceChild.php
+++ b/tests/Fixtures/CircularReferenceChild.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * Copyright 2016 Johannes M. Schmitt <schmittjoh@gmail.com>
  *

--- a/tests/Fixtures/CircularReferenceCollection.php
+++ b/tests/Fixtures/CircularReferenceCollection.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * Copyright 2016 Johannes M. Schmitt <schmittjoh@gmail.com>
  *

--- a/tests/Fixtures/CircularReferenceParent.php
+++ b/tests/Fixtures/CircularReferenceParent.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * Copyright 2016 Johannes M. Schmitt <schmittjoh@gmail.com>
  *

--- a/tests/Fixtures/Comment.php
+++ b/tests/Fixtures/Comment.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * Copyright 2016 Johannes M. Schmitt <schmittjoh@gmail.com>
  *

--- a/tests/Fixtures/CurrencyAwareOrder.php
+++ b/tests/Fixtures/CurrencyAwareOrder.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * Copyright 2016 Johannes M. Schmitt <schmittjoh@gmail.com>
  *

--- a/tests/Fixtures/CurrencyAwarePrice.php
+++ b/tests/Fixtures/CurrencyAwarePrice.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * Copyright 2016 Johannes M. Schmitt <schmittjoh@gmail.com>
  *

--- a/tests/Fixtures/CustomDeserializationObject.php
+++ b/tests/Fixtures/CustomDeserializationObject.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * Copyright 2016 Johannes M. Schmitt <schmittjoh@gmail.com>
  *

--- a/tests/Fixtures/DateTimeArraysObject.php
+++ b/tests/Fixtures/DateTimeArraysObject.php
@@ -1,4 +1,6 @@
 <?php
+
+declare(strict_types=1);
 /*
  * Copyright 2016 Johannes M. Schmitt <schmittjoh@gmail.com>
  *

--- a/tests/Fixtures/Discriminator/Car.php
+++ b/tests/Fixtures/Discriminator/Car.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * Copyright 2016 Johannes M. Schmitt <schmittjoh@gmail.com>
  *

--- a/tests/Fixtures/Discriminator/Moped.php
+++ b/tests/Fixtures/Discriminator/Moped.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * Copyright 2016 Johannes M. Schmitt <schmittjoh@gmail.com>
  *

--- a/tests/Fixtures/Discriminator/ObjectWithXmlAttributeDiscriminatorChild.php
+++ b/tests/Fixtures/Discriminator/ObjectWithXmlAttributeDiscriminatorChild.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * Copyright 2016 Björn Bösel <bjoern.boesel@twt.de>
  *

--- a/tests/Fixtures/Discriminator/ObjectWithXmlAttributeDiscriminatorParent.php
+++ b/tests/Fixtures/Discriminator/ObjectWithXmlAttributeDiscriminatorParent.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * Copyright 2016 Björn Bösel <bjoern.boesel@twt.de>
  *

--- a/tests/Fixtures/Discriminator/ObjectWithXmlNamespaceDiscriminatorChild.php
+++ b/tests/Fixtures/Discriminator/ObjectWithXmlNamespaceDiscriminatorChild.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * Copyright 2016 Björn Bösel <bjoern.boesel@twt.de>
  *

--- a/tests/Fixtures/Discriminator/ObjectWithXmlNamespaceDiscriminatorParent.php
+++ b/tests/Fixtures/Discriminator/ObjectWithXmlNamespaceDiscriminatorParent.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * Copyright 2016 Björn Bösel <bjoern.boesel@twt.de>
  *

--- a/tests/Fixtures/Discriminator/ObjectWithXmlNotCDataDiscriminatorChild.php
+++ b/tests/Fixtures/Discriminator/ObjectWithXmlNotCDataDiscriminatorChild.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * Copyright 2016 Björn Bösel <bjoern.boesel@twt.de>
  *

--- a/tests/Fixtures/Discriminator/ObjectWithXmlNotCDataDiscriminatorParent.php
+++ b/tests/Fixtures/Discriminator/ObjectWithXmlNotCDataDiscriminatorParent.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * Copyright 2016 Björn Bösel <bjoern.boesel@twt.de>
  *

--- a/tests/Fixtures/Discriminator/Vehicle.php
+++ b/tests/Fixtures/Discriminator/Vehicle.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * Copyright 2016 Johannes M. Schmitt <schmittjoh@gmail.com>
  *

--- a/tests/Fixtures/Discriminator/VehicleInterface.php
+++ b/tests/Fixtures/Discriminator/VehicleInterface.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * Copyright 2016 Johannes M. Schmitt <schmittjoh@gmail.com>
  *

--- a/tests/Fixtures/DiscriminatorGroup/Car.php
+++ b/tests/Fixtures/DiscriminatorGroup/Car.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * Copyright 2016 Johannes M. Schmitt <schmittjoh@gmail.com>
  *

--- a/tests/Fixtures/DiscriminatorGroup/Vehicle.php
+++ b/tests/Fixtures/DiscriminatorGroup/Vehicle.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * Copyright 2016 Johannes M. Schmitt <schmittjoh@gmail.com>
  *

--- a/tests/Fixtures/Doctrine/Author.php
+++ b/tests/Fixtures/Doctrine/Author.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * Copyright 2016 Johannes M. Schmitt <schmittjoh@gmail.com>
  *

--- a/tests/Fixtures/Doctrine/BlogPost.php
+++ b/tests/Fixtures/Doctrine/BlogPost.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * Copyright 2016 Johannes M. Schmitt <schmittjoh@gmail.com>
  *

--- a/tests/Fixtures/Doctrine/Comment.php
+++ b/tests/Fixtures/Doctrine/Comment.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * Copyright 2016 Johannes M. Schmitt <schmittjoh@gmail.com>
  *

--- a/tests/Fixtures/Doctrine/SingleTableInheritance/AbstractModel.php
+++ b/tests/Fixtures/Doctrine/SingleTableInheritance/AbstractModel.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace JMS\Serializer\Tests\Fixtures\Doctrine\SingleTableInheritance;
 
 /**

--- a/tests/Fixtures/Doctrine/SingleTableInheritance/Clazz.php
+++ b/tests/Fixtures/Doctrine/SingleTableInheritance/Clazz.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace JMS\Serializer\Tests\Fixtures\Doctrine\SingleTableInheritance;
 
 use Doctrine\Common\Collections\ArrayCollection;

--- a/tests/Fixtures/Doctrine/SingleTableInheritance/Organization.php
+++ b/tests/Fixtures/Doctrine/SingleTableInheritance/Organization.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace JMS\Serializer\Tests\Fixtures\Doctrine\SingleTableInheritance;
 
 use Doctrine\ORM\Mapping as ORM;

--- a/tests/Fixtures/Doctrine/SingleTableInheritance/Person.php
+++ b/tests/Fixtures/Doctrine/SingleTableInheritance/Person.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace JMS\Serializer\Tests\Fixtures\Doctrine\SingleTableInheritance;
 
 use Doctrine\ORM\Mapping as ORM;

--- a/tests/Fixtures/Doctrine/SingleTableInheritance/School.php
+++ b/tests/Fixtures/Doctrine/SingleTableInheritance/School.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace JMS\Serializer\Tests\Fixtures\Doctrine\SingleTableInheritance;
 
 use Doctrine\ORM\Mapping as ORM;

--- a/tests/Fixtures/Doctrine/SingleTableInheritance/Student.php
+++ b/tests/Fixtures/Doctrine/SingleTableInheritance/Student.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace JMS\Serializer\Tests\Fixtures\Doctrine\SingleTableInheritance;
 
 use Doctrine\ORM\Mapping as ORM;

--- a/tests/Fixtures/Doctrine/SingleTableInheritance/Teacher.php
+++ b/tests/Fixtures/Doctrine/SingleTableInheritance/Teacher.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace JMS\Serializer\Tests\Fixtures\Doctrine\SingleTableInheritance;
 
 use Doctrine\ORM\Mapping as ORM;

--- a/tests/Fixtures/DoctrinePHPCR/Author.php
+++ b/tests/Fixtures/DoctrinePHPCR/Author.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * Copyright 2016 Johannes M. Schmitt <schmittjoh@gmail.com>
  *

--- a/tests/Fixtures/DoctrinePHPCR/BlogPost.php
+++ b/tests/Fixtures/DoctrinePHPCR/BlogPost.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * Copyright 2016 Johannes M. Schmitt <schmittjoh@gmail.com>
  *

--- a/tests/Fixtures/DoctrinePHPCR/Comment.php
+++ b/tests/Fixtures/DoctrinePHPCR/Comment.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * Copyright 2016 Johannes M. Schmitt <schmittjoh@gmail.com>
  *

--- a/tests/Fixtures/ExcludePublicAccessor.php
+++ b/tests/Fixtures/ExcludePublicAccessor.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * Copyright 2016 Johannes M. Schmitt <schmittjoh@gmail.com>
  *

--- a/tests/Fixtures/ExclusionStrategy/AlwaysExcludeExclusionStrategy.php
+++ b/tests/Fixtures/ExclusionStrategy/AlwaysExcludeExclusionStrategy.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace JMS\Serializer\Tests\Fixtures\ExclusionStrategy;
 
 use JMS\Serializer\Context;

--- a/tests/Fixtures/Garage.php
+++ b/tests/Fixtures/Garage.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * Copyright 2016 Johannes M. Schmitt <schmittjoh@gmail.com>
  *

--- a/tests/Fixtures/GetSetObject.php
+++ b/tests/Fixtures/GetSetObject.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * Copyright 2016 Johannes M. Schmitt <schmittjoh@gmail.com>
  *

--- a/tests/Fixtures/GroupsObject.php
+++ b/tests/Fixtures/GroupsObject.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * Copyright 2016 Johannes M. Schmitt <schmittjoh@gmail.com>
  *

--- a/tests/Fixtures/GroupsTrim.php
+++ b/tests/Fixtures/GroupsTrim.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * Copyright 2016 Johannes M. Schmitt <schmittjoh@gmail.com>
  *

--- a/tests/Fixtures/IndexedCommentsBlogPost.php
+++ b/tests/Fixtures/IndexedCommentsBlogPost.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * Copyright 2016 Johannes M. Schmitt <schmittjoh@gmail.com>
  *

--- a/tests/Fixtures/InitializedBlogPostConstructor.php
+++ b/tests/Fixtures/InitializedBlogPostConstructor.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * Copyright 2016 Johannes M. Schmitt <schmittjoh@gmail.com>
  *

--- a/tests/Fixtures/InitializedObjectConstructor.php
+++ b/tests/Fixtures/InitializedObjectConstructor.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * Copyright 2016 Johannes M. Schmitt <schmittjoh@gmail.com>
  *

--- a/tests/Fixtures/InlineChild.php
+++ b/tests/Fixtures/InlineChild.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * Copyright 2016 Johannes M. Schmitt <schmittjoh@gmail.com>
  *

--- a/tests/Fixtures/InlineChildEmpty.php
+++ b/tests/Fixtures/InlineChildEmpty.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * Copyright 2016 Johannes M. Schmitt <schmittjoh@gmail.com>
  *

--- a/tests/Fixtures/InlineChildWithGroups.php
+++ b/tests/Fixtures/InlineChildWithGroups.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * Copyright 2016 Johannes M. Schmitt <schmittjoh@gmail.com>
  *

--- a/tests/Fixtures/InlineParent.php
+++ b/tests/Fixtures/InlineParent.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * Copyright 2016 Johannes M. Schmitt <schmittjoh@gmail.com>
  *

--- a/tests/Fixtures/Input.php
+++ b/tests/Fixtures/Input.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * Copyright 2016 Johannes M. Schmitt <schmittjoh@gmail.com>
  *

--- a/tests/Fixtures/InvalidGroupsObject.php
+++ b/tests/Fixtures/InvalidGroupsObject.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * Copyright 2016 Johannes M. Schmitt <schmittjoh@gmail.com>
  *

--- a/tests/Fixtures/InvalidUsageOfXmlValue.php
+++ b/tests/Fixtures/InvalidUsageOfXmlValue.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * Copyright 2016 Johannes M. Schmitt <schmittjoh@gmail.com>
  *

--- a/tests/Fixtures/Log.php
+++ b/tests/Fixtures/Log.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * Copyright 2016 Johannes M. Schmitt <schmittjoh@gmail.com>
  *

--- a/tests/Fixtures/MaxDepth/Gh236Bar.php
+++ b/tests/Fixtures/MaxDepth/Gh236Bar.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace JMS\Serializer\Tests\Fixtures\MaxDepth;
 
 use JMS\Serializer\Annotation as Serializer;

--- a/tests/Fixtures/MaxDepth/Gh236Foo.php
+++ b/tests/Fixtures/MaxDepth/Gh236Foo.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace JMS\Serializer\Tests\Fixtures\MaxDepth;
 
 use JMS\Serializer\Annotation as Serializer;

--- a/tests/Fixtures/MultilineGroupsFormat.php
+++ b/tests/Fixtures/MultilineGroupsFormat.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * Copyright 2016 Johannes M. Schmitt <schmittjoh@gmail.com>
  *

--- a/tests/Fixtures/NamedDateTimeArraysObject.php
+++ b/tests/Fixtures/NamedDateTimeArraysObject.php
@@ -1,4 +1,6 @@
 <?php
+
+declare(strict_types=1);
 /*
  * Copyright 2016 Johannes M. Schmitt <schmittjoh@gmail.com>
  *

--- a/tests/Fixtures/NamedDateTimeImmutableArraysObject.php
+++ b/tests/Fixtures/NamedDateTimeImmutableArraysObject.php
@@ -1,4 +1,6 @@
 <?php
+
+declare(strict_types=1);
 /*
  * Copyright 2013 Johannes M. Schmitt <schmittjoh@gmail.com>
  *

--- a/tests/Fixtures/Node.php
+++ b/tests/Fixtures/Node.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * Copyright 2016 Johannes M. Schmitt <schmittjoh@gmail.com>
  *

--- a/tests/Fixtures/ObjectWithAbsentXmlListNode.php
+++ b/tests/Fixtures/ObjectWithAbsentXmlListNode.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * Copyright 2016 Johannes M. Schmitt <schmittjoh@gmail.com>
  *

--- a/tests/Fixtures/ObjectWithEmptyArrayAndHash.php
+++ b/tests/Fixtures/ObjectWithEmptyArrayAndHash.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * Copyright 2016 Johannes M. Schmitt <schmittjoh@gmail.com>
  *

--- a/tests/Fixtures/ObjectWithEmptyHash.php
+++ b/tests/Fixtures/ObjectWithEmptyHash.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * Copyright 2016 Johannes M. Schmitt <schmittjoh@gmail.com>
  *

--- a/tests/Fixtures/ObjectWithEmptyNullableAndEmptyArrays.php
+++ b/tests/Fixtures/ObjectWithEmptyNullableAndEmptyArrays.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * Copyright 2016 Johannes M. Schmitt <schmittjoh@gmail.com>
  *

--- a/tests/Fixtures/ObjectWithExpressionVirtualPropertiesAndExcludeAll.php
+++ b/tests/Fixtures/ObjectWithExpressionVirtualPropertiesAndExcludeAll.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * Copyright 2016 Johannes M. Schmitt <schmittjoh@gmail.com>
  *

--- a/tests/Fixtures/ObjectWithIntListAndIntMap.php
+++ b/tests/Fixtures/ObjectWithIntListAndIntMap.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace JMS\Serializer\Tests\Fixtures;
 
 use JMS\Serializer\Annotation as Serializer;

--- a/tests/Fixtures/ObjectWithLifecycleCallbacks.php
+++ b/tests/Fixtures/ObjectWithLifecycleCallbacks.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * Copyright 2016 Johannes M. Schmitt <schmittjoh@gmail.com>
  *

--- a/tests/Fixtures/ObjectWithNamespacesAndList.php
+++ b/tests/Fixtures/ObjectWithNamespacesAndList.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * Copyright 2016 Johannes M. Schmitt <schmittjoh@gmail.com>
  *

--- a/tests/Fixtures/ObjectWithNamespacesAndNestedList.php
+++ b/tests/Fixtures/ObjectWithNamespacesAndNestedList.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * Copyright 2016 Johannes M. Schmitt <schmittjoh@gmail.com>
  *

--- a/tests/Fixtures/ObjectWithNullProperty.php
+++ b/tests/Fixtures/ObjectWithNullProperty.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * Copyright 2016 Johannes M. Schmitt <schmittjoh@gmail.com>
  *

--- a/tests/Fixtures/ObjectWithObjectProperty.php
+++ b/tests/Fixtures/ObjectWithObjectProperty.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * Copyright 2016 Johannes M. Schmitt <schmittjoh@gmail.com>
  * 

--- a/tests/Fixtures/ObjectWithToString.php
+++ b/tests/Fixtures/ObjectWithToString.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * Copyright 2016 Johannes M. Schmitt <schmittjoh@gmail.com>
  *

--- a/tests/Fixtures/ObjectWithVersionedVirtualProperties.php
+++ b/tests/Fixtures/ObjectWithVersionedVirtualProperties.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * Copyright 2016 Johannes M. Schmitt <schmittjoh@gmail.com>
  *

--- a/tests/Fixtures/ObjectWithVirtualProperties.php
+++ b/tests/Fixtures/ObjectWithVirtualProperties.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * Copyright 2016 Johannes M. Schmitt <schmittjoh@gmail.com>
  *

--- a/tests/Fixtures/ObjectWithVirtualPropertiesAndDuplicatePropName.php
+++ b/tests/Fixtures/ObjectWithVirtualPropertiesAndDuplicatePropName.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * Copyright 2016 Johannes M. Schmitt <schmittjoh@gmail.com>
  *

--- a/tests/Fixtures/ObjectWithVirtualPropertiesAndExcludeAll.php
+++ b/tests/Fixtures/ObjectWithVirtualPropertiesAndExcludeAll.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * Copyright 2016 Johannes M. Schmitt <schmittjoh@gmail.com>
  *

--- a/tests/Fixtures/ObjectWithVirtualXmlProperties.php
+++ b/tests/Fixtures/ObjectWithVirtualXmlProperties.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * Copyright 2016 Johannes M. Schmitt <schmittjoh@gmail.com>
  *

--- a/tests/Fixtures/ObjectWithXmlKeyValuePairs.php
+++ b/tests/Fixtures/ObjectWithXmlKeyValuePairs.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * Copyright 2016 Johannes M. Schmitt <schmittjoh@gmail.com>
  *

--- a/tests/Fixtures/ObjectWithXmlKeyValuePairsWithObjectType.php
+++ b/tests/Fixtures/ObjectWithXmlKeyValuePairsWithObjectType.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * Copyright 2016 Johannes M. Schmitt <schmittjoh@gmail.com>
  *

--- a/tests/Fixtures/ObjectWithXmlKeyValuePairsWithType.php
+++ b/tests/Fixtures/ObjectWithXmlKeyValuePairsWithType.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * Copyright 2016 Johannes M. Schmitt <schmittjoh@gmail.com>
  *

--- a/tests/Fixtures/ObjectWithXmlNamespaces.php
+++ b/tests/Fixtures/ObjectWithXmlNamespaces.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * Copyright 2016 Johannes M. Schmitt <schmittjoh@gmail.com>
  * 

--- a/tests/Fixtures/ObjectWithXmlNamespacesAndObjectProperty.php
+++ b/tests/Fixtures/ObjectWithXmlNamespacesAndObjectProperty.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * Copyright 2013 Johannes M. Schmitt <schmittjoh@gmail.com>
  * 

--- a/tests/Fixtures/ObjectWithXmlNamespacesAndObjectPropertyAuthor.php
+++ b/tests/Fixtures/ObjectWithXmlNamespacesAndObjectPropertyAuthor.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * Copyright 2013 Johannes M. Schmitt <schmittjoh@gmail.com>
  * 

--- a/tests/Fixtures/ObjectWithXmlNamespacesAndObjectPropertyVirtual.php
+++ b/tests/Fixtures/ObjectWithXmlNamespacesAndObjectPropertyVirtual.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * Copyright 2013 Johannes M. Schmitt <schmittjoh@gmail.com>
  * 

--- a/tests/Fixtures/ObjectWithXmlRootNamespace.php
+++ b/tests/Fixtures/ObjectWithXmlRootNamespace.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * Copyright 2016 Johannes M. Schmitt <schmittjoh@gmail.com>
  * 

--- a/tests/Fixtures/Order.php
+++ b/tests/Fixtures/Order.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * Copyright 2016 Johannes M. Schmitt <schmittjoh@gmail.com>
  *

--- a/tests/Fixtures/ParentDoNotSkipWithEmptyChild.php
+++ b/tests/Fixtures/ParentDoNotSkipWithEmptyChild.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * Copyright 2016 Johannes M. Schmitt <schmittjoh@gmail.com>
  *

--- a/tests/Fixtures/ParentSkipWithEmptyChild.php
+++ b/tests/Fixtures/ParentSkipWithEmptyChild.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * Copyright 2016 Johannes M. Schmitt <schmittjoh@gmail.com>
  *

--- a/tests/Fixtures/Person.php
+++ b/tests/Fixtures/Person.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * Copyright 2016 Johannes M. Schmitt <schmittjoh@gmail.com>
  *

--- a/tests/Fixtures/PersonCollection.php
+++ b/tests/Fixtures/PersonCollection.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * Copyright 2016 Johannes M. Schmitt <schmittjoh@gmail.com>
  *

--- a/tests/Fixtures/PersonLocation.php
+++ b/tests/Fixtures/PersonLocation.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * Copyright 2016 Johannes M. Schmitt <schmittjoh@gmail.com>
  *

--- a/tests/Fixtures/PersonSecret.php
+++ b/tests/Fixtures/PersonSecret.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * Copyright 2016 Johannes M. Schmitt <schmittjoh@gmail.com>
  *

--- a/tests/Fixtures/PersonSecretMore.php
+++ b/tests/Fixtures/PersonSecretMore.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * Copyright 2016 Johannes M. Schmitt <schmittjoh@gmail.com>
  *

--- a/tests/Fixtures/PersonSecretMoreVirtual.php
+++ b/tests/Fixtures/PersonSecretMoreVirtual.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * Copyright 2016 Johannes M. Schmitt <schmittjoh@gmail.com>
  *

--- a/tests/Fixtures/PersonSecretVirtual.php
+++ b/tests/Fixtures/PersonSecretVirtual.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * Copyright 2016 Johannes M. Schmitt <schmittjoh@gmail.com>
  *

--- a/tests/Fixtures/PersonSecretWithVariables.php
+++ b/tests/Fixtures/PersonSecretWithVariables.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * Copyright 2016 Johannes M. Schmitt <schmittjoh@gmail.com>
  *

--- a/tests/Fixtures/Price.php
+++ b/tests/Fixtures/Price.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * Copyright 2016 Johannes M. Schmitt <schmittjoh@gmail.com>
  *

--- a/tests/Fixtures/Publisher.php
+++ b/tests/Fixtures/Publisher.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * Copyright 2016 Johannes M. Schmitt <schmittjoh@gmail.com>
  *

--- a/tests/Fixtures/SimpleClassObject.php
+++ b/tests/Fixtures/SimpleClassObject.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * Copyright 2016 Johannes M. Schmitt <schmittjoh@gmail.com>
  * 

--- a/tests/Fixtures/SimpleObject.php
+++ b/tests/Fixtures/SimpleObject.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * Copyright 2016 Johannes M. Schmitt <schmittjoh@gmail.com>
  *

--- a/tests/Fixtures/SimpleObjectProxy.php
+++ b/tests/Fixtures/SimpleObjectProxy.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * Copyright 2016 Johannes M. Schmitt <schmittjoh@gmail.com>
  *

--- a/tests/Fixtures/SimpleSubClassObject.php
+++ b/tests/Fixtures/SimpleSubClassObject.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * Copyright 2016 Johannes M. Schmitt <schmittjoh@gmail.com>
  *

--- a/tests/Fixtures/Tag.php
+++ b/tests/Fixtures/Tag.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * Copyright 2016 Johannes M. Schmitt <schmittjoh@gmail.com>
  *

--- a/tests/Fixtures/Timestamp.php
+++ b/tests/Fixtures/Timestamp.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * Copyright 2016 Johannes M. Schmitt <schmittjoh@gmail.com>
  *

--- a/tests/Fixtures/Tree.php
+++ b/tests/Fixtures/Tree.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * Copyright 2016 Johannes M. Schmitt <schmittjoh@gmail.com>
  *

--- a/tests/Fixtures/VehicleInterfaceGarage.php
+++ b/tests/Fixtures/VehicleInterfaceGarage.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * Copyright 2016 Johannes M. Schmitt <schmittjoh@gmail.com>
  *

--- a/tests/Fixtures/VersionedObject.php
+++ b/tests/Fixtures/VersionedObject.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * Copyright 2016 Johannes M. Schmitt <schmittjoh@gmail.com>
  *

--- a/tests/Handler/ArrayCollectionDepthTest.php
+++ b/tests/Handler/ArrayCollectionDepthTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace JMS\Serializer\Tests\Handler;
 
 use JMS\Serializer\Annotation as Serializer;

--- a/tests/Handler/ArrayCollectionHandlerTest.php
+++ b/tests/Handler/ArrayCollectionHandlerTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace JMS\Serializer\Tests\Handler;
 
 use Doctrine\Common\Collections\ArrayCollection;

--- a/tests/Handler/DateHandlerTest.php
+++ b/tests/Handler/DateHandlerTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace JMS\Serializer\Tests\Handler;
 
 use JMS\Serializer\Handler\DateHandler;
@@ -98,7 +100,7 @@ class DateHandlerTest extends \PHPUnit\Framework\TestCase
             ->getMock();
 
 
-        $timestamp = time();
+        $timestamp = (string)time();
         $timezone = 'Europe/Brussels';
         $type = ['name' => 'DateTime', 'params' => ['U', $timezone]];
 
@@ -120,7 +122,7 @@ class DateHandlerTest extends \PHPUnit\Framework\TestCase
             ->getMock();
 
 
-        $timestamp = time();
+        $timestamp = (string)time();
         $timezone = 'Europe/Brussels';
         $type = ['name' => 'DateTimeImmutable', 'params' => ['U', $timezone]];
 

--- a/tests/Handler/FormErrorHandlerTest.php
+++ b/tests/Handler/FormErrorHandlerTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace JMS\Serializer\Tests\Handler;
 
 use JMS\Serializer\Accessor\AccessorStrategyInterface;

--- a/tests/Handler/HandlerRegistryTest.php
+++ b/tests/Handler/HandlerRegistryTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * Copyright 2016 Johannes M. Schmitt <schmittjoh@gmail.com>
  *

--- a/tests/Handler/LazyHandlerRegistryTest.php
+++ b/tests/Handler/LazyHandlerRegistryTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * Copyright 2016 Johannes M. Schmitt <schmittjoh@gmail.com>
  *

--- a/tests/Handler/LazyHandlerRegistryWithPsr11ContainerTest.php
+++ b/tests/Handler/LazyHandlerRegistryWithPsr11ContainerTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * Copyright 2016 Johannes M. Schmitt <schmittjoh@gmail.com>
  *

--- a/tests/Handler/LazyHandlerRegistryWithSymfonyContainerTest.php
+++ b/tests/Handler/LazyHandlerRegistryWithSymfonyContainerTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * Copyright 2016 Johannes M. Schmitt <schmittjoh@gmail.com>
  *

--- a/tests/JMS/Serializer/Tests/Fixtures/ObjectWithInlineArray.php
+++ b/tests/JMS/Serializer/Tests/Fixtures/ObjectWithInlineArray.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace JMS\Serializer\Tests\Fixtures;
 
 use JMS\Serializer\Annotation as Serializer;

--- a/tests/Metadata/ClassMetadataTest.php
+++ b/tests/Metadata/ClassMetadataTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * Copyright 2016 Johannes M. Schmitt <schmittjoh@gmail.com>
  *

--- a/tests/Metadata/Driver/AnnotationDriverTest.php
+++ b/tests/Metadata/Driver/AnnotationDriverTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * Copyright 2016 Johannes M. Schmitt <schmittjoh@gmail.com>
  *

--- a/tests/Metadata/Driver/BaseDriverTest.php
+++ b/tests/Metadata/Driver/BaseDriverTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * Copyright 2016 Johannes M. Schmitt <schmittjoh@gmail.com>
  *

--- a/tests/Metadata/Driver/DoctrineDriverTest.php
+++ b/tests/Metadata/Driver/DoctrineDriverTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * Copyright 2016 Johannes M. Schmitt <schmittjoh@gmail.com>
  *

--- a/tests/Metadata/Driver/DoctrinePHPCRDriverTest.php
+++ b/tests/Metadata/Driver/DoctrinePHPCRDriverTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * Copyright 2016 Johannes M. Schmitt <schmittjoh@gmail.com>
  *

--- a/tests/Metadata/Driver/NullDriverTest.php
+++ b/tests/Metadata/Driver/NullDriverTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * Copyright 2016 Johannes M. Schmitt <schmittjoh@gmail.com>
  *

--- a/tests/Metadata/Driver/XmlDriverTest.php
+++ b/tests/Metadata/Driver/XmlDriverTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * Copyright 2016 Johannes M. Schmitt <schmittjoh@gmail.com>
  *

--- a/tests/Metadata/Driver/YamlDriverTest.php
+++ b/tests/Metadata/Driver/YamlDriverTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * Copyright 2016 Johannes M. Schmitt <schmittjoh@gmail.com>
  *

--- a/tests/Serializer/ArrayTest.php
+++ b/tests/Serializer/ArrayTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * Copyright 2016 Johannes M. Schmitt <schmittjoh@gmail.com>
  *

--- a/tests/Serializer/BaseSerializationTest.php
+++ b/tests/Serializer/BaseSerializationTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * Copyright 2016 Johannes M. Schmitt <schmittjoh@gmail.com>
  *
@@ -1065,17 +1067,17 @@ abstract class BaseSerializationTest extends \PHPUnit\Framework\TestCase
     {
         $this->assertEquals(
             $this->getContent('virtual_properties_low'),
-            $this->serialize(new ObjectWithVersionedVirtualProperties(), SerializationContext::create()->setVersion(2))
+            $this->serialize(new ObjectWithVersionedVirtualProperties(), SerializationContext::create()->setVersion('2'))
         );
 
         $this->assertEquals(
             $this->getContent('virtual_properties_all'),
-            $this->serialize(new ObjectWithVersionedVirtualProperties(), SerializationContext::create()->setVersion(7))
+            $this->serialize(new ObjectWithVersionedVirtualProperties(), SerializationContext::create()->setVersion('7'))
         );
 
         $this->assertEquals(
             $this->getContent('virtual_properties_high'),
-            $this->serialize(new ObjectWithVersionedVirtualProperties(), SerializationContext::create()->setVersion(9))
+            $this->serialize(new ObjectWithVersionedVirtualProperties(), SerializationContext::create()->setVersion('9'))
         );
     }
 

--- a/tests/Serializer/ContextTest.php
+++ b/tests/Serializer/ContextTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * Copyright 2016 Johannes M. Schmitt <schmittjoh@gmail.com>
  *
@@ -191,11 +193,5 @@ class ContextTest extends \PHPUnit\Framework\TestCase
 
         $context->setSerializeNull(true);
         $this->assertTrue($context->shouldSerializeNull());
-
-        $context->setSerializeNull("foo");
-        $this->assertTrue($context->shouldSerializeNull());
-
-        $context->setSerializeNull("0");
-        $this->assertFalse($context->shouldSerializeNull());
     }
 }

--- a/tests/Serializer/DateIntervalFormatTest.php
+++ b/tests/Serializer/DateIntervalFormatTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * Copyright 2016 Johannes M. Schmitt <schmittjoh@gmail.com>
  *

--- a/tests/Serializer/Doctrine/IntegrationTest.php
+++ b/tests/Serializer/Doctrine/IntegrationTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace JMS\Serializer\Tests\Serializer\Doctrine;
 
 use Doctrine\Common\Annotations\AnnotationReader;

--- a/tests/Serializer/Doctrine/ObjectConstructorTest.php
+++ b/tests/Serializer/Doctrine/ObjectConstructorTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace JMS\Serializer\Tests\Serializer\Doctrine;
 
 use Doctrine\Common\Annotations\AnnotationReader;

--- a/tests/Serializer/EventDispatcher/EventDispatcherTest.php
+++ b/tests/Serializer/EventDispatcher/EventDispatcherTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * Copyright 2016 Johannes M. Schmitt <schmittjoh@gmail.com>
  *

--- a/tests/Serializer/EventDispatcher/LazyEventDispatcherTest.php
+++ b/tests/Serializer/EventDispatcher/LazyEventDispatcherTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * Copyright 2016 Johannes M. Schmitt <schmittjoh@gmail.com>
  *

--- a/tests/Serializer/EventDispatcher/LazyEventDispatcherWithPsr11ContainerTest.php
+++ b/tests/Serializer/EventDispatcher/LazyEventDispatcherWithPsr11ContainerTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * Copyright 2016 Johannes M. Schmitt <schmittjoh@gmail.com>
  *

--- a/tests/Serializer/EventDispatcher/LazyEventDispatcherWithSymfonyContainerTest.php
+++ b/tests/Serializer/EventDispatcher/LazyEventDispatcherWithSymfonyContainerTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * Copyright 2016 Johannes M. Schmitt <schmittjoh@gmail.com>
  *

--- a/tests/Serializer/EventDispatcher/Subscriber/DoctrineProxySubscriberTest.php
+++ b/tests/Serializer/EventDispatcher/Subscriber/DoctrineProxySubscriberTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * Copyright 2016 Johannes M. Schmitt <schmittjoh@gmail.com>
  *

--- a/tests/Serializer/EventDispatcher/Subscriber/SymfonyValidatorValidatorSubscriberTest.php
+++ b/tests/Serializer/EventDispatcher/Subscriber/SymfonyValidatorValidatorSubscriberTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * Copyright 2016 Asmir Mustafic <goetas@gmail.com>
  *

--- a/tests/Serializer/GraphNavigatorTest.php
+++ b/tests/Serializer/GraphNavigatorTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * Copyright 2016 Johannes M. Schmitt <schmittjoh@gmail.com>
  *

--- a/tests/Serializer/JsonSerializationTest.php
+++ b/tests/Serializer/JsonSerializationTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * Copyright 2016 Johannes M. Schmitt <schmittjoh@gmail.com>
  *
@@ -204,32 +206,16 @@ class JsonSerializationTest extends BaseSerializationTest
                 'data' => true,
             ),
             array(
-                'type' => 'boolean',
-                'data' => 1,
-            ),
-            array(
                 'type' => 'integer',
                 'data' => 123,
-            ),
-            array(
-                'type' => 'integer',
-                'data' => "123",
             ),
             array(
                 'type' => 'string',
                 'data' => "hello",
             ),
             array(
-                'type' => 'string',
-                'data' => 123,
-            ),
-            array(
                 'type' => 'double',
                 'data' => 0.1234,
-            ),
-            array(
-                'type' => 'double',
-                'data' => "0.1234",
             ),
         );
     }
@@ -266,7 +252,7 @@ class JsonSerializationTest extends BaseSerializationTest
      */
     public function testSerializeWithNonUtf8EncodingWhenDisplayErrorsOff()
     {
-        ini_set('display_errors', 1);
+        ini_set('display_errors', '1');
         $this->serialize(array('foo' => 'bar', 'bar' => pack("H*", 'c32e')));
     }
 
@@ -277,7 +263,7 @@ class JsonSerializationTest extends BaseSerializationTest
      */
     public function testSerializeWithNonUtf8EncodingWhenDisplayErrorsOn()
     {
-        ini_set('display_errors', 0);
+        ini_set('display_errors', '0');
         $this->serialize(array('foo' => 'bar', 'bar' => pack("H*", 'c32e')));
     }
 

--- a/tests/Serializer/Naming/CamelCaseNamingStrategyTest.php
+++ b/tests/Serializer/Naming/CamelCaseNamingStrategyTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace JMS\Serializer\Tests\Serializer\Naming;
 
 use JMS\Serializer\Naming\CamelCaseNamingStrategy;

--- a/tests/Serializer/Naming/IdenticalPropertyNamingStrategyTest.php
+++ b/tests/Serializer/Naming/IdenticalPropertyNamingStrategyTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * Copyright 2016 Johannes M. Schmitt <schmittjoh@gmail.com>
  *

--- a/tests/Serializer/SerializationContextFactoryTest.php
+++ b/tests/Serializer/SerializationContextFactoryTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * Copyright 2013 Johannes M. Schmitt <schmittjoh@gmail.com>
  *

--- a/tests/Serializer/TypeParserTest.php
+++ b/tests/Serializer/TypeParserTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * Copyright 2016 Johannes M. Schmitt <schmittjoh@gmail.com>
  *

--- a/tests/Serializer/XmlSerializationTest.php
+++ b/tests/Serializer/XmlSerializationTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * Copyright 2016 Johannes M. Schmitt <schmittjoh@gmail.com>
  *
@@ -383,15 +385,6 @@ class XmlSerializationTest extends BaseSerializationTest
     public function testDeserializingNull()
     {
         $this->markTestSkipped('Not supported in XML.');
-    }
-
-    public function testDeserializeWithObjectWithToStringMethod()
-    {
-        $input = new ObjectWithToString($this->getContent('simple_object'));
-
-        $object = $this->deserialize($input, SimpleObject::class);
-
-        $this->assertInstanceOf(SimpleObject::class, $object);
     }
 
     public function testObjectWithXmlNamespaces()

--- a/tests/SerializerBuilderTest.php
+++ b/tests/SerializerBuilderTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * Copyright 2016 Johannes M. Schmitt <schmittjoh@gmail.com>
  *

--- a/tests/Twig/SerializerExtensionTest.php
+++ b/tests/Twig/SerializerExtensionTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * Copyright 2016 Johannes M. Schmitt <schmittjoh@gmail.com>
  *

--- a/tests/benchmark-black.php
+++ b/tests/benchmark-black.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 if (!isset($_SERVER['argv'][1], $_SERVER['argv'][2])) {
     echo 'Usage: php benchmark.php <format> <iterations> [output-file]' . PHP_EOL;
     exit(1);

--- a/tests/benchmark.php
+++ b/tests/benchmark.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 if (!isset($_SERVER['argv'][1], $_SERVER['argv'][2])) {
     echo 'Usage: php benchmark.php <format> <iterations> [output-file]' . PHP_EOL;
     exit(1);

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * Copyright 2011 Johannes M. Schmitt <schmittjoh@gmail.com>
  *


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | yes

This breaks some type juggling which is incompatible with strict mode by design (like deserializing object with `__toString()`).