### PR TITLE
Make PHPUnit stricter, drop redundant defaults

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,18 +1,17 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <phpunit
-    backupGlobals               = "false"
-    backupStaticAttributes      = "false"
-    colors                      = "true"
-    convertErrorsToExceptions   = "true"
-    convertNoticesToExceptions  = "true"
-    convertWarningsToExceptions = "true"
-    processIsolation            = "false"
-    stopOnFailure               = "false"
-    syntaxCheck                 = "false"
-    bootstrap                   = "tests/bootstrap.php"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd"
+    colors="true"
+    beStrictAboutOutputDuringTests="true"
+    beStrictAboutTodoAnnotatedTests="true"
+    failOnRisky="true"
+    failOnWarning="true"
+    bootstrap="tests/bootstrap.php"
 >
     <php>
+        <ini name="error_reporting" value="-1" />
         <ini name="serialize_precision" value="14"/>
     </php>
 


### PR DESCRIPTION
* add PHPUnit schema
* most of the options are now only duplicating defaults
* be strict about test behavior
* fail on risky tests and warnings

Should prevent #910 to re-appear.