### PR TITLE
Allow instance of event filtering 

### DIFF
--- a/src/EventDispatcher/EventDispatcherInterface.php
+++ b/src/EventDispatcher/EventDispatcherInterface.php
@@ -54,9 +54,10 @@ interface EventDispatcherInterface
      * @param callable $callable
      * @param string|null $class
      * @param string|null $format
+     * @param string|null $interface
      * @return void
      */
-    public function addListener($eventName, $callable, $class = null, $format = null);
+    public function addListener($eventName, $callable, $class = null, $format = null, $interface = null);
 
     /**
      * Adds a subscribers.

--- a/src/EventDispatcher/LazyEventDispatcher.php
+++ b/src/EventDispatcher/LazyEventDispatcher.php
@@ -45,15 +45,15 @@ class LazyEventDispatcher extends EventDispatcher
         $listeners = parent::initializeListeners($eventName, $loweredClass, $format);
 
         foreach ($listeners as &$listener) {
-            if (!\is_array($listener) || !\is_string($listener[0])) {
+            if (!\is_array($listener[0]) || !\is_string($listener[0][0])) {
                 continue;
             }
 
-            if (!$this->container->has($listener[0])) {
+            if (!$this->container->has($listener[0][0])) {
                 continue;
             }
 
-            $listener[0] = $this->container->get($listener[0]);
+            $listener[0][0] = $this->container->get($listener[0][0]);
         }
 
         return $listeners;

--- a/src/EventDispatcher/Subscriber/DoctrineProxySubscriber.php
+++ b/src/EventDispatcher/Subscriber/DoctrineProxySubscriber.php
@@ -119,8 +119,11 @@ class DoctrineProxySubscriber implements EventSubscriberInterface
     public static function getSubscribedEvents()
     {
         return array(
-            array('event' => 'serializer.pre_serialize', 'method' => 'onPreSerializeTypedProxy'),
-            array('event' => 'serializer.pre_serialize', 'method' => 'onPreSerialize'),
+            array('event' => 'serializer.pre_serialize', 'method' => 'onPreSerializeTypedProxy', 'interface' => Proxy::class),
+            array('event' => 'serializer.pre_serialize', 'method' => 'onPreSerialize', 'interface' => PersistentCollection::class),
+            array('event' => 'serializer.pre_serialize', 'method' => 'onPreSerialize', 'interface' => MongoDBPersistentCollection::class),
+            array('event' => 'serializer.pre_serialize', 'method' => 'onPreSerialize', 'interface' => PHPCRPersistentCollection::class),
+            array('event' => 'serializer.pre_serialize', 'method' => 'onPreSerialize', 'interface' => Proxy::class),
         );
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| Doc updated   | no
| BC breaks?    | yes
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
| License       | Apache-2.0

This gives a boost ~20% when running the test suite. Basically an event listener can declare the instance of objects is interested in.

![screenshot from 2018-04-28 13-41-52](https://user-images.githubusercontent.com/776743/39396185-f4c25d4a-4ae9-11e8-8004-dbfede99afc2.png)
