### PR TITLE
No global graph navigator

### DIFF
--- a/src/AbstractVisitor.php
+++ b/src/AbstractVisitor.php
@@ -24,21 +24,16 @@ use JMS\Serializer\Accessor\AccessorStrategyInterface;
 use JMS\Serializer\Accessor\DefaultAccessorStrategy;
 use JMS\Serializer\Naming\PropertyNamingStrategyInterface;
 
-abstract class AbstractVisitor
+abstract class AbstractVisitor implements VisitorInterface
 {
     /**
      * @var GraphNavigatorInterface
      */
     protected $navigator;
-    /**
-     * @var Context
-     */
-    protected $context;
 
-    public function __construct(GraphNavigatorInterface $navigator, Context $context)
+    public function setNavigator(GraphNavigatorInterface $navigator) : void
     {
         $this->navigator = $navigator;
-        $this->context = $context;
     }
 
     public function prepare($data)

--- a/src/DeserializationVisitorInterface.php
+++ b/src/DeserializationVisitorInterface.php
@@ -32,18 +32,8 @@ use JMS\Serializer\Metadata\PropertyMetadata;
  * @author Johannes M. Schmitt <schmittjoh@gmail.com>
  * @author Asmir Mustafic <goetas@gmail.com>
  */
-interface DeserializationVisitorInterface
+interface DeserializationVisitorInterface extends VisitorInterface
 {
-    /**
-     * Allows visitors to convert the input data to a different representation
-     * before the actual serialization/deserialization process starts.
-     *
-     * @param mixed $data
-     *
-     * @return mixed
-     */
-    public function prepare($data);
-
     /**
      * @param mixed $data
      * @param array $type

--- a/src/GraphNavigator.php
+++ b/src/GraphNavigator.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * Copyright 2016 Johannes M. Schmitt <schmittjoh@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace JMS\Serializer;
+use JMS\Serializer\Exclusion\ExclusionStrategyInterface;
+
+/**
+ * Handles traversal along the object graph.
+ *
+ * This class handles traversal along the graph, and calls different methods
+ * on visitors, or custom handlers to process its nodes.
+ *
+ * @author Johannes M. Schmitt <schmittjoh@gmail.com>
+ */
+abstract class GraphNavigator implements GraphNavigatorInterface
+{
+    /**
+     * @var VisitorInterface
+     */
+    protected $visitor;
+    /**
+     * @var Context
+     */
+    protected $context;
+    /***
+     * @var string
+     */
+    protected $format;
+    /**
+     * @var ExclusionStrategyInterface
+     */
+    protected $exclusionStrategy;
+
+    public function initialize(VisitorInterface $visitor, Context $context):void
+    {
+        $this->visitor = $visitor;
+        $this->context = $context;
+
+        // cache value
+        $this->format = $context->getFormat();
+        $this->exclusionStrategy = $context->getExclusionStrategy();
+    }
+}
+
+

--- a/src/GraphNavigatorInterface.php
+++ b/src/GraphNavigatorInterface.php
@@ -40,14 +40,14 @@ interface GraphNavigatorInterface
     const DIRECTION_SERIALIZATION = 1;
     const DIRECTION_DESERIALIZATION = 2;
 
+    public function initialize(VisitorInterface $visitor, Context $context): void;
     /**
      * Called for each node of the graph that is being traversed.
      *
      * @throws NotAcceptableException
      * @param mixed $data the data depends on the direction, and type of visitor
      * @param null|array $type array has the format ["name" => string, "params" => array]
-     * @param Context $context
      * @return mixed the return value depends on the direction, and type of visitor
      */
-    public function accept($data, array $type = null, Context $context);
+    public function accept($data, array $type = null);
 }

--- a/src/GraphNavigatorInterface.php
+++ b/src/GraphNavigatorInterface.php
@@ -40,6 +40,13 @@ interface GraphNavigatorInterface
     const DIRECTION_SERIALIZATION = 1;
     const DIRECTION_DESERIALIZATION = 2;
 
+    /**
+     * Called at the beginning of the serialization process. The navigator should use the traverse the object graph
+     * and pass to the $visitor the value of found nodes (following the rules obtained from $context).
+     *
+     * @param VisitorInterface $visitor
+     * @param Context $context
+     */
     public function initialize(VisitorInterface $visitor, Context $context): void;
     /**
      * Called for each node of the graph that is being traversed.

--- a/src/JsonDeserializationVisitor.php
+++ b/src/JsonDeserializationVisitor.php
@@ -35,11 +35,8 @@ class JsonDeserializationVisitor extends AbstractVisitor implements Deserializat
     private $currentObject;
 
     public function __construct(
-        GraphNavigatorInterface $navigator,
-        DeserializationContext $context,
         int $options = 0, int $depth = 512)
     {
-        parent::__construct($navigator, $context);
         $this->objectStack = new \SplStack;
         $this->options = $options;
         $this->depth = $depth;
@@ -88,7 +85,7 @@ class JsonDeserializationVisitor extends AbstractVisitor implements Deserializat
                 $result = array();
 
                 foreach ($data as $v) {
-                    $result[] = $this->navigator->accept($v, $listType, $this->context);
+                    $result[] = $this->navigator->accept($v, $listType);
                 }
 
                 return $result;
@@ -99,7 +96,7 @@ class JsonDeserializationVisitor extends AbstractVisitor implements Deserializat
                 $result = array();
 
                 foreach ($data as $k => $v) {
-                    $result[$this->navigator->accept($k, $keyType, $this->context)] = $this->navigator->accept($v, $entryType, $this->context);
+                    $result[$this->navigator->accept($k, $keyType)] = $this->navigator->accept($v, $entryType);
                 }
 
                 return $result;
@@ -147,7 +144,7 @@ class JsonDeserializationVisitor extends AbstractVisitor implements Deserializat
             throw new RuntimeException(sprintf('You must define a type for %s::$%s.', $metadata->reflection->class, $metadata->name));
         }
 
-        $v = $data[$name] !== null ? $this->navigator->accept($data[$name], $metadata->type, $this->context) : null;
+        $v = $data[$name] !== null ? $this->navigator->accept($data[$name], $metadata->type) : null;
 
         return $v;
     }

--- a/src/JsonSerializationVisitor.php
+++ b/src/JsonSerializationVisitor.php
@@ -33,13 +33,9 @@ class JsonSerializationVisitor extends AbstractVisitor implements SerializationV
     private $dataStack;
     private $data;
 
-
     public function __construct(
-        GraphNavigatorInterface $navigator,
-        SerializationContext $context,
         int $options = JSON_PRESERVE_ZERO_FRACTION)
     {
-        parent::__construct($navigator, $context);
         $this->dataStack = new \SplStack;
         $this->options = $options;
     }
@@ -87,7 +83,7 @@ class JsonSerializationVisitor extends AbstractVisitor implements SerializationV
         foreach ($data as $k => $v) {
 
             try {
-                $v = $this->navigator->accept($v, $elType, $this->context);
+                $v = $this->navigator->accept($v, $elType);
             } catch (NotAcceptableException $e) {
                 continue;
             }
@@ -125,7 +121,7 @@ class JsonSerializationVisitor extends AbstractVisitor implements SerializationV
     public function visitProperty(PropertyMetadata $metadata, $v): void
     {
         try {
-            $v = $this->navigator->accept($v, $metadata->type, $this->context);
+            $v = $this->navigator->accept($v, $metadata->type);
         } catch (NotAcceptableException $e) {
             return;
         }

--- a/src/SerializationVisitorInterface.php
+++ b/src/SerializationVisitorInterface.php
@@ -32,18 +32,8 @@ use JMS\Serializer\Metadata\PropertyMetadata;
  * @author Johannes M. Schmitt <schmittjoh@gmail.com>
  * @author Asmir Mustafic <goetas@gmail.com>
  */
-interface SerializationVisitorInterface
+interface SerializationVisitorInterface extends VisitorInterface
 {
-    /**
-     * Allows visitors to convert the input data to a different representation
-     * before the actual serialization/deserialization process starts.
-     *
-     * @param mixed $data
-     *
-     * @return mixed
-     */
-    public function prepare($data);
-
     /**
      * @param mixed $data
      * @param array $type

--- a/src/VisitorFactory/DeserializationVisitorFactory.php
+++ b/src/VisitorFactory/DeserializationVisitorFactory.php
@@ -32,5 +32,5 @@ use JMS\Serializer\SerializationContext;
  */
 interface DeserializationVisitorFactory
 {
-    public function getVisitor(GraphNavigatorInterface $navigator, DeserializationContext $context): DeserializationVisitorInterface;
+    public function getVisitor(): DeserializationVisitorInterface;
 }

--- a/src/VisitorFactory/JsonDeserializationVisitorFactory.php
+++ b/src/VisitorFactory/JsonDeserializationVisitorFactory.php
@@ -42,9 +42,9 @@ class JsonDeserializationVisitorFactory implements DeserializationVisitorFactory
      */
     private $depth = 512;
 
-    public function getVisitor(GraphNavigatorInterface $navigator, DeserializationContext $context): DeserializationVisitorInterface
+    public function getVisitor(): DeserializationVisitorInterface
     {
-        return new JsonDeserializationVisitor($navigator, $context);
+        return new JsonDeserializationVisitor($this->options, $this->depth);
     }
 
     public function setOptions(int $options): self

--- a/src/VisitorFactory/JsonSerializationVisitorFactory.php
+++ b/src/VisitorFactory/JsonSerializationVisitorFactory.php
@@ -37,9 +37,9 @@ class JsonSerializationVisitorFactory implements SerializationVisitorFactory
      */
     private $options = JSON_PRESERVE_ZERO_FRACTION;
 
-    public function getVisitor(GraphNavigatorInterface $navigator, SerializationContext $context): SerializationVisitorInterface
+    public function getVisitor(): SerializationVisitorInterface
     {
-        return new JsonSerializationVisitor($navigator, $context, $this->options);
+        return new JsonSerializationVisitor($this->options);
     }
 
     public function setOptions(int $options): self

--- a/src/VisitorFactory/SerializationVisitorFactory.php
+++ b/src/VisitorFactory/SerializationVisitorFactory.php
@@ -31,5 +31,5 @@ use JMS\Serializer\SerializationVisitorInterface;
  */
 interface SerializationVisitorFactory
 {
-    public function getVisitor(GraphNavigatorInterface $navigator, SerializationContext $context): SerializationVisitorInterface;
+    public function getVisitor(): SerializationVisitorInterface;
 }

--- a/src/VisitorFactory/XmlDeserializationVisitorFactory.php
+++ b/src/VisitorFactory/XmlDeserializationVisitorFactory.php
@@ -35,9 +35,9 @@ class XmlDeserializationVisitorFactory implements DeserializationVisitorFactory
     private $disableExternalEntities = true;
     private $doctypeWhitelist = array();
 
-    public function getVisitor(GraphNavigatorInterface $navigator, DeserializationContext $context): DeserializationVisitorInterface
+    public function getVisitor(): DeserializationVisitorInterface
     {
-        return new XmlDeserializationVisitor($navigator, $context, $this->disableExternalEntities, $this->doctypeWhitelist);
+        return new XmlDeserializationVisitor($this->disableExternalEntities, $this->doctypeWhitelist);
     }
 
     public function enableExternalEntities(bool $enable = true): self

--- a/src/VisitorFactory/XmlSerializationVisitorFactory.php
+++ b/src/VisitorFactory/XmlSerializationVisitorFactory.php
@@ -39,11 +39,9 @@ class XmlSerializationVisitorFactory implements SerializationVisitorFactory
     private $formatOutput = true;
     private $defaultRootNamespace;
 
-    public function getVisitor(GraphNavigatorInterface $navigator, SerializationContext $context): SerializationVisitorInterface
+    public function getVisitor(): SerializationVisitorInterface
     {
         return new XmlSerializationVisitor(
-            $navigator,
-            $context,
             $this->formatOutput,
             $this->defaultEncoding,
             $this->defaultVersion,

--- a/src/VisitorInterface.php
+++ b/src/VisitorInterface.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * Copyright 2016 Johannes M. Schmitt <schmittjoh@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace JMS\Serializer;
+
+use JMS\Serializer\Metadata\ClassMetadata;
+use JMS\Serializer\Metadata\PropertyMetadata;
+
+/**
+ * Interface for visitors.
+ *
+ * This contains the minimal set of values that must be supported for any
+ * output format.
+ *
+ * @author Johannes M. Schmitt <schmittjoh@gmail.com>
+ * @author Asmir Mustafic <goetas@gmail.com>
+ */
+interface VisitorInterface
+{
+    /**
+     * Allows visitors to convert the input data to a different representation
+     * before the actual serialization/deserialization process starts.
+     *
+     * @param mixed $data
+     *
+     * @return mixed
+     */
+    public function prepare($data);
+
+    /**
+     * Called before serialization/deserialization starts.
+     *
+     * @param GraphNavigatorInterface $navigator
+     *
+     * @return void
+     */
+    public function setNavigator(GraphNavigatorInterface $navigator): void;
+}

--- a/src/XmlDeserializationVisitor.php
+++ b/src/XmlDeserializationVisitor.php
@@ -40,11 +40,8 @@ class XmlDeserializationVisitor extends AbstractVisitor implements NullAwareVisi
     private $doctypeWhitelist = array();
 
     public function __construct(
-        GraphNavigatorInterface $navigator,
-        DeserializationContext $context,
         bool $disableExternalEntities = true, array $doctypeWhitelist = array())
     {
-        parent::__construct($navigator, $context);
         $this->objectStack = new \SplStack;
         $this->metadataStack = new \SplStack;
         $this->objectMetadataStack = new \SplStack;
@@ -134,8 +131,8 @@ class XmlDeserializationVisitor extends AbstractVisitor implements NullAwareVisi
 
             $result = [];
             foreach ($data as $key => $v) {
-                $k = $this->navigator->accept($key, $keyType, $this->context);
-                $result[$k] = $this->navigator->accept($v, $entryType, $this->context);
+                $k = $this->navigator->accept($key, $keyType);
+                $result[$k] = $this->navigator->accept($v, $entryType);
             }
 
             return $result;
@@ -175,7 +172,7 @@ class XmlDeserializationVisitor extends AbstractVisitor implements NullAwareVisi
                 $result = array();
 
                 foreach ($nodes as $v) {
-                    $result[] = $this->navigator->accept($v, $type['params'][0], $this->context);
+                    $result[] = $this->navigator->accept($v, $type['params'][0]);
                 }
 
                 return $result;
@@ -195,8 +192,8 @@ class XmlDeserializationVisitor extends AbstractVisitor implements NullAwareVisi
                         throw new RuntimeException(sprintf('The key attribute "%s" must be set for each entry of the map.', $this->currentMetadata->xmlKeyAttribute));
                     }
 
-                    $k = $this->navigator->accept($attrs[$this->currentMetadata->xmlKeyAttribute], $keyType, $this->context);
-                    $result[$k] = $this->navigator->accept($v, $entryType, $this->context);
+                    $k = $this->navigator->accept($attrs[$this->currentMetadata->xmlKeyAttribute], $keyType);
+                    $result[$k] = $this->navigator->accept($v, $entryType);
                 }
 
                 return $result;
@@ -248,14 +245,14 @@ class XmlDeserializationVisitor extends AbstractVisitor implements NullAwareVisi
 
             $attributes = $data->attributes($metadata->xmlNamespace);
             if (isset($attributes[$name])) {
-                return $this->navigator->accept($attributes[$name], $metadata->type, $this->context);
+                return $this->navigator->accept($attributes[$name], $metadata->type);
             }
 
             throw new NotAcceptableException();
         }
 
         if ($metadata->xmlValue) {
-            return $this->navigator->accept($data, $metadata->type, $this->context);
+            return $this->navigator->accept($data, $metadata->type);
         }
 
         if ($metadata->xmlCollection) {
@@ -265,7 +262,7 @@ class XmlDeserializationVisitor extends AbstractVisitor implements NullAwareVisi
             }
 
             $this->setCurrentMetadata($metadata);
-            $v = $this->navigator->accept($enclosingElem, $metadata->type, $this->context);
+            $v = $this->navigator->accept($enclosingElem, $metadata->type);
             $this->revertCurrentMetadata();
             return $v;
         }
@@ -296,7 +293,7 @@ class XmlDeserializationVisitor extends AbstractVisitor implements NullAwareVisi
             $this->setCurrentMetadata($metadata);
         }
 
-        return $this->navigator->accept($node, $metadata->type, $this->context);
+        return $this->navigator->accept($node, $metadata->type);
     }
 
     /**

--- a/src/XmlSerializationVisitor.php
+++ b/src/XmlSerializationVisitor.php
@@ -49,16 +49,12 @@ class XmlSerializationVisitor extends AbstractVisitor implements SerializationVi
     private $objectMetadataStack;
 
     public function __construct(
-        GraphNavigatorInterface $navigator,
-        SerializationContext $context,
         bool $formatOutput = true,
         string $defaultEncoding = 'UTF-8',
         string $defaultVersion = '1.0',
         string $defaultRootName = 'result',
         string $defaultRootNamespace = null
     ) {
-        parent::__construct($navigator, $context);
-
         $this->objectMetadataStack = new \SplStack;
         $this->stack = new \SplStack;
         $this->metadataStack = new \SplStack;
@@ -166,7 +162,7 @@ class XmlSerializationVisitor extends AbstractVisitor implements SerializationVi
             }
 
             try {
-                if (null !== $node = $this->navigator->accept($v, $elType, $this->context)) {
+                if (null !== $node = $this->navigator->accept($v, $elType)) {
                     $this->currentNode->appendChild($node);
                 }
             } catch (NotAcceptableException $e) {
@@ -194,7 +190,7 @@ class XmlSerializationVisitor extends AbstractVisitor implements SerializationVi
     {
         if ($metadata->xmlAttribute) {
             $this->setCurrentMetadata($metadata);
-            $node = $this->navigator->accept($v, $metadata->type, $this->context);
+            $node = $this->navigator->accept($v, $metadata->type);
             $this->revertCurrentMetadata();
 
             if (!$node instanceof \DOMCharacterData) {
@@ -216,7 +212,7 @@ class XmlSerializationVisitor extends AbstractVisitor implements SerializationVi
             $this->hasValue = true;
 
             $this->setCurrentMetadata($metadata);
-            $node = $this->navigator->accept($v, $metadata->type, $this->context);
+            $node = $this->navigator->accept($v, $metadata->type);
             $this->revertCurrentMetadata();
 
             if (!$node instanceof \DOMCharacterData) {
@@ -235,7 +231,7 @@ class XmlSerializationVisitor extends AbstractVisitor implements SerializationVi
 
             foreach ($v as $key => $value) {
                 $this->setCurrentMetadata($metadata);
-                $node = $this->navigator->accept($value, null, $this->context);
+                $node = $this->navigator->accept($value, null);
                 $this->revertCurrentMetadata();
 
                 if (!$node instanceof \DOMCharacterData) {
@@ -262,7 +258,7 @@ class XmlSerializationVisitor extends AbstractVisitor implements SerializationVi
         $this->setCurrentMetadata($metadata);
 
         try {
-            if (null !== $node = $this->navigator->accept($v, $metadata->type, $this->context)) {
+            if (null !== $node = $this->navigator->accept($v, $metadata->type)) {
                 $this->currentNode->appendChild($node);
             }
         } catch (NotAcceptableException $e) {
@@ -278,7 +274,7 @@ class XmlSerializationVisitor extends AbstractVisitor implements SerializationVi
         if ($addEnclosingElement) {
             $this->revertCurrentNode();
 
-            if ($this->isElementEmpty($element) && ($v === null || $this->isSkippableCollection($metadata) || $this->isSkippableEmptyObject($node, $metadata) || $this->isCircularRef($this->context, $v))) {
+            if ($this->isElementEmpty($element) && ($v === null || $this->isSkippableCollection($metadata) || $this->isSkippableEmptyObject($node, $metadata))) {
                 $this->currentNode->removeChild($element);
             }
         }
@@ -289,11 +285,6 @@ class XmlSerializationVisitor extends AbstractVisitor implements SerializationVi
     private function isInLineCollection(PropertyMetadata $metadata)
     {
         return $metadata->xmlCollection && $metadata->xmlCollectionInline;
-    }
-
-    private function isCircularRef(SerializationContext $context, $v)
-    {
-        return $this->context->isVisiting($v);
     }
 
     private function isSkippableEmptyObject($node, PropertyMetadata $metadata)

--- a/tests/Serializer/BaseSerializationTest.php
+++ b/tests/Serializer/BaseSerializationTest.php
@@ -1460,7 +1460,7 @@ abstract class BaseSerializationTest extends \PHPUnit\Framework\TestCase
                     ),
                 );
 
-                $elements = $context->getNavigator()->accept($data, $type, $context);
+                $elements = $context->getNavigator()->accept($data, $type);
                 $list = new AuthorList();
                 foreach ($elements as $author) {
                     $list->add($author);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| Doc updated   | no
| BC breaks?    | yes
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
| License       | Apache-2.0

The graph navigator gets re-instantiated on each serialize/deserialize call. 
This allow to cache a lot of "context" related data (since the context does not change between `accept` calls, makes no sense to calculate them each time).

This also re-introduses `VisitorInterface` and `GraphNavigator` class, that should ease the migration from 1.x to 2.0

![screenshot from 2018-04-28 15-15-43](https://user-images.githubusercontent.com/776743/39396907-0b39bf66-4af7-11e8-864c-2fb30e62ea18.png)

