### PR TITLE
Move property ordering strategy out of Metadata

### DIFF
--- a/src/Ordering/AlphabeticalPropertyOrderingStrategy.php
+++ b/src/Ordering/AlphabeticalPropertyOrderingStrategy.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * Copyright 2016 Johannes M. Schmitt <schmittjoh@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace JMS\Serializer\Ordering;
+
+use JMS\Serializer\Metadata\PropertyMetadata;
+
+final class AlphabeticalPropertyOrderingStrategy implements PropertyOrderingInterface
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function order(array $properties) : array
+    {
+        uasort(
+            $properties,
+            function (PropertyMetadata $a, PropertyMetadata $b) : int {
+                return strcmp($a->name, $b->name);
+            }
+        );
+
+        return $properties;
+    }
+}

--- a/src/Ordering/CustomPropertyOrderingStrategy.php
+++ b/src/Ordering/CustomPropertyOrderingStrategy.php
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * Copyright 2016 Johannes M. Schmitt <schmittjoh@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace JMS\Serializer\Ordering;
+
+final class CustomPropertyOrderingStrategy implements PropertyOrderingInterface
+{
+    /** @var int[] property => weight */
+    private $ordering;
+
+    /**
+     * @param int[] $ordering property => weight
+     */
+    public function __construct(array $ordering)
+    {
+        $this->ordering = $ordering;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function order(array $properties) : array
+    {
+        $currentSorting = $properties ? array_combine(array_keys($properties), range(1, \count($properties))) : [];
+
+        uksort($properties, function ($a, $b) use ($currentSorting) {
+            $existsA = isset($this->ordering[$a]);
+            $existsB = isset($this->ordering[$b]);
+
+            if (!$existsA && !$existsB) {
+                return $currentSorting[$a] - $currentSorting[$b];
+            }
+
+            if (!$existsA) {
+                return 1;
+            }
+
+            if (!$existsB) {
+                return -1;
+            }
+
+            return $this->ordering[$a] < $this->ordering[$b] ? -1 : 1;
+        });
+
+        return $properties;
+    }
+}

--- a/src/Ordering/IdenticalPropertyOrderingStrategy.php
+++ b/src/Ordering/IdenticalPropertyOrderingStrategy.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * Copyright 2016 Johannes M. Schmitt <schmittjoh@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace JMS\Serializer\Ordering;
+
+final class IdenticalPropertyOrderingStrategy implements PropertyOrderingInterface
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function order(array $properties) : array
+    {
+        return $properties;
+    }
+}

--- a/src/Ordering/PropertyOrderingInterface.php
+++ b/src/Ordering/PropertyOrderingInterface.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * Copyright 2016 Johannes M. Schmitt <schmittjoh@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace JMS\Serializer\Ordering;
+
+use JMS\Serializer\Metadata\PropertyMetadata;
+
+interface PropertyOrderingInterface
+{
+    /**
+     * @param PropertyMetadata[] $properties name => property
+     * @return PropertyMetadata[] name => property
+     */
+    public function order(array $properties) : array;
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| Doc updated   | -
| BC breaks?    | no-ish?

This moves accessor ordering logic out of Metadata.
It has little value on its own currently, it just cleans up metadata responsibilities and opens further refactoring opportunities in Metadata.

No impact on runtime performance, it's only executed during Metadata load.