### PR TITLE
Failing test for first class collections

### DIFF
--- a/tests/Fixtures/FirstClassCollection.php
+++ b/tests/Fixtures/FirstClassCollection.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace JMS\Serializer\Tests\Fixtures;
+
+use JMS\Serializer\Annotation as Serializer;
+
+class FirstClassCollection implements \IteratorAggregate
+{
+    /**
+     * @Serializer\Type("array<int>")
+     * @Serializer\Inline
+     * @var int[]
+     */
+    public $items = [];
+
+    public function __construct(int ...$items)
+    {
+        $this->items = $items;
+    }
+
+    public function getIterator() : iterable
+    {
+        yield from $this->items;
+    }
+}

--- a/tests/Serializer/JsonSerializationTest.php
+++ b/tests/Serializer/JsonSerializationTest.php
@@ -28,6 +28,7 @@ use JMS\Serializer\GraphNavigatorInterface;
 use JMS\Serializer\SerializationContext;
 use JMS\Serializer\Tests\Fixtures\Author;
 use JMS\Serializer\Tests\Fixtures\AuthorList;
+use JMS\Serializer\Tests\Fixtures\FirstClassCollection;
 use JMS\Serializer\Tests\Fixtures\ObjectWithEmptyArrayAndHash;
 use JMS\Serializer\Tests\Fixtures\ObjectWithInlineArray;
 use JMS\Serializer\Tests\Fixtures\Tag;
@@ -137,6 +138,20 @@ class JsonSerializationTest extends BaseSerializationTest
         $object = new ObjectWithEmptyArrayAndHash();
 
         self::assertEquals('{}', $this->serialize($object));
+    }
+
+    public function testFirstClassCollectionsWithItems() : void
+    {
+        $collection = new FirstClassCollection(1, 2, 3);
+
+        self::assertSame('[1,2,3]', $this->serialize($collection));
+    }
+
+    public function testFirstClassCollectionEmpty() : void
+    {
+        $collection = new FirstClassCollection();
+
+        self::assertSame('[]', $this->serialize($collection));
     }
 
     public function testAddLinksToOutput()


### PR DESCRIPTION
Failing test for #942 - empty first class collections serialized as object.