### PR TITLE
Allow inline lists and maps

### DIFF
--- a/src/JsonSerializationVisitor.php
+++ b/src/JsonSerializationVisitor.php
@@ -112,7 +112,7 @@ final class JsonSerializationVisitor extends AbstractVisitor implements Serializ
         $rs = $this->data;
         $this->data = $this->dataStack->pop();
 
-        if ($metadata->isList) {
+        if ($metadata->isList === true) {
             return array_values((array)$rs);
         }
 

--- a/src/JsonSerializationVisitor.php
+++ b/src/JsonSerializationVisitor.php
@@ -104,7 +104,7 @@ final class JsonSerializationVisitor extends AbstractVisitor implements Serializ
     public function startVisitingObject(ClassMetadata $metadata, object $data, array $type): void
     {
         $this->dataStack->push($this->data);
-        $this->data = new \ArrayObject();
+        $this->data = $metadata->isMap === true ? new \ArrayObject() : [];
     }
 
     public function endVisitingObject(ClassMetadata $metadata, object $data, array $type)
@@ -113,9 +113,10 @@ final class JsonSerializationVisitor extends AbstractVisitor implements Serializ
         $this->data = $this->dataStack->pop();
 
         if ($metadata->isList === true) {
-            return array_values((array)$rs);
+            return array_values($rs);
+        } elseif (empty($rs)) {
+            return new \ArrayObject();
         }
-
         return $rs;
     }
 

--- a/src/JsonSerializationVisitor.php
+++ b/src/JsonSerializationVisitor.php
@@ -112,9 +112,7 @@ final class JsonSerializationVisitor extends AbstractVisitor implements Serializ
         $rs = $this->data;
         $this->data = $this->dataStack->pop();
 
-        if ($metadata->isList === true) {
-            return array_values($rs);
-        } elseif (empty($rs)) {
+        if ($metadata->isList !== true && empty($rs)) {
             return new \ArrayObject();
         }
         return $rs;

--- a/src/JsonSerializationVisitor.php
+++ b/src/JsonSerializationVisitor.php
@@ -30,7 +30,7 @@ final class JsonSerializationVisitor extends AbstractVisitor implements Serializ
 {
     private $options = JSON_PRESERVE_ZERO_FRACTION;
 
-    private $dataStack;
+    private $dataStack = [];
     /**
      * @var \ArrayObject
      */
@@ -39,7 +39,7 @@ final class JsonSerializationVisitor extends AbstractVisitor implements Serializ
     public function __construct(
         int $options = JSON_PRESERVE_ZERO_FRACTION)
     {
-        $this->dataStack = new \SplStack;
+        $this->dataStack = [];
         $this->options = $options;
     }
 
@@ -75,7 +75,7 @@ final class JsonSerializationVisitor extends AbstractVisitor implements Serializ
      */
     public function visitArray(array $data, array $type)
     {
-        $this->dataStack->push($data);
+        \array_push($this->dataStack, $data);
 
         $rs = isset($type['params'][1]) ? new \ArrayObject() : [];
 
@@ -97,20 +97,20 @@ final class JsonSerializationVisitor extends AbstractVisitor implements Serializ
             }
         }
 
-        $this->dataStack->pop();
+        \array_pop($this->dataStack);
         return $rs;
     }
 
     public function startVisitingObject(ClassMetadata $metadata, object $data, array $type): void
     {
-        $this->dataStack->push($this->data);
+        \array_push($this->dataStack, $this->data);
         $this->data = $metadata->isMap === true ? new \ArrayObject() : [];
     }
 
     public function endVisitingObject(ClassMetadata $metadata, object $data, array $type)
     {
         $rs = $this->data;
-        $this->data = $this->dataStack->pop();
+        $this->data = \array_pop($this->dataStack);
 
         if ($metadata->isList !== true && empty($rs)) {
             return new \ArrayObject();

--- a/src/JsonSerializationVisitor.php
+++ b/src/JsonSerializationVisitor.php
@@ -133,7 +133,11 @@ final class JsonSerializationVisitor extends AbstractVisitor implements Serializ
 
         if ($metadata->inline) {
             if (\is_array($v) || ($v instanceof \ArrayObject)) {
-                $this->data->exchangeArray(array_merge((array)$this->data, (array)$v));
+                // concatenate the two array-like structures
+                // is there anything faster?
+                foreach ($v as $key => $value) {
+                    $this->data[$key] = $value;
+                }
             }
         } else {
             $this->data[$metadata->serializedName] = $v;

--- a/src/JsonSerializationVisitor.php
+++ b/src/JsonSerializationVisitor.php
@@ -111,6 +111,11 @@ final class JsonSerializationVisitor extends AbstractVisitor implements Serializ
     {
         $rs = $this->data;
         $this->data = $this->dataStack->pop();
+
+        if ($metadata->isList) {
+            return array_values((array)$rs);
+        }
+
         return $rs;
     }
 

--- a/src/Metadata/ClassMetadata.php
+++ b/src/Metadata/ClassMetadata.php
@@ -58,6 +58,7 @@ class ClassMetadata extends MergeableClassMetadata
     public $customOrder;
     public $usingExpression = false;
     public $isList = false;
+    public $isMap = false;
 
     public $discriminatorDisabled = false;
     public $discriminatorBaseClass;
@@ -263,6 +264,7 @@ class ClassMetadata extends MergeableClassMetadata
             'usingExpression' => $this->usingExpression,
             'xmlDiscriminatorNamespace' => $this->xmlDiscriminatorNamespace,
             'isList' => $this->isList,
+            'isMap' => $this->isMap,
         ]);
     }
 
@@ -310,6 +312,9 @@ class ClassMetadata extends MergeableClassMetadata
         if (isset($unserialized['isList'])) {
             $this->isList = $unserialized['isList'];
         }
+        if (isset($unserialized['isMap'])) {
+            $this->isMap = $unserialized['isMap'];
+        }
         parent::unserialize($parentStr);
     }
 
@@ -330,3 +335,4 @@ class ClassMetadata extends MergeableClassMetadata
         }
     }
 }
+

--- a/src/Metadata/ClassMetadata.php
+++ b/src/Metadata/ClassMetadata.php
@@ -57,6 +57,7 @@ class ClassMetadata extends MergeableClassMetadata
     public $accessorOrder;
     public $customOrder;
     public $usingExpression = false;
+    public $isList = false;
 
     public $discriminatorDisabled = false;
     public $discriminatorBaseClass;
@@ -261,6 +262,7 @@ class ClassMetadata extends MergeableClassMetadata
             'xmlDiscriminatorCData' => $this->xmlDiscriminatorCData,
             'usingExpression' => $this->usingExpression,
             'xmlDiscriminatorNamespace' => $this->xmlDiscriminatorNamespace,
+            'isList' => $this->isList,
         ]);
     }
 
@@ -305,6 +307,9 @@ class ClassMetadata extends MergeableClassMetadata
             $this->xmlDiscriminatorCData = $unserialized['xmlDiscriminatorCData'];
         }
 
+        if (isset($unserialized['isList'])) {
+            $this->isList = $unserialized['isList'];
+        }
         parent::unserialize($parentStr);
     }
 

--- a/src/Metadata/Driver/AnnotationDriver.php
+++ b/src/Metadata/Driver/AnnotationDriver.php
@@ -244,6 +244,10 @@ class AnnotationDriver implements DriverInterface
                     }
                 }
 
+                if ($propertyMetadata->inline && $propertyMetadata->isCollectionList()) {
+                    $classMetadata->isList = true;
+                }
+
                 if (!$propertyMetadata->serializedName) {
                     $propertyMetadata->serializedName = $this->namingStrategy->translateName($propertyMetadata);
                 }

--- a/src/Metadata/Driver/AnnotationDriver.php
+++ b/src/Metadata/Driver/AnnotationDriver.php
@@ -244,8 +244,9 @@ class AnnotationDriver implements DriverInterface
                     }
                 }
 
-                if ($propertyMetadata->inline && PropertyMetadata::isCollectionList($propertyMetadata->type)) {
-                    $classMetadata->isList = true;
+                if ($propertyMetadata->inline) {
+                    $classMetadata->isList = $classMetadata->isList || PropertyMetadata::isCollectionList($propertyMetadata->type);
+                    $classMetadata->isMap = $classMetadata->isMap || PropertyMetadata::isCollectionMap($propertyMetadata->type);
                 }
 
                 if (!$propertyMetadata->serializedName) {

--- a/src/Metadata/Driver/AnnotationDriver.php
+++ b/src/Metadata/Driver/AnnotationDriver.php
@@ -244,7 +244,7 @@ class AnnotationDriver implements DriverInterface
                     }
                 }
 
-                if ($propertyMetadata->inline && $propertyMetadata->isCollectionList()) {
+                if ($propertyMetadata->inline && PropertyMetadata::isCollectionList($propertyMetadata->type)) {
                     $classMetadata->isList = true;
                 }
 

--- a/src/Metadata/Driver/XmlDriver.php
+++ b/src/Metadata/Driver/XmlDriver.php
@@ -322,7 +322,7 @@ class XmlDriver extends AbstractFileDriver
                     }
                 }
 
-                if ($pMetadata->inline && $pMetadata->isCollectionList()) {
+                if ($pMetadata->inline && PropertyMetadata::isCollectionList($pMetadata->type)) {
                     $metadata->isList = true;
                 }
 

--- a/src/Metadata/Driver/XmlDriver.php
+++ b/src/Metadata/Driver/XmlDriver.php
@@ -322,6 +322,10 @@ class XmlDriver extends AbstractFileDriver
                     }
                 }
 
+                if ($pMetadata->inline && $pMetadata->isCollectionList()) {
+                    $metadata->isList = true;
+                }
+
                 if (!$pMetadata->serializedName) {
                     $pMetadata->serializedName = $this->namingStrategy->translateName($pMetadata);
                 }

--- a/src/Metadata/Driver/XmlDriver.php
+++ b/src/Metadata/Driver/XmlDriver.php
@@ -322,8 +322,9 @@ class XmlDriver extends AbstractFileDriver
                     }
                 }
 
-                if ($pMetadata->inline && PropertyMetadata::isCollectionList($pMetadata->type)) {
-                    $metadata->isList = true;
+                if ($pMetadata->inline) {
+                    $metadata->isList = $metadata->isList || PropertyMetadata::isCollectionList($pMetadata->type);
+                    $metadata->isMap = $metadata->isMap || PropertyMetadata::isCollectionMap($pMetadata->type);
                 }
 
                 if (!$pMetadata->serializedName) {

--- a/src/Metadata/Driver/YamlDriver.php
+++ b/src/Metadata/Driver/YamlDriver.php
@@ -248,7 +248,7 @@ class YamlDriver extends AbstractFileDriver
                     $pMetadata->serializedName = $this->namingStrategy->translateName($pMetadata);
                 }
 
-                if ($pMetadata->inline && $pMetadata->isCollectionList()) {
+                if ($pMetadata->inline && PropertyMetadata::isCollectionList($pMetadata->type)) {
                     $metadata->isList = true;
                 }
 

--- a/src/Metadata/Driver/YamlDriver.php
+++ b/src/Metadata/Driver/YamlDriver.php
@@ -248,8 +248,9 @@ class YamlDriver extends AbstractFileDriver
                     $pMetadata->serializedName = $this->namingStrategy->translateName($pMetadata);
                 }
 
-                if ($pMetadata->inline && PropertyMetadata::isCollectionList($pMetadata->type)) {
-                    $metadata->isList = true;
+                if ($pMetadata->inline) {
+                    $metadata->isList = $metadata->isList || PropertyMetadata::isCollectionList($pMetadata->type);
+                    $metadata->isMap = $metadata->isMap || PropertyMetadata::isCollectionMap($pMetadata->type);
                 }
 
                 if (isset($config['properties'][$pName])) {

--- a/src/Metadata/Driver/YamlDriver.php
+++ b/src/Metadata/Driver/YamlDriver.php
@@ -248,6 +248,10 @@ class YamlDriver extends AbstractFileDriver
                     $pMetadata->serializedName = $this->namingStrategy->translateName($pMetadata);
                 }
 
+                if ($pMetadata->inline && $pMetadata->isCollectionList()) {
+                    $metadata->isList = true;
+                }
+
                 if (isset($config['properties'][$pName])) {
                     $pConfig = $config['properties'][$pName];
 

--- a/src/Metadata/PropertyMetadata.php
+++ b/src/Metadata/PropertyMetadata.php
@@ -98,6 +98,22 @@ class PropertyMetadata extends BasePropertyMetadata
         $this->type = $type;
     }
 
+    public function isCollectionList(): bool
+    {
+        return is_array($this->type)
+            && $this->type['name'] === 'array'
+            && isset($this->type['params'][0])
+            && !isset($this->type['params'][1]);
+    }
+
+    public function isCollectionMap(): bool
+    {
+        return is_array($this->type)
+            && $this->type['name'] === 'array'
+            && isset($this->type['params'][0])
+            && isset($this->type['params'][1]);
+    }
+
     public function serialize()
     {
         return serialize([

--- a/src/Metadata/PropertyMetadata.php
+++ b/src/Metadata/PropertyMetadata.php
@@ -98,20 +98,20 @@ class PropertyMetadata extends BasePropertyMetadata
         $this->type = $type;
     }
 
-    public function isCollectionList(): bool
+    public static function isCollectionList(array $type = null): bool
     {
-        return is_array($this->type)
-            && $this->type['name'] === 'array'
-            && isset($this->type['params'][0])
-            && !isset($this->type['params'][1]);
+        return is_array($type)
+            && $type['name'] === 'array'
+            && isset($type['params'][0])
+            && !isset($type['params'][1]);
     }
 
-    public function isCollectionMap(): bool
+    public static function isCollectionMap(array $type = null): bool
     {
-        return is_array($this->type)
-            && $this->type['name'] === 'array'
-            && isset($this->type['params'][0])
-            && isset($this->type['params'][1]);
+        return is_array($type)
+            && $type['name'] === 'array'
+            && isset($type['params'][0])
+            && isset($type['params'][1]);
     }
 
     public function serialize()

--- a/tests/Fixtures/FirstClassCollection.php
+++ b/tests/Fixtures/FirstClassCollection.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace JMS\Serializer\Tests\Fixtures;
+
+use JMS\Serializer\Annotation as Serializer;
+
+class FirstClassCollection implements \IteratorAggregate
+{
+    /**
+     * @Serializer\Type("array<int>")
+     * @Serializer\Inline
+     * @var int[]
+     */
+    public $items = [];
+
+    public function __construct(int ...$items)
+    {
+        $this->items = $items;
+    }
+
+    public function getIterator() : iterable
+    {
+        yield from $this->items;
+    }
+}

--- a/tests/Fixtures/FirstClassListCollection.php
+++ b/tests/Fixtures/FirstClassListCollection.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace JMS\Serializer\Tests\Fixtures;
+
+use JMS\Serializer\Annotation as Serializer;
+
+class FirstClassListCollection
+{
+    /**
+     * @Serializer\Type("array<int>")
+     * @Serializer\Inline
+     * @var int[]
+     */
+    public $items = [];
+
+    public function __construct(array $items)
+    {
+        $this->items = $items;
+    }
+}

--- a/tests/Fixtures/FirstClassMapCollection.php
+++ b/tests/Fixtures/FirstClassMapCollection.php
@@ -6,22 +6,17 @@ namespace JMS\Serializer\Tests\Fixtures;
 
 use JMS\Serializer\Annotation as Serializer;
 
-class FirstClassCollection implements \IteratorAggregate
+class FirstClassMapCollection
 {
     /**
-     * @Serializer\Type("array<int>")
+     * @Serializer\Type("array<string,int>")
      * @Serializer\Inline
      * @var int[]
      */
     public $items = [];
 
-    public function __construct(int ...$items)
+    public function __construct(array $items)
     {
         $this->items = $items;
-    }
-
-    public function getIterator() : iterable
-    {
-        yield from $this->items;
     }
 }

--- a/tests/Metadata/Driver/BaseDriverTest.php
+++ b/tests/Metadata/Driver/BaseDriverTest.php
@@ -54,6 +54,9 @@ abstract class BaseDriverTest extends \PHPUnit\Framework\TestCase
         self::assertArrayHasKey('dc', $m->xmlNamespaces);
         self::assertEquals('http://purl.org/dc/elements/1.1/', $m->xmlNamespaces['dc']);
 
+        self::assertFalse($m->isList);
+        self::assertFalse($m->isMap);
+
         $p = new PropertyMetadata($m->name, 'id');
         $p->type = ['name' => 'string', 'params' => []];
         $p->groups = ["comments", "post"];
@@ -151,12 +154,14 @@ abstract class BaseDriverTest extends \PHPUnit\Framework\TestCase
     {
         $m = $this->getDriver()->loadMetadataForClass(new \ReflectionClass(FirstClassListCollection::class));
         self::assertTrue($m->isList);
+        self::assertFalse($m->isMap);
     }
 
     public function testFirstClassMapCollection()
     {
         $m = $this->getDriver()->loadMetadataForClass(new \ReflectionClass(FirstClassMapCollection::class));
         self::assertFalse($m->isList);
+        self::assertTrue($m->isMap);
     }
 
     public function testXmlKeyValuePairs()

--- a/tests/Metadata/Driver/BaseDriverTest.php
+++ b/tests/Metadata/Driver/BaseDriverTest.php
@@ -30,6 +30,8 @@ use JMS\Serializer\Tests\Fixtures\Discriminator\ObjectWithXmlNamespaceAttributeD
 use JMS\Serializer\Tests\Fixtures\Discriminator\ObjectWithXmlNamespaceAttributeDiscriminatorParent;
 use JMS\Serializer\Tests\Fixtures\Discriminator\ObjectWithXmlNamespaceDiscriminatorChild;
 use JMS\Serializer\Tests\Fixtures\Discriminator\ObjectWithXmlNamespaceDiscriminatorParent;
+use JMS\Serializer\Tests\Fixtures\FirstClassListCollection;
+use JMS\Serializer\Tests\Fixtures\FirstClassMapCollection;
 use JMS\Serializer\Tests\Fixtures\ObjectWithVirtualPropertiesAndDuplicatePropName;
 use JMS\Serializer\Tests\Fixtures\ParentSkipWithEmptyChild;
 use Metadata\Driver\DriverInterface;
@@ -143,6 +145,18 @@ abstract class BaseDriverTest extends \PHPUnit\Framework\TestCase
         $p->serializedName = 'virtualValue';
 
         self::assertEquals($p, $m->propertyMetadata['virtualValue']);
+    }
+
+    public function testFirstClassListCollection()
+    {
+        $m = $this->getDriver()->loadMetadataForClass(new \ReflectionClass(FirstClassListCollection::class));
+        self::assertTrue($m->isList);
+    }
+
+    public function testFirstClassMapCollection()
+    {
+        $m = $this->getDriver()->loadMetadataForClass(new \ReflectionClass(FirstClassMapCollection::class));
+        self::assertFalse($m->isList);
     }
 
     public function testXmlKeyValuePairs()

--- a/tests/Metadata/Driver/xml/FirstClassListCollection.xml
+++ b/tests/Metadata/Driver/xml/FirstClassListCollection.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<serializer>
+    <class name="JMS\Serializer\Tests\Fixtures\FirstClassListCollection">
+        <property name="items" inline="true">
+            <type><![CDATA[array<int>]]></type>
+        </property>
+    </class>
+</serializer>

--- a/tests/Metadata/Driver/xml/FirstClassMapCollection.xml
+++ b/tests/Metadata/Driver/xml/FirstClassMapCollection.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<serializer>
+    <class name="JMS\Serializer\Tests\Fixtures\FirstClassMapCollection">
+        <property name="items" inline="true">
+            <type><![CDATA[array<string,int>]]></type>
+        </property>
+    </class>
+</serializer>

--- a/tests/Metadata/Driver/yml/FirstClassListCollection.yml
+++ b/tests/Metadata/Driver/yml/FirstClassListCollection.yml
@@ -1,0 +1,5 @@
+JMS\Serializer\Tests\Fixtures\FirstClassListCollection:
+    properties:
+        items:
+            inline: true
+            type: array<int>

--- a/tests/Metadata/Driver/yml/FirstClassMapCollection.yml
+++ b/tests/Metadata/Driver/yml/FirstClassMapCollection.yml
@@ -1,0 +1,5 @@
+JMS\Serializer\Tests\Fixtures\FirstClassMapCollection:
+    properties:
+        items:
+            inline: true
+            type: array<string,int>

--- a/tests/Serializer/JsonSerializationTest.php
+++ b/tests/Serializer/JsonSerializationTest.php
@@ -28,6 +28,7 @@ use JMS\Serializer\GraphNavigatorInterface;
 use JMS\Serializer\SerializationContext;
 use JMS\Serializer\Tests\Fixtures\Author;
 use JMS\Serializer\Tests\Fixtures\AuthorList;
+use JMS\Serializer\Tests\Fixtures\FirstClassCollection;
 use JMS\Serializer\Tests\Fixtures\ObjectWithEmptyArrayAndHash;
 use JMS\Serializer\Tests\Fixtures\ObjectWithInlineArray;
 use JMS\Serializer\Tests\Fixtures\Tag;
@@ -137,6 +138,20 @@ class JsonSerializationTest extends BaseSerializationTest
         $object = new ObjectWithEmptyArrayAndHash();
 
         self::assertEquals('{}', $this->serialize($object));
+    }
+
+    public function testFirstClassCollectionsWithItems() : void
+    {
+        $collection = new FirstClassCollection(1, 2, 3);
+
+        self::assertSame('[1,2,3]', $this->serialize($collection));
+    }
+
+    public function testFirstClassCollectionEmpty() : void
+    {
+        $collection = new FirstClassCollection();
+
+        self::assertSame('[]', $this->serialize($collection));
     }
 
     public function testAddLinksToOutput()

--- a/tests/Serializer/JsonSerializationTest.php
+++ b/tests/Serializer/JsonSerializationTest.php
@@ -29,6 +29,8 @@ use JMS\Serializer\SerializationContext;
 use JMS\Serializer\Tests\Fixtures\Author;
 use JMS\Serializer\Tests\Fixtures\AuthorList;
 use JMS\Serializer\Tests\Fixtures\FirstClassCollection;
+use JMS\Serializer\Tests\Fixtures\FirstClassListCollection;
+use JMS\Serializer\Tests\Fixtures\FirstClassMapCollection;
 use JMS\Serializer\Tests\Fixtures\ObjectWithEmptyArrayAndHash;
 use JMS\Serializer\Tests\Fixtures\ObjectWithInlineArray;
 use JMS\Serializer\Tests\Fixtures\Tag;
@@ -140,18 +142,51 @@ class JsonSerializationTest extends BaseSerializationTest
         self::assertEquals('{}', $this->serialize($object));
     }
 
-    public function testFirstClassCollectionsWithItems() : void
+    public function getFirstClassListCollectionsValues()
     {
-        $collection = new FirstClassCollection(1, 2, 3);
-
-        self::assertSame('[1,2,3]', $this->serialize($collection));
+        $v = [1, 2];
+        unset($v[0]);
+        $v[0] = 3;
+        return [
+            [[1, 2, 3], '[1,2,3]'],
+            [[], '[]'],
+            [$v, '[2,3]'],
+        ];
     }
 
-    public function testFirstClassCollectionEmpty() : void
+    /**
+     * @dataProvider getFirstClassListCollectionsValues
+     * @param $items
+     * @param $expected
+     */
+    public function testFirstClassListCollections($items, $expected): void
     {
-        $collection = new FirstClassCollection();
+        $collection = new FirstClassListCollection($items);
 
-        self::assertSame('[]', $this->serialize($collection));
+        self::assertSame($expected, $this->serialize($collection));
+    }
+
+    public function getFirstClassMapCollectionsValues()
+    {
+        $v = [1, 2];
+        return [
+            [[1, 2, 3], '{"0":1,"1":2,"2":3}'],
+            [[], '{}'],
+            [["a" => "b", "c" => "d", 5], '{"a":0,"c":0,"0":5}'],
+            [$v, '{"0":1,"1":2}'],
+        ];
+    }
+
+    /**
+     * @dataProvider getFirstClassMapCollectionsValues
+     * @param $items
+     * @param $expected
+     */
+    public function testFirstClassMapCollections($items, $expected): void
+    {
+        $collection = new FirstClassMapCollection($items);
+
+        self::assertSame($expected, $this->serialize($collection));
     }
 
     public function testAddLinksToOutput()

--- a/tests/Serializer/JsonSerializationTest.php
+++ b/tests/Serializer/JsonSerializationTest.php
@@ -144,13 +144,10 @@ class JsonSerializationTest extends BaseSerializationTest
 
     public function getFirstClassListCollectionsValues()
     {
-        $v = [1, 2];
-        unset($v[0]);
-        $v[0] = 3;
         return [
             [[1, 2, 3], '[1,2,3]'],
             [[], '[]'],
-            [$v, '[2,3]'],
+            [[1, 'a' => 2], '[1,2]'],
         ];
     }
 
@@ -168,14 +165,10 @@ class JsonSerializationTest extends BaseSerializationTest
 
     public function getFirstClassMapCollectionsValues()
     {
-        $v = [1, 2];
-        unset($v[0]);
-        $v[0] = 3;
         return [
             [[1, 2, 3], '{"0":1,"1":2,"2":3}'],
             [[], '{}'],
             [["a" => "b", "c" => "d", 5], '{"a":0,"c":0,"0":5}'],
-            [$v, '{"1":2,"0":3}'],
         ];
     }
 

--- a/tests/Serializer/JsonSerializationTest.php
+++ b/tests/Serializer/JsonSerializationTest.php
@@ -169,11 +169,13 @@ class JsonSerializationTest extends BaseSerializationTest
     public function getFirstClassMapCollectionsValues()
     {
         $v = [1, 2];
+        unset($v[0]);
+        $v[0] = 3;
         return [
             [[1, 2, 3], '{"0":1,"1":2,"2":3}'],
             [[], '{}'],
             [["a" => "b", "c" => "d", 5], '{"a":0,"c":0,"0":5}'],
-            [$v, '{"0":1,"1":2}'],
+            [$v, '{"1":2,"0":3}'],
         ];
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| Doc updated   | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | no
| Fixed tickets | https://github.com/schmittjoh/serializer/pull/943 
| License       | Apache-2.0

~This removes the "object" special case, making the codebase much more predictable.~

~@Majkl578 However does not solve your feature request since your `@Inline` trick will not work anymore and collections will be consistently serialized to json objects (unless special manipulation is done inside `endVisitingObject` for `@Inline`).~

