### PR TITLE
Simplify deep group exclusion strategy

### DIFF
--- a/src/Exclusion/GroupsExclusionStrategy.php
+++ b/src/Exclusion/GroupsExclusionStrategy.php
@@ -108,10 +108,6 @@ final class GroupsExclusionStrategy implements ExclusionStrategyInterface
         $groups = $this->groups;
         foreach ($paths as $index => $path) {
             if (!array_key_exists($path, $groups)) {
-                if ($index > 0) {
-                    $groups = [self::DEFAULT_GROUP];
-                }
-
                 break;
             }
 

--- a/tests/Serializer/BaseSerializationTest.php
+++ b/tests/Serializer/BaseSerializationTest.php
@@ -1121,7 +1121,8 @@ abstract class BaseSerializationTest extends \PHPUnit\Framework\TestCase
                         'friends' => ['nickname_group'],
                     ],
                     'friends' => [
-                        'manager_group'
+                        'manager_group',
+                        'nickname_group',
                     ]
                 ])
             )

--- a/tests/Serializer/JsonSerializationTest.php
+++ b/tests/Serializer/JsonSerializationTest.php
@@ -92,7 +92,7 @@ class JsonSerializationTest extends BaseSerializationTest
             $outputs['groups_foo'] = '{"foo":"foo","foobar":"foobar"}';
             $outputs['groups_foobar'] = '{"foo":"foo","foobar":"foobar","bar":"bar"}';
             $outputs['groups_default'] = '{"bar":"bar","none":"none"}';
-            $outputs['groups_advanced'] = '{"name":"John","manager":{"name":"John Manager","friends":[{"nickname":"nickname"},{"nickname":"nickname"}]},"friends":[{"manager":{"name":"John friend 1 manager"}},{"manager":{"name":"John friend 2 manager"}}]}';
+            $outputs['groups_advanced'] = '{"name":"John","manager":{"name":"John Manager","friends":[{"nickname":"nickname"},{"nickname":"nickname"}]},"friends":[{"nickname":"nickname","manager":{"nickname":"nickname"}},{"nickname":"nickname","manager":{"nickname":"nickname"}}]}';
             $outputs['virtual_properties'] = '{"exist_field":"value","virtual_value":"value","test":"other-name","typed_virtual_property":1}';
             $outputs['virtual_properties_low'] = '{"low":1}';
             $outputs['virtual_properties_high'] = '{"high":8}';

--- a/tests/Serializer/xml/groups_advanced.xml
+++ b/tests/Serializer/xml/groups_advanced.xml
@@ -14,13 +14,15 @@
   </manager>
   <friends>
     <entry>
+      <nickname><![CDATA[nickname]]></nickname>
       <manager>
-        <name><![CDATA[John friend 1 manager]]></name>
+        <nickname><![CDATA[nickname]]></nickname>
       </manager>
     </entry>
     <entry>
+      <nickname><![CDATA[nickname]]></nickname>
       <manager>
-        <name><![CDATA[John friend 2 manager]]></name>
+        <nickname><![CDATA[nickname]]></nickname>
       </manager>
     </entry>
   </friends>


### PR DESCRIPTION
do not fallback on the fallback on the "Default" group but use the
latest discovered group

| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| Doc updated   | no
| BC breaks?    | yes
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets |  https://github.com/schmittjoh/serializer/issues/898 (discovered incongruity also in https://github.com/nelmio/NelmioApiDocBundle/pull/1311)
| License       | Apache-2.0

The "deep-groups" option was introduced last year, the impact of users should not be enourmous

