### PR TITLE
Fix DoctrineObjectConstructor deserialization with naming strategies

### DIFF
--- a/src/JMS/Serializer/Construction/DoctrineObjectConstructor.php
+++ b/src/JMS/Serializer/Construction/DoctrineObjectConstructor.php
@@ -87,11 +87,12 @@ class DoctrineObjectConstructor implements ObjectConstructorInterface
         $identifierList = array();
 
         foreach ($classMetadata->getIdentifierFieldNames() as $name) {
-            if (!array_key_exists($name, $data)) {
+            $dataName = $metadata->propertyMetadata[$name]->serializedName ?: $name;
+            if (!array_key_exists($dataName, $data)) {
                 return $this->fallbackConstructor->construct($visitor, $metadata, $data, $type, $context);
             }
 
-            $identifierList[$name] = $data[$name];
+            $identifierList[$name] = $data[$dataName];
         }
 
         // Entity update, load it from database

--- a/src/JMS/Serializer/Construction/DoctrineObjectConstructor.php
+++ b/src/JMS/Serializer/Construction/DoctrineObjectConstructor.php
@@ -19,6 +19,7 @@
 namespace JMS\Serializer\Construction;
 
 use Doctrine\Common\Persistence\ManagerRegistry;
+use JMS\Serializer\AbstractVisitor;
 use JMS\Serializer\DeserializationContext;
 use JMS\Serializer\Exception\InvalidArgumentException;
 use JMS\Serializer\Exception\ObjectConstructionException;
@@ -88,7 +89,7 @@ class DoctrineObjectConstructor implements ObjectConstructorInterface
         $identifierList = array();
 
         foreach ($classMetadata->getIdentifierFieldNames() as $name) {
-            if (method_exists($visitor, 'getNamingStrategy')) {
+            if ($visitor instanceof AbstractVisitor) {
                 /** @var PropertyNamingStrategyInterface $namingStrategy */
                 $namingStrategy = $visitor->getNamingStrategy();
                 $dataName = $namingStrategy->translateName($metadata->propertyMetadata[$name]);

--- a/src/JMS/Serializer/Construction/DoctrineObjectConstructor.php
+++ b/src/JMS/Serializer/Construction/DoctrineObjectConstructor.php
@@ -23,6 +23,7 @@ use JMS\Serializer\DeserializationContext;
 use JMS\Serializer\Exception\InvalidArgumentException;
 use JMS\Serializer\Exception\ObjectConstructionException;
 use JMS\Serializer\Metadata\ClassMetadata;
+use JMS\Serializer\Naming\PropertyNamingStrategyInterface;
 use JMS\Serializer\VisitorInterface;
 
 /**
@@ -87,7 +88,14 @@ class DoctrineObjectConstructor implements ObjectConstructorInterface
         $identifierList = array();
 
         foreach ($classMetadata->getIdentifierFieldNames() as $name) {
-            $dataName = $metadata->propertyMetadata[$name]->serializedName ?: $name;
+            if (method_exists($visitor, 'getNamingStrategy')) {
+                /** @var PropertyNamingStrategyInterface $namingStrategy */
+                $namingStrategy = $visitor->getNamingStrategy();
+                $dataName = $namingStrategy->translateName($metadata->propertyMetadata[$name]);
+            } else {
+                $dataName = $name;
+            }
+
             if (!array_key_exists($dataName, $data)) {
                 return $this->fallbackConstructor->construct($visitor, $metadata, $data, $type, $context);
             }

--- a/tests/Fixtures/Doctrine/IdentityFields/Server.php
+++ b/tests/Fixtures/Doctrine/IdentityFields/Server.php
@@ -2,22 +2,6 @@
 
 declare(strict_types=1);
 
-/*
- * Copyright 2018 Rene Gerritsen <rene.gerritsen@me.com>
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 namespace JMS\Serializer\Tests\Fixtures\Doctrine\IdentityFields;
 
 use Doctrine\ORM\Mapping as ORM;
@@ -32,7 +16,7 @@ class Server
      * @Serializer\Type("string")
      * @var string
      */
-    protected $ip;
+    protected $ipAddress;
 
     /**
      * @ORM\Id
@@ -53,13 +37,13 @@ class Server
     /**
      * Server constructor.
      * @param string $name
-     * @param string $ip
+     * @param string $ipAddress
      * @param string $serverId
      */
-    public function __construct($name, $ip, $serverId)
+    public function __construct($name, $ipAddress, $serverId)
     {
         $this->name = $name;
-        $this->ip = $ip;
+        $this->ipAddress = $ipAddress;
         $this->serverId = $serverId;
     }
 
@@ -74,9 +58,9 @@ class Server
     /**
      * @return string
      */
-    public function getIp()
+    public function getIpAddress()
     {
-        return $this->ip;
+        return $this->ipAddress;
     }
 
     /**

--- a/tests/Fixtures/Doctrine/IdentityFields/Server.php
+++ b/tests/Fixtures/Doctrine/IdentityFields/Server.php
@@ -1,0 +1,89 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * Copyright 2018 Rene Gerritsen <rene.gerritsen@me.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace JMS\Serializer\Tests\Fixtures\Doctrine\IdentityFields;
+
+use Doctrine\ORM\Mapping as ORM;
+use JMS\Serializer\Annotation as Serializer;
+
+/** @ORM\Entity */
+class Server
+{
+    /**
+     * @ORM\Id
+     * @ORM\Column(type="string", name="ip_address")
+     * @Serializer\Type("string")
+     * @var string
+     */
+    protected $ip;
+
+    /**
+     * @ORM\Id
+     * @ORM\Column(type="string", name="server_id")
+     * @Serializer\SerializedName("server_id_extracted")
+     * @Serializer\Type("string")
+     * @var string
+     */
+    protected $serverId;
+
+    /**
+     * @ORM\Column(type="string")
+     * @Serializer\Type("string")
+     * @var string
+     */
+    private $name;
+
+    /**
+     * Server constructor.
+     * @param string $name
+     * @param string $ip
+     * @param string $serverId
+     */
+    public function __construct($name, $ip, $serverId)
+    {
+        $this->name = $name;
+        $this->ip = $ip;
+        $this->serverId = $serverId;
+    }
+
+    /**
+     * @return string
+     */
+    public function getName()
+    {
+        return $this->name;
+    }
+
+    /**
+     * @return string
+     */
+    public function getIp()
+    {
+        return $this->ip;
+    }
+
+    /**
+     * @return string
+     */
+    public function getServerId()
+    {
+        return $this->serverId;
+    }
+}

--- a/tests/Serializer/Doctrine/ObjectConstructorTest.php
+++ b/tests/Serializer/Doctrine/ObjectConstructorTest.php
@@ -13,16 +13,19 @@ use Doctrine\ORM\EntityManager;
 use Doctrine\ORM\Mapping\Driver\AnnotationDriver;
 use Doctrine\ORM\ORMException;
 use Doctrine\ORM\Tools\SchemaTool;
+use Doctrine\ORM\UnitOfWork;
 use JMS\Serializer\Builder\CallbackDriverFactory;
 use JMS\Serializer\Builder\DefaultDriverFactory;
 use JMS\Serializer\Construction\DoctrineObjectConstructor;
 use JMS\Serializer\Construction\ObjectConstructorInterface;
+use JMS\Serializer\Construction\UnserializeObjectConstructor;
 use JMS\Serializer\DeserializationContext;
 use JMS\Serializer\Metadata\ClassMetadata;
 use JMS\Serializer\Metadata\Driver\DoctrineTypeDriver;
 use JMS\Serializer\Serializer;
 use JMS\Serializer\SerializerBuilder;
 use JMS\Serializer\Tests\Fixtures\Doctrine\Author;
+use JMS\Serializer\Tests\Fixtures\Doctrine\IdentityFields\Server;
 use JMS\Serializer\Tests\Fixtures\Doctrine\SingleTableInheritance\Excursion;
 use JMS\Serializer\VisitorInterface;
 
@@ -182,6 +185,27 @@ class ObjectConstructorTest extends \PHPUnit_Framework_TestCase
         $this->assertSame($author, $authorFetched);
     }
 
+    public function testNamingForIdentifierColumnIsConsidered()
+    {
+        $serializer = $this->createSerializerWithDoctrineObjectConstructor();
+
+        /** @var EntityManager $em */
+        $em = $this->registry->getManager();
+        $server = new Server('Linux', '127.0.0.1', 'home');
+        $em->persist($server);
+        $em->flush();
+        $em->clear();
+
+        $jsonData = '{"ip":"127.0.0.1", "server_id_extracted":"home", "name":"Windows"}';
+        /** @var Server $serverDeserialized */
+        $serverDeserialized = $serializer->deserialize($jsonData, Server::class ,'json');
+
+        static::assertSame(
+            $em->getUnitOfWork()->getEntityState($serverDeserialized),
+            UnitOfWork::STATE_MANAGED
+        );
+    }
+
     protected function setUp()
     {
         $this->visitor = $this->getMockBuilder('JMS\Serializer\VisitorInterface')->getMock();
@@ -250,6 +274,24 @@ class ObjectConstructorTest extends \PHPUnit_Framework_TestCase
         $em = EntityManager::create($con, $cfg);
 
         return $em;
+    }
+
+    /**
+     * @return \JMS\Serializer\SerializerInterface
+     */
+    private function createSerializerWithDoctrineObjectConstructor()
+    {
+        return SerializerBuilder::create()
+
+            ->setObjectConstructor(
+                new DoctrineObjectConstructor(
+                    $this->registry,
+                    new UnserializeObjectConstructor(),
+                    DoctrineObjectConstructor::ON_MISSING_FALLBACK
+                )
+            )
+            ->addDefaultHandlers()
+            ->build();
     }
 }
 

--- a/tests/Serializer/Doctrine/ObjectConstructorTest.php
+++ b/tests/Serializer/Doctrine/ObjectConstructorTest.php
@@ -196,9 +196,9 @@ class ObjectConstructorTest extends \PHPUnit_Framework_TestCase
         $em->flush();
         $em->clear();
 
-        $jsonData = '{"ip":"127.0.0.1", "server_id_extracted":"home", "name":"Windows"}';
+        $jsonData = '{"ip_address":"127.0.0.1", "server_id_extracted":"home", "name":"Windows"}';
         /** @var Server $serverDeserialized */
-        $serverDeserialized = $serializer->deserialize($jsonData, Server::class ,'json');
+        $serverDeserialized = $serializer->deserialize($jsonData, Server::class, 'json');
 
         static::assertSame(
             $em->getUnitOfWork()->getEntityState($serverDeserialized),
@@ -282,7 +282,6 @@ class ObjectConstructorTest extends \PHPUnit_Framework_TestCase
     private function createSerializerWithDoctrineObjectConstructor()
     {
         return SerializerBuilder::create()
-
             ->setObjectConstructor(
                 new DoctrineObjectConstructor(
                     $this->registry,


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Doc updated   | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #806 https://github.com/schmittjoh/serializer/issues/734
| License       | MIT

Use NamingStrategy to determine which array key in data should be used.
This should fix Error #806.

Problem Analysis:
While Object construction $data is used as Source for Doctrine Identifier Fields.
Since $data is either a raw array the names are not converted yet.
