### PR TITLE
Fix bug deserialising inline key-value pairs

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -38,6 +38,7 @@
         "doctrine/orm": "~2.1",
         "jackalope/jackalope-doctrine-dbal": "^1.1.5",
         "doctrine/phpcr-odm": "^1.3|^2.0",
+        "mockery/mockery": "^0.9|^1.0",
         "propel/propel1": "~1.7",
         "psr/container": "^1.0",
         "symfony/dependency-injection": "^2.7|^3.3|^4.0",

--- a/src/JMS/Serializer/XmlDeserializationVisitor.php
+++ b/src/JMS/Serializer/XmlDeserializationVisitor.php
@@ -183,14 +183,14 @@ class XmlDeserializationVisitor extends AbstractVisitor implements NullAwareVisi
                 }
             }
         }
-
+        $isKVP = (null !== $this->currentMetadata && $this->currentMetadata->xmlKeyValuePairs);
         $nsName = "";
         if (null !== $namespace) {
             $prefix = uniqid('ns-');
             $data->registerXPathNamespace($prefix, $namespace);
-            $nsName = $prefix . ':':
-		}
-        $nsName .=  (null !== $this->currentMetadata && $this->currentMetadata->xmlKeyValuePairs) ? '*' : $entryName
+            $nsName = $prefix . ':';
+        }
+        $nsName .=  $isKVP ? '*' : $entryName;
         $nodes = $data->xpath($nsName);
 
 
@@ -214,7 +214,7 @@ class XmlDeserializationVisitor extends AbstractVisitor implements NullAwareVisi
                 }
 
                 foreach ($nodes as $v) {
-                    $key = (null !== $this->currentMetadata && $this->currentMetadata->xmlKeyValuePairs) ? $v->getName() : count($result);
+                    $key = $isKVP ? $v->getName() : count($result);
                     $result[$key] = $this->navigator->accept($v, $type['params'][0], $context);
                 }
 

--- a/src/JMS/Serializer/XmlDeserializationVisitor.php
+++ b/src/JMS/Serializer/XmlDeserializationVisitor.php
@@ -184,21 +184,15 @@ class XmlDeserializationVisitor extends AbstractVisitor implements NullAwareVisi
             }
         }
 
+        $nsName = "";
         if (null !== $namespace) {
             $prefix = uniqid('ns-');
             $data->registerXPathNamespace($prefix, $namespace);
-            if($this->currentMetadata->xmlKeyValuePairs){
-                $nodes = $data->xpath("$prefix:*");
-            }else {
-                $nodes = $data->xpath("$prefix:$entryName");
-            }
-        } else {
-            if($this->currentMetadata->xmlKeyValuePairs){
-                $nodes = $data->xpath("*");
-            }else {
-                $nodes = $data->xpath($entryName);
-            }
-        }
+            $nsName = $prefix . ':':
+		}
+        $nsName .=  $this->currentMetadata->xmlKeyValuePairs ? '*' : $entryName
+        $nodes = $data->xpath($nsName);
+
 
         if (!\count($nodes)) {
             if (null === $this->result) {
@@ -220,11 +214,9 @@ class XmlDeserializationVisitor extends AbstractVisitor implements NullAwareVisi
                 }
 
                 foreach ($nodes as $v) {
-                    if($this->currentMetadata->xmlKeyValuePairs){
-                        $result[$v->getName()] = $this->navigator->accept($v, $type['params'][0], $context);
-                    }else {
-                        $result[] = $this->navigator->accept($v, $type['params'][0], $context);
-                    }                }
+					$key = $this->currentMetadata->xmlKeyValuePairs ? $v->getName() : count($result);
+                    $result[$key] = $this->navigator->accept($v, $type['params'][0], $context);
+                }
 
                 return $result;
 

--- a/src/JMS/Serializer/XmlDeserializationVisitor.php
+++ b/src/JMS/Serializer/XmlDeserializationVisitor.php
@@ -187,9 +187,17 @@ class XmlDeserializationVisitor extends AbstractVisitor implements NullAwareVisi
         if (null !== $namespace) {
             $prefix = uniqid('ns-');
             $data->registerXPathNamespace($prefix, $namespace);
-            $nodes = $data->xpath("$prefix:$entryName");
+            if($this->currentMetadata->xmlKeyValuePairs){
+                $nodes = $data->xpath("$prefix:*");
+            }else {
+                $nodes = $data->xpath("$prefix:$entryName");
+            }
         } else {
-            $nodes = $data->xpath($entryName);
+            if($this->currentMetadata->xmlKeyValuePairs){
+                $nodes = $data->xpath("*");
+            }else {
+                $nodes = $data->xpath($entryName);
+            }
         }
 
         if (!\count($nodes)) {
@@ -212,8 +220,11 @@ class XmlDeserializationVisitor extends AbstractVisitor implements NullAwareVisi
                 }
 
                 foreach ($nodes as $v) {
-                    $result[] = $this->navigator->accept($v, $type['params'][0], $context);
-                }
+                    if($this->currentMetadata->xmlKeyValuePairs){
+                        $result[$v->getName()] = $this->navigator->accept($v, $type['params'][0], $context);
+                    }else {
+                        $result[] = $this->navigator->accept($v, $type['params'][0], $context);
+                    }                }
 
                 return $result;
 
@@ -287,7 +298,7 @@ class XmlDeserializationVisitor extends AbstractVisitor implements NullAwareVisi
 
         if ($metadata->xmlCollection) {
             $enclosingElem = $data;
-            if (!$metadata->xmlCollectionInline) {
+            if (!$metadata->xmlCollectionInline  && !$metadata->xmlKeyValuePairs) {
                 $enclosingElem = $data->children($metadata->xmlNamespace)->$name;
             }
 

--- a/src/JMS/Serializer/XmlDeserializationVisitor.php
+++ b/src/JMS/Serializer/XmlDeserializationVisitor.php
@@ -190,7 +190,7 @@ class XmlDeserializationVisitor extends AbstractVisitor implements NullAwareVisi
             $data->registerXPathNamespace($prefix, $namespace);
             $nsName = $prefix . ':':
 		}
-        $nsName .=  $this->currentMetadata->xmlKeyValuePairs ? '*' : $entryName
+        $nsName .=  (null !== $this->currentMetadata && $this->currentMetadata->xmlKeyValuePairs) ? '*' : $entryName
         $nodes = $data->xpath($nsName);
 
 
@@ -214,7 +214,7 @@ class XmlDeserializationVisitor extends AbstractVisitor implements NullAwareVisi
                 }
 
                 foreach ($nodes as $v) {
-					$key = $this->currentMetadata->xmlKeyValuePairs ? $v->getName() : count($result);
+                    $key = (null !== $this->currentMetadata && $this->currentMetadata->xmlKeyValuePairs) ? $v->getName() : count($result);
                     $result[$key] = $this->navigator->accept($v, $type['params'][0], $context);
                 }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Doc updated   | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | NIL
| License       | Apache-2.0

We made this change to enable the POData project to work properly.  
We needed to deserialise inline KVPs and as we found it, the JMS serialiser didn't do that.