### PR TITLE
Feature/different tagnames in xmllist

### DIFF
--- a/doc/reference/annotations.rst
+++ b/doc/reference/annotations.rst
@@ -649,6 +649,110 @@ Resulting XML:
     </post>
 
 You can also specify the entry tag namespace using the ``namespace`` attribute (``@XmlList(inline = true, entry = "comment", namespace="http://www.example.com/ns")``).
+If the tag name is determined by the type of the object, use the ``allowTypes`` attribute (see @XmlElementRef).
+
+@XmlElementRef
+~~~~~~~~~~~~~~
+It is used in the ``allowTypes`` attribute of the ``@XmlList`` annotation to describe the types used.
+
+.. code-block :: php
+
+    <?php
+
+    namespace JMS\Serializer\Tests\Fixtures;
+
+    use JMS\Serializer\Annotation\Type;
+    use JMS\Serializer\Annotation\XmlRoot;
+    use JMS\Serializer\Annotation\XmlList;
+    use JMS\Serializer\Annotation\XmlElementRef;
+
+    interface ObjectWithXmlListWithObjectTypesInterface
+    {
+    }
+
+    class ObjectWithXmlListWithObjectTypeA implements ObjectWithXmlListWithObjectTypesInterface
+    {
+        /**
+         * @var string
+         * @Type(name="string")
+         */
+        private $foo;
+
+        /**
+         * @param string $foo
+         */
+        public function __construct($foo = null)
+        {
+            $this->foo = $foo;
+        }
+    }
+
+    class ObjectWithXmlListWithObjectTypeB implements ObjectWithXmlListWithObjectTypesInterface
+    {
+        /**
+         * @var string
+         * @Type(name="string")
+         */
+        private $bar;
+
+        /**
+         * @param string $bar
+         */
+        public function __construct($bar = null)
+        {
+            $this->bar = $bar;
+        }
+    }
+
+    /**
+     * @XmlRoot(name="object")
+     */
+    class ObjectWithXmlListWithObjectType
+    {
+        /**
+         * @var ObjectWithXmlListWithObjectTypesInterface[]
+         * @Type(name="array<JMS\Serializer\Tests\Fixtures\ObjectWithXmlListWithObjectTypesInterface>")
+         * @XmlList(inline=true, allowTypes={
+         *     @XmlElementRef(name="TypeA", type="JMS\Serializer\Tests\Fixtures\ObjectWithXmlListWithObjectTypeA"),
+         *     @XmlElementRef(name="TypeB", type="JMS\Serializer\Tests\Fixtures\ObjectWithXmlListWithObjectTypeB")
+         * })
+         */
+        private $list;
+
+        public function __construct()
+        {
+            $this->list = self::create();
+        }
+
+        public static function create()
+        {
+            return
+                [
+                    new ObjectWithXmlListWithObjectTypeA('testA'),
+                    new ObjectWithXmlListWithObjectTypeB(),
+                    new ObjectWithXmlListWithObjectTypeA(),
+                    new ObjectWithXmlListWithObjectTypeB('testB'),
+                ]
+            ;
+        }
+    }
+
+Resulting XML:
+
+.. code-block :: xml
+
+    <?xml version="1.0" encoding="UTF-8"?>
+    <object>
+        <TypeA>
+            <foo><![CDATA[testA]]></foo>
+        </TypeA>
+        <TypeB/>
+        <TypeA/>
+        <TypeB>
+            <bar><![CDATA[testB]]></bar>
+        </TypeB>
+    </object>
+
 
 @XmlMap
 ~~~~~~~

--- a/src/JMS/Serializer/Annotation/XmlCollection.php
+++ b/src/JMS/Serializer/Annotation/XmlCollection.php
@@ -39,4 +39,9 @@ abstract class XmlCollection
      * @var boolean
      */
     public $skipWhenEmpty = true;
+
+    /**
+     * @var array<JMS\Serializer\Annotation\XmlElementRef>
+     */
+    public $allowTypes = [];
 }

--- a/src/JMS/Serializer/Annotation/XmlElementRef.php
+++ b/src/JMS/Serializer/Annotation/XmlElementRef.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace JMS\Serializer\Annotation;
+
+/**
+ * @Annotation
+ * @Target({"PROPERTY","METHOD","ANNOTATION"})
+ */
+class XmlElementRef
+{
+    /**
+     * @var string
+     */
+    public $name;
+
+    /**
+     * @var string
+     */
+    public $namespace;
+
+    /**
+     * @var string
+     */
+    public $type;
+}

--- a/src/JMS/Serializer/Metadata/Driver/AnnotationDriver.php
+++ b/src/JMS/Serializer/Metadata/Driver/AnnotationDriver.php
@@ -45,6 +45,7 @@ use JMS\Serializer\Annotation\XmlAttribute;
 use JMS\Serializer\Annotation\XmlAttributeMap;
 use JMS\Serializer\Annotation\XmlDiscriminator;
 use JMS\Serializer\Annotation\XmlElement;
+use JMS\Serializer\Annotation\XmlElementRef;
 use JMS\Serializer\Annotation\XmlKeyValuePairs;
 use JMS\Serializer\Annotation\XmlList;
 use JMS\Serializer\Annotation\XmlMap;
@@ -191,6 +192,16 @@ class AnnotationDriver implements DriverInterface
                     } elseif ($annot instanceof XmlList) {
                         $propertyMetadata->xmlCollection = true;
                         $propertyMetadata->xmlCollectionInline = $annot->inline;
+                        if (!empty($annot->allowTypes)) {
+                            /** @var XmlElementRef $allowType */
+                            foreach ($annot->allowTypes as $allowType) {
+                                $propertyMetadata->xmlAllowTypes[] = [
+                                    'type' => $allowType->type,
+                                    'name' => $allowType->name,
+                                    'namespace' => $allowType->namespace
+                                ];
+                            }
+                        }
                         $propertyMetadata->xmlEntryName = $annot->entry;
                         $propertyMetadata->xmlEntryNamespace = $annot->namespace;
                         $propertyMetadata->xmlCollectionSkipWhenEmpty = $annot->skipWhenEmpty;

--- a/src/JMS/Serializer/Metadata/Driver/XmlDriver.php
+++ b/src/JMS/Serializer/Metadata/Driver/XmlDriver.php
@@ -227,6 +227,16 @@ class XmlDriver extends AbstractFileDriver
                         if (isset($colConfig->attributes()->namespace)) {
                             $pMetadata->xmlEntryNamespace = (string)$colConfig->attributes()->namespace;
                         }
+
+                        if (isset($colConfig->{'allow-types'}->type) /*&& is_array(($colConfig->{'allow-types'}->type))*/) {
+                            foreach ($colConfig->{'allow-types'}->type as $allowType) {
+                                $pMetadata->xmlAllowTypes[] = [
+                                    'type' => $allowType->attributes()->type,
+                                    'name' => $allowType->attributes()->name,
+                                    'namespace' => $allowType->attributes()->namespace ?: null
+                                ];
+                            }
+                        }
                     }
 
                     if (isset($pElem->{'xml-map'})) {

--- a/src/JMS/Serializer/Metadata/Driver/YamlDriver.php
+++ b/src/JMS/Serializer/Metadata/Driver/YamlDriver.php
@@ -158,7 +158,7 @@ class YamlDriver extends AbstractFileDriver
                                 $pMetadata->xmlAllowTypes[] = [
                                     'type' => $allowType['type'],
                                     'name' => $allowType['name'],
-                                    'namespace' => $allowType['namespace']
+                                    'namespace' => array_key_exists('namespace', $allowType) ? $allowType['namespace'] : null
                                 ];
                             }
                         }

--- a/src/JMS/Serializer/Metadata/Driver/YamlDriver.php
+++ b/src/JMS/Serializer/Metadata/Driver/YamlDriver.php
@@ -152,6 +152,16 @@ class YamlDriver extends AbstractFileDriver
                         if (isset($colConfig['namespace'])) {
                             $pMetadata->xmlEntryNamespace = (string)$colConfig['namespace'];
                         }
+
+                        if (isset($colConfig['allow_types']) && is_array($colConfig['allow_types'])) {
+                            foreach ($colConfig['allow_types'] as $allowType) {
+                                $pMetadata->xmlAllowTypes[] = [
+                                    'type' => $allowType['type'],
+                                    'name' => $allowType['name'],
+                                    'namespace' => $allowType['namespace']
+                                ];
+                            }
+                        }
                     }
 
                     if (isset($pConfig['xml_map'])) {

--- a/src/JMS/Serializer/Metadata/PropertyMetadata.php
+++ b/src/JMS/Serializer/Metadata/PropertyMetadata.php
@@ -43,6 +43,7 @@ class PropertyMetadata extends BasePropertyMetadata
     public $xmlNamespace;
     public $xmlKeyValuePairs = false;
     public $xmlElementCData = true;
+    public $xmlAllowTypes = null;
     public $getter;
     public $setter;
     public $inline = false;

--- a/src/JMS/Serializer/XmlSerializationVisitor.php
+++ b/src/JMS/Serializer/XmlSerializationVisitor.php
@@ -32,8 +32,10 @@ use JMS\Serializer\Naming\PropertyNamingStrategyInterface;
  */
 class XmlSerializationVisitor extends AbstractVisitor
 {
+    /** @var \DOMDocument */
     public $document;
 
+    /** @var GraphNavigator */
     private $navigator;
     private $defaultRootName = 'result';
     private $defaultRootNamespace;
@@ -42,6 +44,8 @@ class XmlSerializationVisitor extends AbstractVisitor
     private $stack;
     private $metadataStack;
     private $currentNode;
+
+    /** @var PropertyMetadata */
     private $currentMetadata;
     private $hasValue;
     private $nullWasVisited;
@@ -184,6 +188,21 @@ class XmlSerializationVisitor extends AbstractVisitor
             }
 
             $tagName = (null !== $this->currentMetadata && $this->currentMetadata->xmlKeyValuePairs && $this->isElementNameValid($k)) ? $k : $entryName;
+
+            if (null !== $this->currentMetadata && !empty($this->currentMetadata->xmlAllowTypes)) {
+                $type = null;
+                foreach ($this->currentMetadata->xmlAllowTypes as $xmlAllowType) {
+                    if ($xmlAllowType['type'] == get_class($v)) {
+                        $type = $xmlAllowType;
+                        break;
+                    }
+                }
+                if ($type) {
+                    $tagName = $type['name'];
+                    $namespace = $type['namespace'];
+                } else
+                    continue;//or Exception?
+            }
 
             $entryNode = $this->createElement($tagName, $namespace);
             $this->currentNode->appendChild($entryNode);

--- a/tests/Fixtures/ObjectWithXmlListWithObjectType.php
+++ b/tests/Fixtures/ObjectWithXmlListWithObjectType.php
@@ -11,10 +11,9 @@ use JMS\Serializer\Annotation as Serializer;
 class ObjectWithXmlListWithObjectType
 {
     /**
-     * @var array
-     * @Serializer\Type(name="array<MS\Serializer\Tests\Fixtures\ObjectWithXmlListWithObjectTypesInterface>")
-     * @ Serializer\XmlList(inline=true)
-     * @Serializer\XmlList(inline=true, entry="item", allowTypes={
+     * @var ObjectWithXmlListWithObjectTypesInterface[]
+     * @Serializer\Type(name="array<JMS\Serializer\Tests\Fixtures\ObjectWithXmlListWithObjectTypesInterface>")
+     * @Serializer\XmlList(inline=true, allowTypes={
      *     @Serializer\XmlElementRef(name="TypeA", type="JMS\Serializer\Tests\Fixtures\ObjectWithXmlListWithObjectTypeA"),
      *     @Serializer\XmlElementRef(name="TypeB", type="JMS\Serializer\Tests\Fixtures\ObjectWithXmlListWithObjectTypeB")
      * })

--- a/tests/Fixtures/ObjectWithXmlListWithObjectType.php
+++ b/tests/Fixtures/ObjectWithXmlListWithObjectType.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace JMS\Serializer\Tests\Fixtures;
+
+
+use JMS\Serializer\Annotation as Serializer;
+
+/**
+ * @Serializer\XmlRoot(name="object")
+ */
+class ObjectWithXmlListWithObjectType
+{
+    /**
+     * @var array
+     * @Serializer\Type(name="array<MS\Serializer\Tests\Fixtures\ObjectWithXmlListWithObjectTypesInterface>")
+     * @ Serializer\XmlList(inline=true)
+     * @Serializer\XmlList(inline=true, entry="item", allowTypes={
+     *     @Serializer\XmlElementRef(name="TypeA", type="JMS\Serializer\Tests\Fixtures\ObjectWithXmlListWithObjectTypeA"),
+     *     @Serializer\XmlElementRef(name="TypeB", type="JMS\Serializer\Tests\Fixtures\ObjectWithXmlListWithObjectTypeB")
+     * })
+     */
+    private $list;
+
+    public function __construct()
+    {
+        $this->list = self::create();
+    }
+
+    public static function create()
+    {
+        return
+            [
+                new ObjectWithXmlListWithObjectTypeA('testA'),
+                new ObjectWithXmlListWithObjectTypeB(),
+                new ObjectWithXmlListWithObjectTypeA(),
+                new ObjectWithXmlListWithObjectTypeB('testB'),
+            ]
+        ;
+    }
+}

--- a/tests/Fixtures/ObjectWithXmlListWithObjectTypeA.php
+++ b/tests/Fixtures/ObjectWithXmlListWithObjectTypeA.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace JMS\Serializer\Tests\Fixtures;
+
+use JMS\Serializer\Annotation as Serializer;
+
+class ObjectWithXmlListWithObjectTypeA implements ObjectWithXmlListWithObjectTypesInterface
+{
+    /**
+     * @var string
+     * @Serializer\Type(name="string")
+     */
+    private $foo;
+
+    /**
+     * @param string $foo
+     */
+    public function __construct($foo = null)
+    {
+        $this->foo = $foo;
+    }
+}

--- a/tests/Fixtures/ObjectWithXmlListWithObjectTypeB.php
+++ b/tests/Fixtures/ObjectWithXmlListWithObjectTypeB.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace JMS\Serializer\Tests\Fixtures;
+
+use JMS\Serializer\Annotation as Serializer;
+
+class ObjectWithXmlListWithObjectTypeB implements ObjectWithXmlListWithObjectTypesInterface
+{
+    /**
+     * @var string
+     * @Serializer\Type(name="string")
+     */
+    private $bar;
+
+    /**
+     * @param string $bar
+     */
+    public function __construct($bar = null)
+    {
+        $this->bar = $bar;
+    }
+}

--- a/tests/Fixtures/ObjectWithXmlListWithObjectTypesInterface.php
+++ b/tests/Fixtures/ObjectWithXmlListWithObjectTypesInterface.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace JMS\Serializer\Tests\Fixtures;
+
+interface ObjectWithXmlListWithObjectTypesInterface
+{
+}

--- a/tests/Metadata/Driver/BaseDriverTest.php
+++ b/tests/Metadata/Driver/BaseDriverTest.php
@@ -115,6 +115,27 @@ abstract class BaseDriverTest extends \PHPUnit_Framework_TestCase
         $this->assertFalse($m->propertyMetadata['present']->xmlCollectionSkipWhenEmpty);
     }
 
+    public function testXMLListWithTypes()
+    {
+        $m = $this->getDriver()->loadMetadataForClass(new \ReflectionClass('JMS\Serializer\Tests\Fixtures\ObjectWithXmlListWithObjectType'));
+
+        $this->assertEquals(
+            array(
+                array(
+                    'type' => 'JMS\Serializer\Tests\Fixtures\ObjectWithXmlListWithObjectTypeA',
+                    'name' => 'TypeA',
+                    'namespace' => null
+                ),
+                array(
+                    'type' => 'JMS\Serializer\Tests\Fixtures\ObjectWithXmlListWithObjectTypeB',
+                    'name' => 'TypeB',
+                    'namespace' => null
+                )
+            ),
+            $m->propertyMetadata['list']->xmlAllowTypes
+        );
+    }
+
     public function testVirtualProperty()
     {
         $m = $this->getDriver()->loadMetadataForClass(new \ReflectionClass('JMS\Serializer\Tests\Fixtures\ObjectWithVirtualProperties'));

--- a/tests/Metadata/Driver/php/ObjectWithXmlListWithObjectType.php
+++ b/tests/Metadata/Driver/php/ObjectWithXmlListWithObjectType.php
@@ -1,0 +1,24 @@
+<?php
+use JMS\Serializer\Metadata\ClassMetadata;
+use JMS\Serializer\Metadata\PropertyMetadata;
+
+$className = 'JMS\Serializer\Tests\Fixtures\ObjectWithXmlListWithObjectType';
+
+$metadata = new ClassMetadata($className);
+
+$pMetadata = new PropertyMetadata($className, 'list');
+$pMetadata->xmlAllowTypes = array(
+    array(
+        'type' => 'JMS\Serializer\Tests\Fixtures\ObjectWithXmlListWithObjectTypeA',
+        'name' => 'TypeA',
+        'namespace' => null
+    ),
+    array(
+        'type' => 'JMS\Serializer\Tests\Fixtures\ObjectWithXmlListWithObjectTypeB',
+        'name' => 'TypeB',
+        'namespace' => null
+    )
+);
+$metadata->addPropertyMetadata($pMetadata);
+
+return $metadata;

--- a/tests/Metadata/Driver/xml/ObjectWithXmlListWithObjectType.xml
+++ b/tests/Metadata/Driver/xml/ObjectWithXmlListWithObjectType.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<serializer>
+    <class name="JMS\Serializer\Tests\Fixtures\ObjectWithXmlListWithObjectType" >
+        <property name="list" type="array">
+            <xml-list>
+                <allow-types>
+                    <type name="TypeA" type="JMS\Serializer\Tests\Fixtures\ObjectWithXmlListWithObjectTypeA" />
+                    <type name="TypeB" type="JMS\Serializer\Tests\Fixtures\ObjectWithXmlListWithObjectTypeB" />
+                </allow-types>
+            </xml-list>
+        </property>
+    </class>
+</serializer>

--- a/tests/Metadata/Driver/yml/ObjectWithXmlListWithObjectType.yml
+++ b/tests/Metadata/Driver/yml/ObjectWithXmlListWithObjectType.yml
@@ -1,0 +1,8 @@
+JMS\Serializer\Tests\Fixtures\ObjectWithXmlListWithObjectType:
+    properties:
+        list:
+            type: array
+            xml_list:
+                allow_types:
+                    - { name: TypeA, type: JMS\Serializer\Tests\Fixtures\ObjectWithXmlListWithObjectTypeA }
+                    - { name: TypeB, type: JMS\Serializer\Tests\Fixtures\ObjectWithXmlListWithObjectTypeB }

--- a/tests/Serializer/XmlSerializationTest.php
+++ b/tests/Serializer/XmlSerializationTest.php
@@ -45,6 +45,7 @@ use JMS\Serializer\Tests\Fixtures\ObjectWithVirtualXmlProperties;
 use JMS\Serializer\Tests\Fixtures\ObjectWithXmlKeyValuePairs;
 use JMS\Serializer\Tests\Fixtures\ObjectWithXmlKeyValuePairsWithObjectType;
 use JMS\Serializer\Tests\Fixtures\ObjectWithXmlKeyValuePairsWithType;
+use JMS\Serializer\Tests\Fixtures\ObjectWithXmlListWithObjectType;
 use JMS\Serializer\Tests\Fixtures\ObjectWithXmlNamespaces;
 use JMS\Serializer\Tests\Fixtures\ObjectWithXmlNamespacesAndObjectProperty;
 use JMS\Serializer\Tests\Fixtures\ObjectWithXmlNamespacesAndObjectPropertyAuthor;
@@ -202,6 +203,17 @@ class XmlSerializationTest extends BaseSerializationTest
             $this->getContent('virtual_properties_map'),
             $this->serialize(new ObjectWithVirtualXmlProperties(), SerializationContext::create()->setGroups(array('map')))
         );
+    }
+
+    public function testObjectWithListWithTypes()
+    {
+        $object = new ObjectWithXmlListWithObjectType();
+        $this->assertEquals(
+            $this->getContent('object_with_xml_list_with_object_type'),
+            $this->serialize($object)
+        );
+        $deserialized = $this->deserialize($this->getContent('object_with_xml_list_with_object_type'), get_class($object));
+        $this->assertEquals($object, $deserialized);
     }
 
     public function testUnserializeMissingArray()

--- a/tests/Serializer/xml/object_with_xml_list_with_object_type.xml
+++ b/tests/Serializer/xml/object_with_xml_list_with_object_type.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<object>
+  <TypeA>
+    <foo><![CDATA[testA]]></foo>
+  </TypeA>
+  <TypeB/>
+  <TypeA/>
+  <TypeB>
+    <bar><![CDATA[testB]]></bar>
+  </TypeB>
+</object>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| Doc updated   | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #921 
| License       | Apache-2.0

Adds support for xml lists, in which the tag name depends on the type of object.