### PR TITLE
[POC] Split property selection from graph navigator

### DIFF
--- a/src/Accessor/AccessorStrategyInterface.php
+++ b/src/Accessor/AccessorStrategyInterface.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace JMS\Serializer\Accessor;
 
-use JMS\Serializer\Context;
 use JMS\Serializer\DeserializationContext;
 use JMS\Serializer\Metadata\ClassMetadata;
 use JMS\Serializer\Metadata\PropertyMetadata;
@@ -16,25 +15,21 @@ use JMS\Serializer\SerializationContext;
 interface AccessorStrategyInterface
 {
     /**
-     * @param ClassMetadata $metadata
-     * @param Context $context
-     * @return PropertyMetadata[]
-     */
-    public function getProperties(ClassMetadata $metadata, Context $context): array;
-    /**
      * @param object $object
+     * @param ClassMetadata $metadata
      * @param PropertyMetadata[] $properties
      * @param SerializationContext $context
      * @return mixed[]
      */
-    public function getValues(object $object, array $properties, SerializationContext $context):array;
+    public function getValues(object $object,  ClassMetadata $metadata, array $properties, SerializationContext $context):array;
 
     /**
      * @param object $object
      * @param mixed[] $values
+     * @param ClassMetadata $metadata
      * @param PropertyMetadata[] $properties
      * @param DeserializationContext $context
      * @return void
      */
-    public function setValues(object $object, array $values, array $properties, DeserializationContext $context): void;
+    public function setValues(object $object, array $values,  ClassMetadata $metadata, array $properties, DeserializationContext $context): void;
 }

--- a/src/Accessor/AccessorStrategyInterface.php
+++ b/src/Accessor/AccessorStrategyInterface.php
@@ -4,7 +4,11 @@ declare(strict_types=1);
 
 namespace JMS\Serializer\Accessor;
 
+use JMS\Serializer\Context;
+use JMS\Serializer\DeserializationContext;
+use JMS\Serializer\Metadata\ClassMetadata;
 use JMS\Serializer\Metadata\PropertyMetadata;
+use JMS\Serializer\SerializationContext;
 
 /**
  * @author Asmir Mustafic <goetas@gmail.com>
@@ -12,17 +16,25 @@ use JMS\Serializer\Metadata\PropertyMetadata;
 interface AccessorStrategyInterface
 {
     /**
-     * @param object $object
-     * @param PropertyMetadata $metadata
-     * @return mixed
+     * @param ClassMetadata $metadata
+     * @param Context $context
+     * @return PropertyMetadata[]
      */
-    public function getValue(object $object, PropertyMetadata $metadata);
+    public function getProperties(ClassMetadata $metadata, Context $context): array;
+    /**
+     * @param object $object
+     * @param PropertyMetadata[] $properties
+     * @param SerializationContext $context
+     * @return mixed[]
+     */
+    public function getValues(object $object, array $properties, SerializationContext $context):array;
 
     /**
      * @param object $object
-     * @param mixed $value
-     * @param PropertyMetadata $metadata
+     * @param mixed[] $values
+     * @param PropertyMetadata[] $properties
+     * @param DeserializationContext $context
      * @return void
      */
-    public function setValue(object $object, $value, PropertyMetadata $metadata): void;
+    public function setValues(object $object, array $values, array $properties, DeserializationContext $context): void;
 }

--- a/src/GraphNavigator/DeserializationGraphNavigator.php
+++ b/src/GraphNavigator/DeserializationGraphNavigator.php
@@ -166,28 +166,21 @@ final class DeserializationGraphNavigator extends GraphNavigator implements Grap
                 $object = $this->objectConstructor->construct($this->visitor, $metadata, $data, $type, $this->context);
 
                 $this->visitor->startVisitingObject($metadata, $object, $type);
-                foreach ($metadata->propertyMetadata as $propertyMetadata) {
-                    if ($this->exclusionStrategy->shouldSkipProperty($propertyMetadata, $this->context)) {
-                        continue;
-                    }
 
-                    if (null !== $this->expressionExclusionStrategy && $this->expressionExclusionStrategy->shouldSkipProperty($propertyMetadata, $this->context)) {
-                        continue;
-                    }
+                $props = $this->accessor->getProperties($metadata, $this->context);
+                $values = [];
 
-                    if ($propertyMetadata->readOnly) {
-                        continue;
-                    }
-
+                foreach ($props as $i => $propertyMetadata) {
                     $this->context->pushPropertyMetadata($propertyMetadata);
                     try {
-                        $v = $this->visitor->visitProperty($propertyMetadata, $data);
-                        $this->accessor->setValue($object, $v, $propertyMetadata);
+                        $values[$i] = $this->visitor->visitProperty($propertyMetadata, $data);
                     } catch (NotAcceptableException $e) {
 
                     }
                     $this->context->popPropertyMetadata();
                 }
+
+                $this->accessor->setValues($data, $props, $values, $this->context);
 
                 $rs = $this->visitor->endVisitingObject($metadata, $data, $type);
                 $this->afterVisitingObject($metadata, $rs, $type);

--- a/src/GraphNavigator/DeserializationGraphNavigator.php
+++ b/src/GraphNavigator/DeserializationGraphNavigator.php
@@ -22,6 +22,7 @@ use JMS\Serializer\GraphNavigatorInterface;
 use JMS\Serializer\Handler\HandlerRegistryInterface;
 use JMS\Serializer\Metadata\ClassMetadata;
 use JMS\Serializer\NullAwareVisitorInterface;
+use JMS\Serializer\Selector\PropertySelectorInterface;
 use JMS\Serializer\Visitor\DeserializationVisitorInterface;
 use Metadata\MetadataFactoryInterface;
 
@@ -58,23 +59,25 @@ final class DeserializationGraphNavigator extends GraphNavigator implements Grap
      * @var AccessorStrategyInterface
      */
     private $accessor;
+    /**
+     * @var PropertySelectorInterface
+     */
+    private $selector;
 
     public function __construct(
         MetadataFactoryInterface $metadataFactory,
         HandlerRegistryInterface $handlerRegistry,
         ObjectConstructorInterface $objectConstructor,
         AccessorStrategyInterface $accessor,
-        EventDispatcherInterface $dispatcher = null,
-        ExpressionEvaluatorInterface $expressionEvaluator = null
+        PropertySelectorInterface $selector,
+        EventDispatcherInterface $dispatcher = null
     ) {
         $this->dispatcher = $dispatcher ?: new EventDispatcher();
         $this->metadataFactory = $metadataFactory;
         $this->handlerRegistry = $handlerRegistry;
         $this->objectConstructor = $objectConstructor;
         $this->accessor = $accessor;
-        if ($expressionEvaluator) {
-            $this->expressionExclusionStrategy = new ExpressionLanguageExclusionStrategy($expressionEvaluator);
-        }
+        $this->selector = $selector;
     }
 
     /**
@@ -147,10 +150,6 @@ final class DeserializationGraphNavigator extends GraphNavigator implements Grap
                 /** @var $metadata ClassMetadata */
                 $metadata = $this->metadataFactory->getMetadataForClass($type['name']);
 
-                if ($metadata->usingExpression && !$this->expressionExclusionStrategy) {
-                    throw new ExpressionLanguageRequiredException("To use conditional exclude/expose in {$metadata->name} you must configure the expression language.");
-                }
-
                 if (!empty($metadata->discriminatorMap) && $type['name'] === $metadata->discriminatorBaseClass) {
                     $metadata = $this->resolveMetadata($data, $metadata);
                 }
@@ -167,10 +166,10 @@ final class DeserializationGraphNavigator extends GraphNavigator implements Grap
 
                 $this->visitor->startVisitingObject($metadata, $object, $type);
 
-                $props = $this->accessor->getProperties($metadata, $this->context);
+                $properties = $this->selector->select($metadata, $this->context);
                 $values = [];
 
-                foreach ($props as $i => $propertyMetadata) {
+                foreach ($properties as $i => $propertyMetadata) {
                     $this->context->pushPropertyMetadata($propertyMetadata);
                     try {
                         $values[$i] = $this->visitor->visitProperty($propertyMetadata, $data);
@@ -180,7 +179,7 @@ final class DeserializationGraphNavigator extends GraphNavigator implements Grap
                     $this->context->popPropertyMetadata();
                 }
 
-                $this->accessor->setValues($data, $props, $values, $this->context);
+                $this->accessor->setValues($data, $values, $metadata, $properties, $this->context);
 
                 $rs = $this->visitor->endVisitingObject($metadata, $data, $type);
                 $this->afterVisitingObject($metadata, $rs, $type);

--- a/src/GraphNavigator/SerializationGraphNavigator.php
+++ b/src/GraphNavigator/SerializationGraphNavigator.php
@@ -12,11 +12,8 @@ use JMS\Serializer\EventDispatcher\ObjectEvent;
 use JMS\Serializer\EventDispatcher\PreSerializeEvent;
 use JMS\Serializer\Exception\CircularReferenceDetectedException;
 use JMS\Serializer\Exception\ExcludedClassException;
-use JMS\Serializer\Exception\ExpressionLanguageRequiredException;
 use JMS\Serializer\Exception\NotAcceptableException;
 use JMS\Serializer\Exception\RuntimeException;
-use JMS\Serializer\Exclusion\ExpressionLanguageExclusionStrategy;
-use JMS\Serializer\Expression\ExpressionEvaluatorInterface;
 use JMS\Serializer\GraphNavigator;
 use JMS\Serializer\GraphNavigatorInterface;
 use JMS\Serializer\Handler\HandlerRegistryInterface;
@@ -41,17 +38,10 @@ final class SerializationGraphNavigator extends GraphNavigator implements GraphN
      * @var SerializationVisitorInterface
      */
     protected $visitor;
-
     /**
      * @var SerializationContext
      */
     protected $context;
-
-    /**
-     * @var ExpressionLanguageExclusionStrategy
-     */
-    private $expressionExclusionStrategy;
-
     private $dispatcher;
     private $metadataFactory;
     private $handlerRegistry;
@@ -59,7 +49,6 @@ final class SerializationGraphNavigator extends GraphNavigator implements GraphN
      * @var AccessorStrategyInterface
      */
     private $accessor;
-
     /**
      * @var bool
      */
@@ -69,17 +58,12 @@ final class SerializationGraphNavigator extends GraphNavigator implements GraphN
         MetadataFactoryInterface $metadataFactory,
         HandlerRegistryInterface $handlerRegistry,
         AccessorStrategyInterface $accessor,
-        EventDispatcherInterface $dispatcher = null,
-        ExpressionEvaluatorInterface $expressionEvaluator = null
+        EventDispatcherInterface $dispatcher = null
     ) {
         $this->dispatcher = $dispatcher ?: new EventDispatcher();
         $this->metadataFactory = $metadataFactory;
         $this->handlerRegistry = $handlerRegistry;
         $this->accessor = $accessor;
-
-        if ($expressionEvaluator) {
-            $this->expressionExclusionStrategy = new ExpressionLanguageExclusionStrategy($expressionEvaluator);
-        }
     }
 
     public function initialize(VisitorInterface $visitor, Context $context): void
@@ -189,10 +173,6 @@ final class SerializationGraphNavigator extends GraphNavigator implements GraphN
                 /** @var $metadata ClassMetadata */
                 $metadata = $this->metadataFactory->getMetadataForClass($type['name']);
 
-                if ($metadata->usingExpression && $this->expressionExclusionStrategy === null) {
-                    throw new ExpressionLanguageRequiredException("To use conditional exclude/expose in {$metadata->name} you must configure the expression language.");
-                }
-
                 if ($this->exclusionStrategy->shouldSkipClass($metadata, $this->context)) {
                     $this->context->stopVisiting($data);
 
@@ -206,23 +186,13 @@ final class SerializationGraphNavigator extends GraphNavigator implements GraphN
                 }
 
                 $this->visitor->startVisitingObject($metadata, $data, $type);
-                foreach ($metadata->propertyMetadata as $propertyMetadata) {
-                    if ($this->exclusionStrategy->shouldSkipProperty($propertyMetadata, $this->context)) {
-                        continue;
-                    }
 
-                    if (null !== $this->expressionExclusionStrategy && $this->expressionExclusionStrategy->shouldSkipProperty($propertyMetadata, $this->context)) {
-                        continue;
-                    }
+                $props = $this->accessor->getProperties($metadata, $this->context);
+                $values = $this->accessor->getValues($data, $props, $this->context);
 
-                    $v = $this->accessor->getValue($data, $propertyMetadata);
-
-                    if (null === $v && $this->shouldSerializeNull !== true) {
-                        continue;
-                    }
-
+                foreach ($props as $i => $propertyMetadata) {
                     $this->context->pushPropertyMetadata($propertyMetadata);
-                    $this->visitor->visitProperty($propertyMetadata, $v);
+                    $this->visitor->visitProperty($propertyMetadata, $values[$i]);
                     $this->context->popPropertyMetadata();
                 }
 

--- a/src/Selector/DefaultPropertySelector.php
+++ b/src/Selector/DefaultPropertySelector.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+namespace JMS\Serializer\Selector;
+
+use JMS\Serializer\Context;
+use JMS\Serializer\DeserializationContext;
+use JMS\Serializer\Exception\LogicException;
+use JMS\Serializer\Exclusion\ExclusionStrategyInterface;
+use JMS\Serializer\Exclusion\ExpressionLanguageExclusionStrategy;
+use JMS\Serializer\Expression\ExpressionEvaluatorInterface;
+use JMS\Serializer\Metadata\ClassMetadata;
+use JMS\Serializer\Metadata\ExpressionPropertyMetadata;
+use JMS\Serializer\Metadata\PropertyMetadata;
+use JMS\Serializer\Metadata\StaticPropertyMetadata;
+use JMS\Serializer\SerializationContext;
+
+/**
+ * @author Asmir Mustafic <goetas@gmail.com>
+ */
+final class DefaultPropertySelector implements PropertySelectorInterface
+{
+    /**
+     * @var ExpressionEvaluatorInterface
+     */
+    private $evaluator;
+    /**
+     * @var ExclusionStrategyInterface
+     */
+    private $exclusionStrategy;
+    /**
+     * @var ExpressionLanguageExclusionStrategy
+     */
+    private $expressionExclusionStrategy;
+
+    public function __construct(
+        ExclusionStrategyInterface $exclusionStrategy,
+        ExpressionEvaluatorInterface $evaluator
+    ) {
+        $this->exclusionStrategy = $exclusionStrategy;
+        $this->evaluator = $evaluator;
+        $this->expressionExclusionStrategy = new ExpressionLanguageExclusionStrategy($evaluator);
+    }
+
+    /**
+     * @param ClassMetadata $metadata
+     * @param Context $context
+     * @return PropertyMetadata[]
+     */
+    public function select(ClassMetadata $metadata, Context $context): array
+    {
+        $values = [];
+        foreach ($metadata->propertyMetadata as $propertyMetadata) {
+            if ($context instanceof DeserializationContext && $propertyMetadata->readOnly) {
+                continue;
+            }
+
+            if ($this->exclusionStrategy->shouldSkipProperty($propertyMetadata, $context) || $this->expressionExclusionStrategy->shouldSkipProperty($propertyMetadata, $context)) {
+                continue;
+            }
+
+            $values[] = $propertyMetadata;
+        }
+
+        return $values;
+    }
+}

--- a/src/Selector/PropertySelectorInterface.php
+++ b/src/Selector/PropertySelectorInterface.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace JMS\Serializer\Selector;
+
+use JMS\Serializer\Context;
+use JMS\Serializer\DeserializationContext;
+use JMS\Serializer\Metadata\ClassMetadata;
+use JMS\Serializer\Metadata\PropertyMetadata;
+use JMS\Serializer\SerializationContext;
+
+/**
+ * @author Asmir Mustafic <goetas@gmail.com>
+ */
+interface PropertySelectorInterface
+{
+    /**
+     * @param ClassMetadata $metadata
+     * @param Context $context
+     * @return PropertyMetadata[]
+     */
+    public function select(ClassMetadata $metadata, Context $context): array;
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| Doc updated   | no
| BC breaks?    | yes
| Deprecations? | no
| Tests pass?   | no
| Fixed tickets | -
| License       | MIT

This changes a bit the way how the serializer internally works. The solution is still ugly and does not work (yet) but has big potentials.

With this implementation:
- the property selection depends only on the current exclusion strategy, and since the exclusion strategy does not change during the whole graph visitor, can easily be cached (and even compiled for group/version based exclusion strategies)
- the property access depends only on the class metadata and can be easily compiled into static classes. in addition now the property access can be done in batch, using a single closure for property access
