### PR TITLE
Bugfix/metadata serialization

### DIFF
--- a/src/JMS/Serializer/Metadata/ExpressionPropertyMetadata.php
+++ b/src/JMS/Serializer/Metadata/ExpressionPropertyMetadata.php
@@ -46,66 +46,23 @@ class ExpressionPropertyMetadata extends PropertyMetadata
     public function serialize()
     {
         return serialize(array(
-            $this->sinceVersion,
-            $this->untilVersion,
-            $this->groups,
-            $this->serializedName,
-            $this->type,
-            $this->xmlCollection,
-            $this->xmlCollectionInline,
-            $this->xmlEntryName,
-            $this->xmlKeyAttribute,
-            $this->xmlAttribute,
-            $this->xmlValue,
-            $this->xmlNamespace,
-            $this->xmlKeyValuePairs,
-            $this->xmlElementCData,
-            $this->xmlAttributeMap,
-            $this->maxDepth,
-            $this->getter,
-            $this->setter,
-            $this->inline,
-            $this->readOnly,
-            $this->class,
-            $this->name,
-            'excludeIf' => $this->excludeIf,
-            'expression' => $this->expression,
+            $this->expression,
+            parent::serialize()
         ));
     }
 
     public function unserialize($str)
     {
-        $unserialized = unserialize($str);
-        list(
-            $this->sinceVersion,
-            $this->untilVersion,
-            $this->groups,
-            $this->serializedName,
-            $this->type,
-            $this->xmlCollection,
-            $this->xmlCollectionInline,
-            $this->xmlEntryName,
-            $this->xmlKeyAttribute,
-            $this->xmlAttribute,
-            $this->xmlValue,
-            $this->xmlNamespace,
-            $this->xmlKeyValuePairs,
-            $this->xmlElementCData,
-            $this->xmlAttributeMap,
-            $this->maxDepth,
-            $this->getter,
-            $this->setter,
-            $this->inline,
-            $this->readOnly,
-            $this->class,
-            $this->name
-            ) = $unserialized;
+        $parentStr = $this->unserializeProperties($str);
+        list($this->class, $this->name) = unserialize($parentStr);
+    }
 
-        if (isset($unserialized['excludeIf'])) {
-            $this->excludeIf = $unserialized['excludeIf'];
-        }
-        if (isset($unserialized['expression'])) {
-            $this->expression = $unserialized['expression'];
-        }
+    protected function unserializeProperties($str)
+    {
+        list(
+            $this->expression,
+            $parentStr
+            ) = unserialize($str);
+        return parent::unserializeProperties($parentStr);
     }
 }

--- a/src/JMS/Serializer/Metadata/PropertyMetadata.php
+++ b/src/JMS/Serializer/Metadata/PropertyMetadata.php
@@ -156,6 +156,14 @@ class PropertyMetadata extends BasePropertyMetadata
 
     public function unserialize($str)
     {
+        $parentStr = $this->unserializeProperties($str);
+        parent::unserialize($parentStr);
+
+        $this->initAccessor();
+    }
+
+    protected function unserializeProperties($str)
+    {
         $unserialized = unserialize($str);
         list(
             $this->sinceVersion,
@@ -194,8 +202,6 @@ class PropertyMetadata extends BasePropertyMetadata
             $this->skipWhenEmpty = $unserialized['skipWhenEmpty'];
         }
 
-        parent::unserialize($parentStr);
-
-        $this->initAccessor();
+        return $parentStr;
     }
 }

--- a/src/JMS/Serializer/Metadata/StaticPropertyMetadata.php
+++ b/src/JMS/Serializer/Metadata/StaticPropertyMetadata.php
@@ -32,54 +32,23 @@ class StaticPropertyMetadata extends PropertyMetadata
     public function serialize()
     {
         return serialize(array(
-            $this->sinceVersion,
-            $this->untilVersion,
-            $this->groups,
-            $this->serializedName,
-            $this->type,
-            $this->xmlCollection,
-            $this->xmlCollectionInline,
-            $this->xmlEntryName,
-            $this->xmlKeyAttribute,
-            $this->xmlAttribute,
-            $this->xmlValue,
-            $this->xmlNamespace,
-            $this->xmlKeyValuePairs,
-            $this->xmlElementCData,
-            $this->getter,
-            $this->setter,
-            $this->inline,
-            $this->readOnly,
-            $this->class,
-            $this->name,
-            $this->value
+            $this->value,
+            parent::serialize()
         ));
     }
 
     public function unserialize($str)
     {
+        $parentStr = $this->unserializeProperties($str);
+        list($this->class, $this->name) = unserialize($parentStr);
+    }
+
+    protected function unserializeProperties($str)
+    {
         list(
-            $this->sinceVersion,
-            $this->untilVersion,
-            $this->groups,
-            $this->serializedName,
-            $this->type,
-            $this->xmlCollection,
-            $this->xmlCollectionInline,
-            $this->xmlEntryName,
-            $this->xmlKeyAttribute,
-            $this->xmlAttribute,
-            $this->xmlValue,
-            $this->xmlNamespace,
-            $this->xmlKeyValuePairs,
-            $this->xmlElementCData,
-            $this->getter,
-            $this->setter,
-            $this->inline,
-            $this->readOnly,
-            $this->class,
-            $this->name,
-            $this->value
+            $this->value,
+            $parentStr
             ) = unserialize($str);
+        return parent::unserializeProperties($parentStr);
     }
 }

--- a/src/JMS/Serializer/Metadata/VirtualPropertyMetadata.php
+++ b/src/JMS/Serializer/Metadata/VirtualPropertyMetadata.php
@@ -27,65 +27,9 @@ class VirtualPropertyMetadata extends PropertyMetadata
     {
     }
 
-    public function serialize()
-    {
-        return serialize(array(
-            $this->sinceVersion,
-            $this->untilVersion,
-            $this->groups,
-            $this->serializedName,
-            $this->type,
-            $this->xmlCollection,
-            $this->xmlCollectionInline,
-            $this->xmlEntryName,
-            $this->xmlKeyAttribute,
-            $this->xmlAttribute,
-            $this->xmlValue,
-            $this->xmlNamespace,
-            $this->xmlKeyValuePairs,
-            $this->xmlElementCData,
-            $this->xmlAttributeMap,
-            $this->maxDepth,
-            $this->getter,
-            $this->setter,
-            $this->inline,
-            $this->readOnly,
-            $this->class,
-            $this->name,
-            'excludeIf' => $this->excludeIf,
-        ));
-    }
-
     public function unserialize($str)
     {
-        $unserialized = unserialize($str);
-        list(
-            $this->sinceVersion,
-            $this->untilVersion,
-            $this->groups,
-            $this->serializedName,
-            $this->type,
-            $this->xmlCollection,
-            $this->xmlCollectionInline,
-            $this->xmlEntryName,
-            $this->xmlKeyAttribute,
-            $this->xmlAttribute,
-            $this->xmlValue,
-            $this->xmlNamespace,
-            $this->xmlKeyValuePairs,
-            $this->xmlElementCData,
-            $this->xmlAttributeMap,
-            $this->maxDepth,
-            $this->getter,
-            $this->setter,
-            $this->inline,
-            $this->readOnly,
-            $this->class,
-            $this->name
-            ) = $unserialized;
-
-        if (isset($unserialized['excludeIf'])) {
-            $this->excludeIf = $unserialized['excludeIf'];
-        }
+        $parentStr = $this->unserializeProperties($str);
+        list($this->class, $this->name) = unserialize($parentStr);
     }
 }

--- a/src/JMS/Serializer/YamlSerializationVisitor.php
+++ b/src/JMS/Serializer/YamlSerializationVisitor.php
@@ -146,7 +146,9 @@ class YamlSerializationVisitor extends AbstractVisitor
     {
         $v = $this->accessor->getValue($data, $metadata);
 
-        if (null === $v && $context->shouldSerializeNull() !== true) {
+        if ((null === $v && $context->shouldSerializeNull() !== true)
+            || (true === $metadata->skipWhenEmpty && ($v instanceof \ArrayObject || \is_array($v)) && 0 === count($v))
+        ) {
             return;
         }
 

--- a/tests/Fixtures/ObjectWithVirtualProperties.php
+++ b/tests/Fixtures/ObjectWithVirtualProperties.php
@@ -6,6 +6,7 @@ use JMS\Serializer\Annotation\AccessorOrder;
 use JMS\Serializer\Annotation\SerializedName;
 use JMS\Serializer\Annotation\Type;
 use JMS\Serializer\Annotation\VirtualProperty;
+use JMS\Serializer\Annotation\SkipWhenEmpty;
 
 /**
  * @AccessorOrder("custom", custom = {"prop_name", "existField", "foo" })
@@ -43,5 +44,14 @@ class ObjectWithVirtualProperties
     public function getTypedVirtualProperty()
     {
         return '1';
+    }
+
+    /**
+     * @VirtualProperty
+     * @SkipWhenEmpty()
+     */
+    public function getEmptyArray()
+    {
+        return [];
     }
 }

--- a/tests/Metadata/AbstractPropertyMetadataTest.php
+++ b/tests/Metadata/AbstractPropertyMetadataTest.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace JMS\Serializer\Tests\Metadata;
+
+abstract class AbstractPropertyMetadataTest extends \PHPUnit_Framework_TestCase
+{
+    protected function setNonDefaultMetadataValues($metadata)
+    {
+        $metadata->sinceVersion = '1';
+        $metadata->untilVersion = '2';
+        $metadata->groups = ['test_group', 'test_group_2'];
+        $metadata->serializedName = 'test_value';
+        $metadata->type = 'array';
+        $metadata->xmlCollection = true;
+        $metadata->xmlCollectionInline = true;
+        $metadata->xmlCollectionSkipWhenEmpty = false;
+        $metadata->xmlEntryName = 'test_xml_entry_name';
+        $metadata->xmlEntryNamespace = 'test_xml_entry_namespace';
+        $metadata->xmlKeyAttribute = 'test_xml_key_attribute';
+        $metadata->xmlAttribute = true;
+        $metadata->xmlValue = true;
+        $metadata->xmlNamespace = 'test_xml_namespace';
+        $metadata->xmlKeyValuePairs = true;
+        $metadata->xmlElementCData = false;
+        $metadata->inline = true;
+        $metadata->skipWhenEmpty = true;
+        $metadata->xmlAttributeMap = true;
+        $metadata->maxDepth = 1;
+        $metadata->excludeIf = 'expr';
+    }
+
+}

--- a/tests/Metadata/ExpressionPropertyMetadataTest.php
+++ b/tests/Metadata/ExpressionPropertyMetadataTest.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace JMS\Serializer\Tests\Metadata;
+
+use JMS\Serializer\Metadata\ExpressionPropertyMetadata;
+
+class ExpressionPropertyMetadataTest extends AbstractPropertyMetadataTest
+{
+    public function testSerialization()
+    {
+        $meta = new ExpressionPropertyMetadata('stdClass', 'foo', 'fooExpr');
+        $this->setNonDefaultMetadataValues($meta);
+
+        $restoredMeta = unserialize(serialize($meta));
+        $this->assertEquals($meta, $restoredMeta);
+    }
+}

--- a/tests/Metadata/PropertyMetadataTest.php
+++ b/tests/Metadata/PropertyMetadataTest.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace JMS\Serializer\Tests\Metadata;
+
+use JMS\Serializer\Metadata\PropertyMetadata;
+use JMS\Serializer\Tests\Fixtures\SimpleObject;
+
+class PropertyMetadataTest extends AbstractPropertyMetadataTest
+{
+    public function testSerialization()
+    {
+        $meta = new PropertyMetadata(SimpleObject::class, 'foo');
+        $this->setNonDefaultMetadataValues($meta);
+        $meta->getter = 'getFoo';
+        $meta->setter = 'setFoo';
+        $meta->readOnly = true;
+
+        $restoredMeta = unserialize(serialize($meta));
+        $this->assertEquals($meta, $restoredMeta);
+    }
+
+}

--- a/tests/Metadata/StaticPropertyMetadataTest.php
+++ b/tests/Metadata/StaticPropertyMetadataTest.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace JMS\Serializer\Tests\Metadata;
+
+use JMS\Serializer\Metadata\StaticPropertyMetadata;
+
+class StaticPropertyMetadataTest extends AbstractPropertyMetadataTest
+{
+    public function testSerialization()
+    {
+        $meta = new StaticPropertyMetadata('stdClass', 'foo', 'fooVal');
+        $this->setNonDefaultMetadataValues($meta);
+
+        $restoredMeta = unserialize(serialize($meta));
+        $this->assertEquals($meta, $restoredMeta);
+    }
+}

--- a/tests/Metadata/VirtualPropertyMetadataTest.php
+++ b/tests/Metadata/VirtualPropertyMetadataTest.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace JMS\Serializer\Tests\Metadata;
+
+use JMS\Serializer\Metadata\VirtualPropertyMetadata;
+use JMS\Serializer\Tests\Fixtures\ObjectWithVirtualProperties;
+
+class VirtualPropertyMetadataTest extends AbstractPropertyMetadataTest
+{
+    public function testSerialization()
+    {
+        $meta = new VirtualPropertyMetadata(ObjectWithVirtualProperties::class, 'getEmptyValue');
+        $this->setNonDefaultMetadataValues($meta);
+
+        $restoredMeta = unserialize(serialize($meta));
+        $this->assertEquals($meta, $restoredMeta);
+    }
+
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Doc updated   | no (N/A)
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes (fixed/added tests)
| Fixed tickets | N/A
| License       | MIT

Serialize/unserialize methods in each PropertyMetadata class was completely independent, which is difficult to maintain and keep track of. It resulted in a fact that some of these methods were not updated and some properties were ommited during serialization.

I encountered the issue when serializing a VirtualProperty with SkipWhenEmpty. Initially extracted metadata was OK, but after caching it and retrieving back from cache metadata was corrupted - `skipWhenEmpty` property was `false` again.

In my fix I tried to reuse property serialization code as much as possible without reorganizing class inheritance to preserve backwards compatibility.
I also added unit tests to verify property metadata serialization and deserialization.

The final run of the test suite also revealed a bug in YamlSerializationVisitor - SkipWhenEmpty was not respected in it, so I fixed that as well.