### PR TITLE
Add type "mixed" to configure arrays of mixed values

### DIFF
--- a/doc/cookbook/arrays.rst
+++ b/doc/cookbook/arrays.rst
@@ -34,12 +34,14 @@ In case of a JSON serialization:
     $serializer->serialize([1, 2], SerializationContext::create()->setInitialType('array<integer>')); //  [1, 2]
     $serializer->serialize(['a', 'b'], SerializationContext::create()->setInitialType('array<integer>')); //  ['a', 'b']
     $serializer->serialize(['c' => 'd'], SerializationContext::create()->setInitialType('array<string>')); //  ["d"]
+    $serializer->serialize(['c' => 'd', 'i' => 1], SerializationContext::create()->setInitialType('array<mixed>')); //  ["d", 1]
 
     // typehint as hash, keys will be always considered
     $serializer->serialize([], SerializationContext::create()->setInitialType('array<integer,integer>')); //  {}
     $serializer->serialize([1, 2], SerializationContext::create()->setInitialType('array<integer,integer>')); //  {"0" : 1, "1" : 2}
     $serializer->serialize(['a', 'b'], SerializationContext::create()->setInitialType('array<integer,integer>')); //  {"0" : "a", "1" : "b"}
-    $serializer->serialize(['c' => 'd'], SerializationContext::create()->setInitialType('array<string,string>')); //  {"d" : "d"}
+    $serializer->serialize(['c' => 'd'], SerializationContext::create()->setInitialType('array<string,string>')); //  {"c" : "d"}
+    $serializer->serialize(['c' => 'd', 'i' => 1], SerializationContext::create()->setInitialType('array<string,mixed>')); //  {"c" : "d", "i" : 1}
 
 
 .. note ::

--- a/doc/reference/annotations.rst
+++ b/doc/reference/annotations.rst
@@ -357,6 +357,10 @@ Available Types:
 +----------------------------------------------------------+--------------------------------------------------+
 | string                                                   | Primitive string                                 |
 +----------------------------------------------------------+--------------------------------------------------+
+| mixed                                                    | Same as no ``@Type`` annotation at all.          |
+|                                                          | This type is particularly useful to configure    |
+|                                                          | array values type*.                              |
++----------------------------------------------------------+--------------------------------------------------+
 | array                                                    | An array with arbitrary keys, and values.        |
 +----------------------------------------------------------+--------------------------------------------------+
 | array<T>                                                 | A list of type T (T can be any available type).  |
@@ -367,7 +371,7 @@ Available Types:
 |                                                          | Examples: array<string, string>,                 |
 |                                                          | array<string, MyNamespace\MyObject>, etc.        |
 +----------------------------------------------------------+--------------------------------------------------+
-| DateTime                                                 | PHP's DateTime object (default format*/timezone) |
+| DateTime                                                 | PHP's DateTime object (default format**/timezone)|
 +----------------------------------------------------------+--------------------------------------------------+
 | DateTime<'format'>                                       | PHP's DateTime object (custom format/default     |
 |                                                          | timezone)                                        |
@@ -404,7 +408,9 @@ Available Types:
 |                                                          | into Doctrine's ArrayCollection class.           |
 +----------------------------------------------------------+--------------------------------------------------+
 
-(*) If the standalone jms/serializer is used then default format is `\DateTime::ISO8601` (which is not compatible with ISO-8601 despite the name). For jms/serializer-bundle the default format is `\DateTime::ATOM` (the real ISO-8601 format) but it can be changed in [configuration](https://jmsyst.com/bundles/JMSSerializerBundle/master/configuration#configuration-block-2-0).
+(*) You can use mixed type to explicitly configure associative array of mixed values - ``array<string, mixed>`` (serialized to JSON as object), or when you have an associative array of mixed values, which you want to serialize as simple indexed array - ``array<mixed>.``
+
+(**) If the standalone jms/serializer is used then default format is `\DateTime::ISO8601` (which is not compatible with ISO-8601 despite the name). For jms/serializer-bundle the default format is `\DateTime::ATOM` (the real ISO-8601 format) but it can be changed in [configuration](https://jmsyst.com/bundles/JMSSerializerBundle/master/configuration#configuration-block-2-0).
 
 Examples:
 

--- a/src/JMS/Serializer/GraphNavigator.php
+++ b/src/JMS/Serializer/GraphNavigator.php
@@ -91,7 +91,7 @@ final class GraphNavigator implements GraphNavigatorInterface
 
         // If the type was not given, we infer the most specific type from the
         // input data in serialization mode.
-        if (null === $type) {
+        if (null === $type || 'mixed' === $type['name']) {
             if ($context instanceof DeserializationContext) {
                 throw new RuntimeException('The type must be given for all properties when deserializing.');
             }

--- a/tests/Serializer/JsonSerializationTest.php
+++ b/tests/Serializer/JsonSerializationTest.php
@@ -303,11 +303,17 @@ class JsonSerializationTest extends BaseSerializationTest
             [[1, 2], '[1,2]', null],
             [['a', 'b'], '["a","b"]', null],
             [['a' => 'a', 'b' => 'b'], '{"a":"a","b":"b"}', null],
+            [
+                ['int' => 1, 'string' => 'a', 'dateTime' => new \DateTime('2018-07-07 10:10:10')],
+                '{"int":1,"string":"a","dateTime":"2018-07-07T10:10:10+0000"}',
+                null
+            ],
 
             [[], '[]', null],
             [[], '[]', SerializationContext::create()->setInitialType('array')],
             [[], '[]', SerializationContext::create()->setInitialType('array<integer>')],
             [[], '{}', SerializationContext::create()->setInitialType('array<string,integer>')],
+            [[], '{}', SerializationContext::create()->setInitialType('array<string,mixed>')],
 
 
             [[1, 2], '[1,2]', SerializationContext::create()->setInitialType('array')],
@@ -318,6 +324,12 @@ class JsonSerializationTest extends BaseSerializationTest
             [[1 => 'a', 2 => 'b'], '["a","b"]', SerializationContext::create()->setInitialType('array<string>')],
             [['a' => 'a', 'b' => 'b'], '["a","b"]', SerializationContext::create()->setInitialType('array<string>')],
 
+            [
+                ['int' => 1, 'string' => 'a', 'dateTime' => new \DateTime('2018-07-07 10:10:10')],
+                '[1,"a","2018-07-07T10:10:10+0000"]',
+                SerializationContext::create()->setInitialType('array<mixed>')
+            ],
+
 
             [[1, 2], '{"0":1,"1":2}', SerializationContext::create()->setInitialType('array<integer,integer>')],
             [[1, 2], '{"0":1,"1":2}', SerializationContext::create()->setInitialType('array<string,integer>')],
@@ -326,6 +338,11 @@ class JsonSerializationTest extends BaseSerializationTest
 
             [['a', 'b'], '{"0":"a","1":"b"}', SerializationContext::create()->setInitialType('array<integer,string>')],
             [['a' => 'a', 'b' => 'b'], '{"a":"a","b":"b"}', SerializationContext::create()->setInitialType('array<string,string>')],
+            [
+                ['int' => 1, 'string' => 'a', 'dateTime' => new \DateTime('2018-07-07 10:10:10')],
+                '{"int":1,"string":"a","dateTime":"2018-07-07T10:10:10+0000"}',
+                SerializationContext::create()->setInitialType('array<string,mixed>')
+            ],
         ];
     }
 

--- a/tests/Serializer/YamlSerializationTest.php
+++ b/tests/Serializer/YamlSerializationTest.php
@@ -63,11 +63,17 @@ class YamlSerializationTest extends BaseSerializationTest
             [[1, 2], "- 1\n- 2\n", null],
             [['a', 'b'], "- a\n- b\n", null],
             [['a' => 'a', 'b' => 'b'], "a: a\nb: b\n", null],
+            [
+                ['int' => 1, 'string' => 'a', 'dateTime' => new \DateTime('2018-07-07 10:10:10')],
+                "int: 1\nstring: a\ndateTime: 2018-07-07 10:10:10\n",
+                null
+            ],
 
             [[], " []\n", null],
             [[], " []\n", SerializationContext::create()->setInitialType('array')],
             [[], " []\n", SerializationContext::create()->setInitialType('array<integer>')],
             [[], " {}\n", SerializationContext::create()->setInitialType('array<string,integer>')],
+            [[], " {}\n", SerializationContext::create()->setInitialType('array<string,mixed>')],
 
 
             [[1, 2], "- 1\n- 2\n", SerializationContext::create()->setInitialType('array')],
@@ -86,6 +92,11 @@ class YamlSerializationTest extends BaseSerializationTest
 
             [['a', 'b'], "0: a\n1: b\n", SerializationContext::create()->setInitialType('array<integer,string>')],
             [['a' => 'a', 'b' => 'b'], "a: a\nb: b\n", SerializationContext::create()->setInitialType('array<string,string>')],
+            [
+                ['int' => 1, 'string' => 'a', 'dateTime' => new \DateTime('2018-07-07 10:10:10')],
+                "int: 1\nstring: a\ndateTime: 2018-07-07 10:10:10\n",
+                SerializationContext::create()->setInitialType('array<string,mixed>')
+            ],
         ];
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| Doc updated   | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes (added tests)
| Fixed tickets | n/a
| License       | MIT

This PR adds support for type `mixed` in serializer type annotations.
It is particularly useful when configuring arrays, when you want to explicitly configure associative array of mixed values - `array<string, mixed>`, or when you want to serialize an associative array as simple indexed array - `array<mixed>.
Setting `mixed` type to a property is the same as no type at all.