### PR TITLE
Discriminator property serialization when parent is in discriminator map for v1

### DIFF
--- a/src/JMS/Serializer/Metadata/ClassMetadata.php
+++ b/src/JMS/Serializer/Metadata/ClassMetadata.php
@@ -309,7 +309,6 @@ class ClassMetadata extends MergeableClassMetadata
             $discriminatorProperty->xmlNamespace = $this->xmlDiscriminatorNamespace;
             $this->propertyMetadata[$this->discriminatorFieldName] = $discriminatorProperty;
         }
-
     }
 
     private function sortProperties()

--- a/src/JMS/Serializer/Metadata/ClassMetadata.php
+++ b/src/JMS/Serializer/Metadata/ClassMetadata.php
@@ -268,20 +268,22 @@ class ClassMetadata extends MergeableClassMetadata
 
     private function handleDiscriminatorProperty()
     {
-        if (
-            $this->discriminatorMap
-            && !$this->reflection->isAbstract()
-            && !$this->reflection->isInterface()
-        ) {
-            if (
-                false === ($typeValue = array_search($this->name, $this->discriminatorMap, true))
-                && $this->discriminatorBaseClass !== $this->name
-            ) {
-                throw new \LogicException(sprintf(
-                    'The sub-class "%s" is not listed in the discriminator of the base class "%s".',
-                    $this->name,
-                    $this->discriminatorBaseClass
-                ));
+        if ($this->discriminatorMap && !$this->reflection->isAbstract() && !$this->reflection->isInterface()) {
+            if (false === $typeValue = array_search($this->name, $this->discriminatorMap, true)) {
+                if ($this->discriminatorBaseClass === $this->name) {
+                    @trigger_error(
+                        'Discriminator map was configured on non-abstract parent class but parent class'
+                        .' was not included into discriminator map. It will throw exception in next major version.'
+                        .' Either declare parent as abstract class or add it into discriminator map.',
+                        E_USER_DEPRECATED
+                    );
+                } else {
+                    throw new \LogicException(sprintf(
+                        'The sub-class "%s" is not listed in the discriminator of the base class "%s".',
+                        $this->name,
+                        $this->discriminatorBaseClass
+                    ));
+                }
             }
 
             $this->discriminatorValue = $typeValue;

--- a/src/JMS/Serializer/Metadata/ClassMetadata.php
+++ b/src/JMS/Serializer/Metadata/ClassMetadata.php
@@ -61,6 +61,8 @@ class ClassMetadata extends MergeableClassMetadata
         $this->discriminatorFieldName = $fieldName;
         $this->discriminatorMap = $map;
         $this->discriminatorGroups = $groups;
+
+        $this->handleDiscriminatorProperty();
     }
 
     /**
@@ -167,40 +169,7 @@ class ClassMetadata extends MergeableClassMetadata
             $this->discriminatorBaseClass = $object->discriminatorBaseClass;
         }
 
-        if ($this->discriminatorMap && !$this->reflection->isAbstract()) {
-            if (false === $typeValue = array_search($this->name, $this->discriminatorMap, true)) {
-                throw new \LogicException(sprintf(
-                    'The sub-class "%s" is not listed in the discriminator of the base class "%s".',
-                    $this->name,
-                    $this->discriminatorBaseClass
-                ));
-            }
-
-            $this->discriminatorValue = $typeValue;
-
-            if (isset($this->propertyMetadata[$this->discriminatorFieldName])
-                && !$this->propertyMetadata[$this->discriminatorFieldName] instanceof StaticPropertyMetadata
-            ) {
-                throw new \LogicException(sprintf(
-                    'The discriminator field name "%s" of the base-class "%s" conflicts with a regular property of the sub-class "%s".',
-                    $this->discriminatorFieldName,
-                    $this->discriminatorBaseClass,
-                    $this->name
-                ));
-            }
-
-            $discriminatorProperty = new StaticPropertyMetadata(
-                $this->name,
-                $this->discriminatorFieldName,
-                $typeValue,
-                $this->discriminatorGroups
-            );
-            $discriminatorProperty->serializedName = $this->discriminatorFieldName;
-            $discriminatorProperty->xmlAttribute = $this->xmlDiscriminatorAttribute;
-            $discriminatorProperty->xmlElementCData = $this->xmlDiscriminatorCData;
-            $discriminatorProperty->xmlNamespace = $this->xmlDiscriminatorNamespace;
-            $this->propertyMetadata[$this->discriminatorFieldName] = $discriminatorProperty;
-        }
+        $this->handleDiscriminatorProperty();
 
         $this->sortProperties();
     }
@@ -295,6 +264,52 @@ class ClassMetadata extends MergeableClassMetadata
         }
 
         parent::unserialize($parentStr);
+    }
+
+    private function handleDiscriminatorProperty()
+    {
+        if (
+            $this->discriminatorMap
+            && !$this->reflection->isAbstract()
+            && !$this->reflection->isInterface()
+        ) {
+            if (
+                false === ($typeValue = array_search($this->name, $this->discriminatorMap, true))
+                && $this->discriminatorBaseClass !== $this->name
+            ) {
+                throw new \LogicException(sprintf(
+                    'The sub-class "%s" is not listed in the discriminator of the base class "%s".',
+                    $this->name,
+                    $this->discriminatorBaseClass
+                ));
+            }
+
+            $this->discriminatorValue = $typeValue;
+
+            if (isset($this->propertyMetadata[$this->discriminatorFieldName])
+                && !$this->propertyMetadata[$this->discriminatorFieldName] instanceof StaticPropertyMetadata
+            ) {
+                throw new \LogicException(sprintf(
+                    'The discriminator field name "%s" of the base-class "%s" conflicts with a regular property of the sub-class "%s".',
+                    $this->discriminatorFieldName,
+                    $this->discriminatorBaseClass,
+                    $this->name
+                ));
+            }
+
+            $discriminatorProperty = new StaticPropertyMetadata(
+                $this->name,
+                $this->discriminatorFieldName,
+                $typeValue,
+                $this->discriminatorGroups
+            );
+            $discriminatorProperty->serializedName = $this->discriminatorFieldName;
+            $discriminatorProperty->xmlAttribute = $this->xmlDiscriminatorAttribute;
+            $discriminatorProperty->xmlElementCData = $this->xmlDiscriminatorCData;
+            $discriminatorProperty->xmlNamespace = $this->xmlDiscriminatorNamespace;
+            $this->propertyMetadata[$this->discriminatorFieldName] = $discriminatorProperty;
+        }
+
     }
 
     private function sortProperties()

--- a/tests/Fixtures/Discriminator/ImagePost.php
+++ b/tests/Fixtures/Discriminator/ImagePost.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace JMS\Serializer\Tests\Fixtures\Discriminator;
+
+class ImagePost extends Post
+{
+}

--- a/tests/Fixtures/Discriminator/ImagePost.php
+++ b/tests/Fixtures/Discriminator/ImagePost.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 namespace JMS\Serializer\Tests\Fixtures\Discriminator;
 
 class ImagePost extends Post

--- a/tests/Fixtures/Discriminator/Post.php
+++ b/tests/Fixtures/Discriminator/Post.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace JMS\Serializer\Tests\Fixtures\Discriminator;
+
+use JMS\Serializer\Annotation as Serializer;
+
+/**
+ * @Serializer\Discriminator(field = "type", map = {
+ *    "post": "JMS\Serializer\Tests\Fixtures\Discriminator\Post",
+ *    "image_post": "JMS\Serializer\Tests\Fixtures\Discriminator\ImagePost",
+ * })
+ */
+class Post
+{
+    /** @Serializer\Type("string") */
+    public $title;
+
+    public function __construct(string $title)
+    {
+        $this->title = $title;
+    }
+}

--- a/tests/Fixtures/Discriminator/Post.php
+++ b/tests/Fixtures/Discriminator/Post.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 namespace JMS\Serializer\Tests\Fixtures\Discriminator;
 
 use JMS\Serializer\Annotation as Serializer;
@@ -17,7 +15,7 @@ class Post
     /** @Serializer\Type("string") */
     public $title;
 
-    public function __construct(string $title)
+    public function __construct($title)
     {
         $this->title = $title;
     }

--- a/tests/Metadata/Driver/BaseDriverTest.php
+++ b/tests/Metadata/Driver/BaseDriverTest.php
@@ -183,6 +183,23 @@ abstract class BaseDriverTest extends \PHPUnit_Framework_TestCase
         );
     }
 
+    public function testLoadDiscriminatorWhenParentIsInDiscriminatorMap()
+    {
+        /** @var ClassMetadata $m */
+        $m = $this->getDriver()->loadMetadataForClass(new \ReflectionClass('JMS\Serializer\Tests\Fixtures\Discriminator\Post'));
+
+        self::assertNotNull($m);
+        self::assertEquals('type', $m->discriminatorFieldName);
+        self::assertEquals($m->name, $m->discriminatorBaseClass);
+        self::assertEquals(
+            [
+                'post' => 'JMS\Serializer\Tests\Fixtures\Discriminator\Post',
+                'image_post' => 'JMS\Serializer\Tests\Fixtures\Discriminator\ImagePost',
+            ],
+            $m->discriminatorMap
+        );
+    }
+
     public function testLoadXmlDiscriminator()
     {
         /** @var $m ClassMetadata */
@@ -279,6 +296,18 @@ abstract class BaseDriverTest extends \PHPUnit_Framework_TestCase
         $this->assertNull($m->discriminatorBaseClass);
         $this->assertNull($m->discriminatorFieldName);
         $this->assertEquals(array(), $m->discriminatorMap);
+    }
+
+    public function testLoadDiscriminatorSubClassWhenParentIsInDiscriminatorMap()
+    {
+        /** @var ClassMetadata $m */
+        $m = $this->getDriver()->loadMetadataForClass(new \ReflectionClass('JMS\Serializer\Tests\Fixtures\Discriminator\ImagePost'));
+
+        self::assertNotNull($m);
+        self::assertNull($m->discriminatorValue);
+        self::assertNull($m->discriminatorBaseClass);
+        self::assertNull($m->discriminatorFieldName);
+        self::assertEquals([], $m->discriminatorMap);
     }
 
     public function testLoadXmlObjectWithNamespacesMetadata()

--- a/tests/Metadata/Driver/php/Discriminator.ImagePost.php
+++ b/tests/Metadata/Driver/php/Discriminator.ImagePost.php
@@ -1,0 +1,7 @@
+<?php
+
+use JMS\Serializer\Metadata\ClassMetadata;
+
+$metadata = new ClassMetadata('JMS\Serializer\Tests\Fixtures\Discriminator\ImagePost');
+
+return $metadata;

--- a/tests/Metadata/Driver/php/Discriminator.Post.php
+++ b/tests/Metadata/Driver/php/Discriminator.Post.php
@@ -1,0 +1,16 @@
+<?php
+
+use JMS\Serializer\Metadata\ClassMetadata;
+use JMS\Serializer\Metadata\PropertyMetadata;
+
+$metadata = new ClassMetadata('JMS\Serializer\Tests\Fixtures\Discriminator\Post');
+$metadata->setDiscriminator('type', array(
+    'post' => 'JMS\Serializer\Tests\Fixtures\Discriminator\Post',
+    'image_post' => 'JMS\Serializer\Tests\Fixtures\Discriminator\ImagePost',
+));
+
+$title = new PropertyMetadata('JMS\Serializer\Tests\Fixtures\Discriminator\Post', 'title');
+$title->setType('string');
+$metadata->addPropertyMetadata($title);
+
+return $metadata;

--- a/tests/Metadata/Driver/xml/Discriminator.ImagePost.xml
+++ b/tests/Metadata/Driver/xml/Discriminator.ImagePost.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<serializer>
+    <class name="JMS\Serializer\Tests\Fixtures\Discriminator\ImagePost">
+    </class>
+</serializer>

--- a/tests/Metadata/Driver/xml/Discriminator.Post.xml
+++ b/tests/Metadata/Driver/xml/Discriminator.Post.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<serializer>
+    <class name="JMS\Serializer\Tests\Fixtures\Discriminator\Post" discriminator-field-name="type">
+        <discriminator-class value="post">JMS\Serializer\Tests\Fixtures\Discriminator\Post</discriminator-class>
+        <discriminator-class value="image_post">JMS\Serializer\Tests\Fixtures\Discriminator\ImagePost</discriminator-class>
+        <property name="title" type="string" />
+    </class>
+</serializer>

--- a/tests/Metadata/Driver/yml/Discriminator.ImagePost.yml
+++ b/tests/Metadata/Driver/yml/Discriminator.ImagePost.yml
@@ -1,0 +1,1 @@
+JMS\Serializer\Tests\Fixtures\Discriminator\ImagePost: { }

--- a/tests/Metadata/Driver/yml/Discriminator.Post.yml
+++ b/tests/Metadata/Driver/yml/Discriminator.Post.yml
@@ -1,0 +1,10 @@
+JMS\Serializer\Tests\Fixtures\Discriminator\Post:
+    discriminator:
+        field_name: type
+        map:
+            post: JMS\Serializer\Tests\Fixtures\Discriminator\Post
+            image_post: JMS\Serializer\Tests\Fixtures\Discriminator\ImagePost
+
+    properties:
+        title:
+            type: string

--- a/tests/Serializer/BaseSerializationTest.php
+++ b/tests/Serializer/BaseSerializationTest.php
@@ -47,7 +47,9 @@ use JMS\Serializer\Tests\Fixtures\CurrencyAwarePrice;
 use JMS\Serializer\Tests\Fixtures\CustomDeserializationObject;
 use JMS\Serializer\Tests\Fixtures\DateTimeArraysObject;
 use JMS\Serializer\Tests\Fixtures\Discriminator\Car;
+use JMS\Serializer\Tests\Fixtures\Discriminator\ImagePost;
 use JMS\Serializer\Tests\Fixtures\Discriminator\Moped;
+use JMS\Serializer\Tests\Fixtures\Discriminator\Post;
 use JMS\Serializer\Tests\Fixtures\Garage;
 use JMS\Serializer\Tests\Fixtures\GetSetObject;
 use JMS\Serializer\Tests\Fixtures\GroupsObject;
@@ -1237,6 +1239,14 @@ abstract class BaseSerializationTest extends \PHPUnit_Framework_TestCase
             $this->getContent('car'),
             $this->serialize(new Car(5))
         );
+        self::assertEquals(
+            $this->getContent('post'),
+            $this->serialize(new Post('Post Title'))
+        );
+        self::assertEquals(
+            $this->getContent('image_post'),
+            $this->serialize(new ImagePost('Image Post Title'))
+        );
 
         if ($this->hasDeserializer()) {
             $this->assertEquals(
@@ -1262,6 +1272,33 @@ abstract class BaseSerializationTest extends \PHPUnit_Framework_TestCase
                 $this->deserialize(
                     $this->getContent('car_without_type'),
                     'JMS\Serializer\Tests\Fixtures\Discriminator\Car'
+                ),
+                'Class is resolved correctly when concrete sub-class is used and no type is defined.'
+            );
+
+            self::assertEquals(
+                new Post('Post Title'),
+                $this->deserialize(
+                    $this->getContent('post'),
+                    'JMS\Serializer\Tests\Fixtures\Discriminator\Post'
+                ),
+                'Class is resolved correctly when parent class is used and type is set.'
+            );
+
+            self::assertEquals(
+                new ImagePost('Image Post Title'),
+                $this->deserialize(
+                    $this->getContent('image_post'),
+                    'JMS\Serializer\Tests\Fixtures\Discriminator\Post'
+                ),
+                'Class is resolved correctly when least supertype is used.'
+            );
+
+            self::assertEquals(
+                new ImagePost('Image Post Title'),
+                $this->deserialize(
+                    $this->getContent('image_post'),
+                    'JMS\Serializer\Tests\Fixtures\Discriminator\ImagePost'
                 ),
                 'Class is resolved correctly when concrete sub-class is used and no type is defined.'
             );

--- a/tests/Serializer/JsonSerializationTest.php
+++ b/tests/Serializer/JsonSerializationTest.php
@@ -93,6 +93,9 @@ class JsonSerializationTest extends BaseSerializationTest
             $outputs['date_interval'] = '"PT45M"';
             $outputs['car'] = '{"km":5,"type":"car"}';
             $outputs['car_without_type'] = '{"km":5}';
+            $outputs['post'] = '{"type":"post","title":"Post Title"}';
+            $outputs['image_post'] = '{"type":"image_post","title":"Image Post Title"}';
+            $outputs['image_post_without_type'] = '{"title":"Image Post Title"}';
             $outputs['garage'] = '{"vehicles":[{"km":3,"type":"car"},{"km":1,"type":"moped"}]}';
             $outputs['tree'] = '{"tree":{"children":[{"children":[{"children":[],"foo":"bar"}],"foo":"bar"}],"foo":"bar"}}';
             $outputs['nullable_arrays'] = '{"empty_inline":[],"not_empty_inline":["not_empty_inline"],"empty_not_inline":[],"not_empty_not_inline":["not_empty_not_inline"],"empty_not_inline_skip":[],"not_empty_not_inline_skip":["not_empty_not_inline_skip"]}';

--- a/tests/Serializer/xml/image_post.xml
+++ b/tests/Serializer/xml/image_post.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<result>
+  <type><![CDATA[image_post]]></type>
+  <title><![CDATA[Image Post Title]]></title>
+</result>

--- a/tests/Serializer/xml/image_post_without_type.xml
+++ b/tests/Serializer/xml/image_post_without_type.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<result>
+  <title><![CDATA[Image Post Title]]></title>
+</result>

--- a/tests/Serializer/xml/post.xml
+++ b/tests/Serializer/xml/post.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<result>
+  <type><![CDATA[post]]></type>
+  <title><![CDATA[Post Title]]></title>
+</result>

--- a/tests/Serializer/yml/image_post.yml
+++ b/tests/Serializer/yml/image_post.yml
@@ -1,0 +1,2 @@
+type: image_post
+title: 'Image Post Title'

--- a/tests/Serializer/yml/image_post_without_type.yml
+++ b/tests/Serializer/yml/image_post_without_type.yml
@@ -1,0 +1,1 @@
+title: 'Image Post Title'

--- a/tests/Serializer/yml/post.yml
+++ b/tests/Serializer/yml/post.yml
@@ -1,0 +1,2 @@
+type: post
+title: 'Post Title'


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Doc updated   | n/a
| BC breaks?    | no
| Deprecations? | yes
| Tests pass?   | yes (added tests)
| Fixed tickets | n/a
| License       | MIT

This is backwards compatible version of #879. It fixes the issue - parent class' discriminator field will be properly serialized, when it's included into discriminator map. But it won't throw an exception if parent class is non-abstract and not included into discriminator map, deprecation notice will be triggered instead.