### PR TITLE
Use reStructuredText link format

### DIFF
--- a/doc/cookbook/exclusion_strategies.rst
+++ b/doc/cookbook/exclusion_strategies.rst
@@ -310,7 +310,7 @@ To enable this feature you have to set the Expression Evaluator when initializin
 
 .. _symfony expression language: https://github.com/symfony/expression-language
 
-By default the serializer exposes three variables (`object`, `context` and `property_metadata` for use in an expression. This enables you to create custom exclusion strategies similar to i.e. the [GroupExclusionStrategy](https://github.com/schmittjoh/serializer/blob/master/src/Exclusion/GroupsExclusionStrategy.php). In the below example, `someMethod` would receive all three variables.
+By default the serializer exposes three variables (`object`, `context` and `property_metadata` for use in an expression. This enables you to create custom exclusion strategies similar to i.e. the `GroupExclusionStrategy`_. In the below example, `someMethod` would receive all three variables.
 
 .. code-block :: php
 
@@ -328,3 +328,5 @@ By default the serializer exposes three variables (`object`, `context` and `prop
          */
         private $name2;
     }
+
+.. _GroupExclusionStrategy: https://github.com/schmittjoh/serializer/blob/master/src/Exclusion/GroupsExclusionStrategy.php


### PR DESCRIPTION
Hi,

Noticed that the link in the diff was using the Markdown syntax and not being displayed correctly. This PR changes it to the reStructuredText format (copied from an example in another part of this same file).

Diff on GitHub displays the link working as expected.

Thanks!
Bruno

| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| Doc updated   | yes
| BC breaks?    | no <!-- don't forget updating UPGRADING.md file -->
| Deprecations? | no <!-- don't forget updating UPGRADING.md file -->
| Tests pass?   | yes
| Fixed tickets | #... <!-- #-prefixed issue number(s), if any -->
| License       | MIT

