### PR TITLE
Change URL to the documentation of 1.x

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
 Serializer [![Scrutinizer Quality Score](https://scrutinizer-ci.com/g/schmittjoh/serializer/badges/quality-score.png?s=189df68e00c75d3fe155bc0da0b53b53709a9895)](https://scrutinizer-ci.com/g/schmittjoh/serializer/) [![Build Status](https://travis-ci.org/schmittjoh/serializer.svg?branch=master)](https://travis-ci.org/schmittjoh/serializer)
 ==========
 
-Learn more about it in its [documentation](http://jmsyst.com/libs/serializer).
+Learn more about it in its [documentation](http://jmsyst.com/libs/serializer/1.x).


### PR DESCRIPTION
Actual URL goes to the master documentation instead of the 1.x documentation and can be confusing if someone doesn't notice of that.

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Doc updated   | no
| BC breaks?    | no <!-- don't forget updating UPGRADING.md file -->
| Deprecations? | no <!-- don't forget updating UPGRADING.md file -->
| Tests pass?   | yes/no
| License       | MIT

