### PR TITLE
Add compilable expression language

### DIFF
--- a/src/Builder/DefaultDriverFactory.php
+++ b/src/Builder/DefaultDriverFactory.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace JMS\Serializer\Builder;
 
 use Doctrine\Common\Annotations\Reader;
+use JMS\Serializer\Expression\CompilableExpressionEvaluatorInterface;
 use JMS\Serializer\Metadata\Driver\AnnotationDriver;
 use JMS\Serializer\Metadata\Driver\XmlDriver;
 use JMS\Serializer\Metadata\Driver\YamlDriver;
@@ -21,15 +22,22 @@ final class DefaultDriverFactory implements DriverFactoryInterface
      * @var ParserInterface
      */
     private $typeParser;
+
     /**
      * @var PropertyNamingStrategyInterface
      */
     private $propertyNamingStrategy;
 
-    public function __construct(PropertyNamingStrategyInterface $propertyNamingStrategy, ?ParserInterface $typeParser = null)
+    /**
+     * @var CompilableExpressionEvaluatorInterface
+     */
+    private $expressionEvaluator;
+
+    public function __construct(PropertyNamingStrategyInterface $propertyNamingStrategy, ?ParserInterface $typeParser = null, ?CompilableExpressionEvaluatorInterface $expressionEvaluator = null)
     {
         $this->typeParser = $typeParser ?: new Parser();
         $this->propertyNamingStrategy = $propertyNamingStrategy;
+        $this->expressionEvaluator = $expressionEvaluator;
     }
 
     public function createDriver(array $metadataDirs, Reader $annotationReader): DriverInterface
@@ -38,9 +46,9 @@ final class DefaultDriverFactory implements DriverFactoryInterface
             $fileLocator = new FileLocator($metadataDirs);
 
             return new DriverChain([
-                new YamlDriver($fileLocator, $this->propertyNamingStrategy, $this->typeParser),
-                new XmlDriver($fileLocator, $this->propertyNamingStrategy, $this->typeParser),
-                new AnnotationDriver($annotationReader, $this->propertyNamingStrategy, $this->typeParser),
+                new YamlDriver($fileLocator, $this->propertyNamingStrategy, $this->typeParser, $this->expressionEvaluator),
+                new XmlDriver($fileLocator, $this->propertyNamingStrategy, $this->typeParser, $this->expressionEvaluator),
+                new AnnotationDriver($annotationReader, $this->propertyNamingStrategy, $this->typeParser, $this->expressionEvaluator),
             ]);
         }
 

--- a/src/Exclusion/ExpressionLanguageExclusionStrategy.php
+++ b/src/Exclusion/ExpressionLanguageExclusionStrategy.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 namespace JMS\Serializer\Exclusion;
 
 use JMS\Serializer\Context;
+use JMS\Serializer\Expression\CompilableExpressionEvaluatorInterface;
+use JMS\Serializer\Expression\Expression;
 use JMS\Serializer\Expression\ExpressionEvaluatorInterface;
 use JMS\Serializer\Metadata\PropertyMetadata;
 use JMS\Serializer\SerializationContext;
@@ -46,6 +48,10 @@ final class ExpressionLanguageExclusionStrategy
             $variables['object'] = $navigatorContext->getObject();
         } else {
             $variables['object'] = null;
+        }
+
+        if (($property->excludeIf instanceof Expression) && ($this->expressionEvaluator instanceof CompilableExpressionEvaluatorInterface)) {
+            return $this->expressionEvaluator->evaluateParsed($property->excludeIf, $variables);
         }
 
         return $this->expressionEvaluator->evaluate($property->excludeIf, $variables);

--- a/src/Expression/CompilableExpressionEvaluatorInterface.php
+++ b/src/Expression/CompilableExpressionEvaluatorInterface.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace JMS\Serializer\Expression;
+
+/**
+ * @author Asmir Mustafic <goetas@gmail.com>
+ */
+interface CompilableExpressionEvaluatorInterface extends ExpressionEvaluatorInterface
+{
+    public function parse(string $expression, array $names = []): Expression;
+
+    /**
+     * @return mixed
+     */
+    public function evaluateParsed(Expression $expression, array $data = []);
+}

--- a/src/Expression/CompilableExpressionEvaluatorInterface.php
+++ b/src/Expression/CompilableExpressionEvaluatorInterface.php
@@ -7,7 +7,7 @@ namespace JMS\Serializer\Expression;
 /**
  * @author Asmir Mustafic <goetas@gmail.com>
  */
-interface CompilableExpressionEvaluatorInterface extends ExpressionEvaluatorInterface
+interface CompilableExpressionEvaluatorInterface
 {
     public function parse(string $expression, array $names = []): Expression;
 

--- a/src/Expression/Expression.php
+++ b/src/Expression/Expression.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+namespace JMS\Serializer\Expression;
+
+use Symfony\Component\ExpressionLanguage\ParsedExpression as BaseExpression;
+use Symfony\Component\ExpressionLanguage\SerializedParsedExpression;
+
+/**
+ * @author Asmir Mustafic <goetas@gmail.com>
+ */
+class Expression implements \Serializable
+{
+    /**
+     * @var BaseExpression
+     */
+    private $expression;
+
+    public function __construct(BaseExpression $expression)
+    {
+        $this->expression = $expression;
+    }
+
+    public function getExpression(): BaseExpression
+    {
+        return $this->expression;
+    }
+
+    /**
+     * @return string
+     *
+     * @phpcsSuppress SlevomatCodingStandard.TypeHints.TypeHintDeclaration.MissingReturnTypeHint
+     * @phpcsSuppress SlevomatCodingStandard.TypeHints.TypeHintDeclaration.UselessReturnAnnotation
+     */
+    public function __toString()
+    {
+        return (string) $this->expression;
+    }
+
+    /**
+     * @return string
+     *
+     * @phpcsSuppress SlevomatCodingStandard.TypeHints.TypeHintDeclaration.MissingParameterTypeHint
+     * @phpcsSuppress SlevomatCodingStandard.TypeHints.TypeHintDeclaration.MissingReturnTypeHint
+     * @phpcsSuppress SlevomatCodingStandard.TypeHints.TypeHintDeclaration.UselessReturnAnnotation
+     */
+    public function serialize()
+    {
+        return serialize([(string) $this->expression, serialize($this->expression->getNodes())]);
+    }
+
+    /**
+     * @param string $str
+     *
+     * @return void
+     *
+     * @phpcsSuppress SlevomatCodingStandard.TypeHints.TypeHintDeclaration.MissingParameterTypeHint
+     * @phpcsSuppress SlevomatCodingStandard.TypeHints.TypeHintDeclaration.MissingReturnTypeHint
+     * @phpcsSuppress SlevomatCodingStandard.TypeHints.TypeHintDeclaration.UselessReturnAnnotation
+     */
+    public function unserialize($str): void
+    {
+        $this->expression = new SerializedParsedExpression(...unserialize($str));
+    }
+}

--- a/src/Expression/ExpressionEvaluator.php
+++ b/src/Expression/ExpressionEvaluator.php
@@ -9,7 +9,7 @@ use Symfony\Component\ExpressionLanguage\ExpressionLanguage;
 /**
  * @author Asmir Mustafic <goetas@gmail.com>
  */
-class ExpressionEvaluator implements CompilableExpressionEvaluatorInterface
+class ExpressionEvaluator implements CompilableExpressionEvaluatorInterface, ExpressionEvaluatorInterface
 {
     /**
      * @var ExpressionLanguage

--- a/src/Expression/ExpressionEvaluatorInterface.php
+++ b/src/Expression/ExpressionEvaluatorInterface.php
@@ -10,8 +10,6 @@ namespace JMS\Serializer\Expression;
 interface ExpressionEvaluatorInterface
 {
     /**
-     * @param  array $data
-     *
      * @return mixed
      */
     public function evaluate(string $expression, array $data = []);

--- a/src/Metadata/Driver/ExpressionMetadataTrait.php
+++ b/src/Metadata/Driver/ExpressionMetadataTrait.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace JMS\Serializer\Metadata\Driver;
+
+use JMS\Serializer\Exception\InvalidMetadataException;
+use JMS\Serializer\Expression\CompilableExpressionEvaluatorInterface;
+use JMS\Serializer\Expression\Expression;
+
+trait ExpressionMetadataTrait
+{
+    /**
+     * @var CompilableExpressionEvaluatorInterface
+     */
+    private $expressionEvaluator;
+
+    /**
+     * @return Expression|string
+     *
+     * @throws InvalidMetadataException
+     */
+    private function parseExpression(string $expression, array $names = [])
+    {
+        if (null === $this->expressionEvaluator) {
+            return $expression;
+        }
+
+        try {
+            return $this->expressionEvaluator->parse($expression, array_merge(['context', 'property_metadata', 'object'], $names));
+        } catch (\LogicException $e) {
+            throw new InvalidMetadataException(sprintf('Can not parse the expression "%s"', $expression), 0, $e);
+        }
+    }
+}

--- a/src/Metadata/ExpressionPropertyMetadata.php
+++ b/src/Metadata/ExpressionPropertyMetadata.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace JMS\Serializer\Metadata;
 
+use JMS\Serializer\Expression\Expression;
+
 /**
  * @Annotation
  * @Target("METHOD")
@@ -13,11 +15,14 @@ namespace JMS\Serializer\Metadata;
 class ExpressionPropertyMetadata extends PropertyMetadata
 {
     /**
-     * @var string
+     * @var string|Expression
      */
     public $expression;
 
-    public function __construct(string $class, string $fieldName, string $expression)
+    /**
+     * @param string|Expression $expression
+     */
+    public function __construct(string $class, string $fieldName, $expression)
     {
         $this->class = $class;
         $this->name = $fieldName;

--- a/src/SerializerBuilder.php
+++ b/src/SerializerBuilder.php
@@ -23,6 +23,7 @@ use JMS\Serializer\EventDispatcher\EventDispatcherInterface;
 use JMS\Serializer\EventDispatcher\Subscriber\DoctrineProxySubscriber;
 use JMS\Serializer\Exception\InvalidArgumentException;
 use JMS\Serializer\Exception\RuntimeException;
+use JMS\Serializer\Expression\CompilableExpressionEvaluatorInterface;
 use JMS\Serializer\Expression\ExpressionEvaluatorInterface;
 use JMS\Serializer\GraphNavigator\Factory\DeserializationGraphNavigatorFactory;
 use JMS\Serializer\GraphNavigator\Factory\GraphNavigatorFactoryInterface;
@@ -511,7 +512,11 @@ final class SerializerBuilder
 
         if (null === $this->driverFactory) {
             $this->initializePropertyNamingStrategy();
-            $this->driverFactory = new DefaultDriverFactory($this->propertyNamingStrategy, $this->typeParser);
+            $this->driverFactory = new DefaultDriverFactory(
+                $this->propertyNamingStrategy,
+                $this->typeParser,
+                $this->expressionEvaluator instanceof CompilableExpressionEvaluatorInterface ? $this->expressionEvaluator : null
+            );
         }
 
         $metadataDriver = $this->driverFactory->createDriver($this->metadataDirs, $annotationReader);

--- a/tests/Expression/ExpressionEvaluatorTest.php
+++ b/tests/Expression/ExpressionEvaluatorTest.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+namespace JMS\Serializer\Tests\Expression;
+
+use JMS\Serializer\Expression\Expression;
+use JMS\Serializer\Expression\ExpressionEvaluator;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\ExpressionLanguage\ExpressionLanguage;
+
+class ExpressionEvaluatorTest extends TestCase
+{
+    /**
+     * @var ExpressionEvaluator
+     */
+    private $evaluator;
+
+    public function setUp()
+    {
+        $this->evaluator = new ExpressionEvaluator(new ExpressionLanguage());
+    }
+
+    public function testEvaluate()
+    {
+        self::assertSame(3, $this->evaluator->evaluate('a + b', ['a' => 1, 'b' => 2]));
+    }
+
+    public function testParse()
+    {
+        $parsed = $this->evaluator->parse('a + b', ['a', 'b' ]);
+        self::assertInstanceOf(Expression::class, $parsed);
+
+        $evaluated = $this->evaluator->evaluateParsed($parsed, ['a' => 1, 'b' => 2]);
+        self::assertSame(3, $evaluated);
+    }
+
+    public function testParseWitPeSetVars()
+    {
+        $this->evaluator->setContextVariable('a', 1);
+        $parsed = $this->evaluator->parse('a + b', ['b']);
+
+        $evaluated = $this->evaluator->evaluateParsed($parsed, ['b' => 2]);
+        self::assertSame(3, $evaluated);
+    }
+
+    public function testParseWitPeSetVarsOverride()
+    {
+        $this->evaluator->setContextVariable('a', 1);
+        $parsed = $this->evaluator->parse('a + b', ['b']);
+
+        $evaluated = $this->evaluator->evaluateParsed($parsed, ['b' => 2, 'a' => 4]);
+        self::assertSame(6, $evaluated);
+    }
+
+    public function testCanBeSerialized()
+    {
+        $this->evaluator->setContextVariable('a', 1);
+        $parsed = $this->evaluator->parse('a + b', ['b']);
+
+        $serializedExpression = unserialize(serialize($parsed));
+
+        $evaluated = $this->evaluator->evaluateParsed($serializedExpression, ['b' => 2]);
+        self::assertSame(3, $evaluated);
+    }
+}

--- a/tests/Fixtures/ObjectWithInvalidExpression.php
+++ b/tests/Fixtures/ObjectWithInvalidExpression.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace JMS\Serializer\Tests\Fixtures;
+
+use JMS\Serializer\Annotation as Serializer;
+
+/**
+ * @Serializer\VirtualProperty(
+ *     "invalid",
+ *     exp="oinvalid"
+ * )
+ */
+class ObjectWithInvalidExpression
+{
+    /**
+     * @var @Serializer\Exclude(if="inval")
+     */
+    private $prop1;
+
+    /**
+     * @var @Serializer\Expose(if="invalid")
+     */
+    private $prop2;
+}

--- a/tests/Metadata/Driver/AnnotationDriverTest.php
+++ b/tests/Metadata/Driver/AnnotationDriverTest.php
@@ -12,7 +12,7 @@ class AnnotationDriverTest extends BaseDriverTest
 {
     protected function getDriver()
     {
-        return new AnnotationDriver(new AnnotationReader(), new IdenticalPropertyNamingStrategy());
+        return new AnnotationDriver(new AnnotationReader(), new IdenticalPropertyNamingStrategy(), null, $this->getExpressionEvaluator());
     }
 
     public function testCanDefineMetadataForInternalClass()

--- a/tests/Metadata/Driver/XmlDriverTest.php
+++ b/tests/Metadata/Driver/XmlDriverTest.php
@@ -97,6 +97,6 @@ class XmlDriverTest extends BaseDriverTest
         return new XmlDriver(new FileLocator([
             'JMS\Serializer\Tests\Fixtures' => __DIR__ . '/xml' . $append,
             '' => __DIR__ . '/xml/_' . $append,
-        ]), new IdenticalPropertyNamingStrategy());
+        ]), new IdenticalPropertyNamingStrategy(), null, $this->getExpressionEvaluator());
     }
 }

--- a/tests/Metadata/Driver/YamlDriverTest.php
+++ b/tests/Metadata/Driver/YamlDriverTest.php
@@ -77,7 +77,7 @@ class YamlDriverTest extends BaseDriverTest
         return new YamlDriver(new FileLocator([
             'JMS\Serializer\Tests\Fixtures' => __DIR__ . '/yml' . ($subDir ? '/' . $subDir : ''),
             '' => __DIR__ . '/yml/_' . ($subDir ? '/' . $subDir : ''),
-        ]), new IdenticalPropertyNamingStrategy());
+        ]), new IdenticalPropertyNamingStrategy(), null, $this->getExpressionEvaluator());
     }
 
     protected function getDriver()

--- a/tests/Metadata/Driver/xml/ObjectWithInvalidExpression.xml
+++ b/tests/Metadata/Driver/xml/ObjectWithInvalidExpression.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<serializer>
+    <class name="JMS\Serializer\Tests\Fixtures\ObjectWithInvalidExpression">
+        <property name="existField"  exclude-if="invalid"/>
+        <property name="existField"  exclude-if="invalid"/>
+        <virtual-property expression="invalid" />
+    </class>
+</serializer>

--- a/tests/Metadata/Driver/yml/ObjectWithInvalidExpression.yml
+++ b/tests/Metadata/Driver/yml/ObjectWithInvalidExpression.yml
@@ -1,0 +1,10 @@
+JMS\Serializer\Tests\Fixtures\ObjectWithInvalidExpression:
+    properties:
+        prop1:
+            exclude_if: invalid
+        prop2:
+            expose_if: invalid
+    virtual_properties:
+      invalid:
+        exp: invalid
+


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| Doc updated   | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT

Currently expression language is parsed when used for the first time. With this PR the parsing of the expression will be done only once when parsing the metadata.

~This PR for now just adds the expression language that supports the compilation, but does not modify any of the existing drivers to effectively add compilation.~

