### PR TITLE
when a typed array is missing, do not try to de-serialize it

### DIFF
--- a/src/JsonDeserializationVisitor.php
+++ b/src/JsonDeserializationVisitor.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace JMS\Serializer;
 
 use JMS\Serializer\Exception\LogicException;
+use JMS\Serializer\Exception\NotAcceptableException;
 use JMS\Serializer\Exception\RuntimeException;
 use JMS\Serializer\Metadata\ClassMetadata;
 use JMS\Serializer\Metadata\PropertyMetadata;
@@ -173,7 +174,7 @@ final class JsonDeserializationVisitor extends AbstractVisitor implements Deseri
         }
 
         if (!array_key_exists($name, $data)) {
-            return;
+            throw new NotAcceptableException();
         }
 
         if (!$metadata->type) {

--- a/tests/Fixtures/ObjectWithTypedArraySetter.php
+++ b/tests/Fixtures/ObjectWithTypedArraySetter.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace JMS\Serializer\Tests\Fixtures;
+
+use JMS\Serializer\Annotation as Serializer;
+
+class ObjectWithTypedArraySetter
+{
+    /**
+     * @Serializer\Type("array<string>")
+     * @Serializer\AccessType(type="public_method")
+     */
+    private $empty = [];
+
+    public function setEmpty(array $empty): void
+    {
+        $this->empty = $empty;
+    }
+
+    public function getEmpty(): array
+    {
+        return $this->empty;
+    }
+}

--- a/tests/Serializer/BaseSerializationTest.php
+++ b/tests/Serializer/BaseSerializationTest.php
@@ -75,6 +75,7 @@ use JMS\Serializer\Tests\Fixtures\ObjectWithIntListAndIntMap;
 use JMS\Serializer\Tests\Fixtures\ObjectWithLifecycleCallbacks;
 use JMS\Serializer\Tests\Fixtures\ObjectWithNullProperty;
 use JMS\Serializer\Tests\Fixtures\ObjectWithToString;
+use JMS\Serializer\Tests\Fixtures\ObjectWithTypedArraySetter;
 use JMS\Serializer\Tests\Fixtures\ObjectWithVersionedVirtualProperties;
 use JMS\Serializer\Tests\Fixtures\ObjectWithVirtualProperties;
 use JMS\Serializer\Tests\Fixtures\Order;
@@ -139,6 +140,20 @@ abstract class BaseSerializationTest extends TestCase
             $this->getContent('nullable'),
             $this->serializer->serialize($arr, $this->getFormat(), SerializationContext::create()->setSerializeNull(true))
         );
+    }
+
+    public function testDeserializeObjectWithMissingTypedArrayProp()
+    {
+        /** @var ObjectWithTypedArraySetter $dObj */
+        $dObj = $this->serializer->deserialize(
+            $this->getContent('empty_object'),
+            ObjectWithTypedArraySetter::class,
+            $this->getFormat()
+        );
+
+        self::assertInstanceOf(ObjectWithTypedArraySetter::class, $dObj);
+
+        self::assertSame([], $dObj->getEmpty());
     }
 
     public function testSerializeNullArrayExcludingNulls()

--- a/tests/Serializer/JsonSerializationTest.php
+++ b/tests/Serializer/JsonSerializationTest.php
@@ -117,6 +117,7 @@ class JsonSerializationTest extends BaseSerializationTest
             $outputs['inline_deserialization_list_collection'] = '[1,2]';
             $outputs['inline_map'] = '{"0":"1","1":"2","2":"3"}';
             $outputs['inline_empty_map'] = '{}';
+            $outputs['empty_object'] = '{}';
             $outputs['inline_deserialization_map'] = '{"a":"b","c":"d","0":"5"}';
         }
 

--- a/tests/Serializer/xml/empty_object.xml
+++ b/tests/Serializer/xml/empty_object.xml
@@ -1,0 +1,2 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<result/>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Doc updated   | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | https://github.com/schmittjoh/serializer/issues/1011
| License       | MIT

