### PR TITLE
allow empty strings and numbers as metadata type parameters

### DIFF
--- a/src/Type/InnerParser.php
+++ b/src/Type/InnerParser.php
@@ -25,17 +25,19 @@ final class InnerParser extends Parser
                     'skip' => '\s+',
                     'parenthesis_' => '<',
                     '_parenthesis' => '>',
+                    'empty_string' => '""|\'\'',
+                    'number' => '(\+|\-)?(0|[1-9]\d*)(\.\d+)?',
                     'comma' => ',',
                     'name' => '(?:[a-zA-Z_\x7f-\xff][a-zA-Z0-9_\x7f-\xff]*\\\)*[a-zA-Z_\x7f-\xff][a-zA-Z0-9_\x7f-\xff]*',
                     'quote_:quoted_string' => '"',
                     'apostrophe_:apostrophed_string' => '\'',
                 ],
                 'quoted_string' => [
-                    'quoted_string' => '(?:[^"]|"")+',
+                    'quoted_string' => '[^"]+',
                     '_quote:default' => '"',
                 ],
                 'apostrophed_string' => [
-                    'apostrophed_string' => '(?:[^\']|\'\')+',
+                    'apostrophed_string' => '[^\']+',
                     '_apostrophe:default' => '\'',
                 ],
             ],
@@ -43,29 +45,33 @@ final class InnerParser extends Parser
                 'type' => new Choice('type', ['simple_type', 'compound_type'], null),
                 1 => new Token(1, 'name', null, -1, true),
                 2 => new Concatenation(2, [1], '#simple_type'),
-                3 => new Token(3, 'quote_', null, -1, false),
-                4 => new Token(4, 'quoted_string', null, -1, true),
-                5 => new Token(5, '_quote', null, -1, false),
-                6 => new Concatenation(6, [3, 4, 5], '#simple_type'),
-                7 => new Token(7, 'apostrophe_', null, -1, false),
-                8 => new Token(8, 'apostrophed_string', null, -1, true),
-                9 => new Token(9, '_apostrophe', null, -1, false),
+                3 => new Token(3, 'number', null, -1, true),
+                4 => new Concatenation(4, [3], '#simple_type'),
+                5 => new Token(5, 'empty_string', null, -1, true),
+                6 => new Concatenation(6, [5], '#simple_type'),
+                7 => new Token(7, 'quote_', null, -1, false),
+                8 => new Token(8, 'quoted_string', null, -1, true),
+                9 => new Token(9, '_quote', null, -1, false),
                 10 => new Concatenation(10, [7, 8, 9], '#simple_type'),
-                'simple_type' => new Choice('simple_type', [2, 6, 10], null),
-                12 => new Token(12, 'name', null, -1, true),
-                13 => new Token(13, 'parenthesis_', null, -1, false),
-                14 => new Token(14, 'comma', null, -1, false),
-                15 => new Concatenation(15, [14, 'type'], '#compound_type'),
-                16 => new Repetition(16, 0, -1, 15, null),
-                17 => new Token(17, '_parenthesis', null, -1, false),
-                'compound_type' => new Concatenation('compound_type', [12, 13, 'type', 16, 17], null),
+                11 => new Token(11, 'apostrophe_', null, -1, false),
+                12 => new Token(12, 'apostrophed_string', null, -1, true),
+                13 => new Token(13, '_apostrophe', null, -1, false),
+                14 => new Concatenation(14, [11, 12, 13], '#simple_type'),
+                'simple_type' => new Choice('simple_type', [2, 4, 6, 10, 14], null),
+                16 => new Token(16, 'name', null, -1, true),
+                17 => new Token(17, 'parenthesis_', null, -1, false),
+                18 => new Token(18, 'comma', null, -1, false),
+                19 => new Concatenation(19, [18, 'type'], '#compound_type'),
+                20 => new Repetition(20, 0, -1, 19, null),
+                21 => new Token(21, '_parenthesis', null, -1, false),
+                'compound_type' => new Concatenation('compound_type', [16, 17, 'type', 20, 21], null),
             ],
             []
         );
 
         $this->getRule('type')->setPPRepresentation(' simple_type() | compound_type()');
         $this->getRule('simple_type')->setDefaultId('#simple_type');
-        $this->getRule('simple_type')->setPPRepresentation(' <name> | ::quote_:: <quoted_string> ::_quote:: | ::apostrophe_:: <apostrophed_string> ::_apostrophe::');
+        $this->getRule('simple_type')->setPPRepresentation(' <name> | <number> | <empty_string> | ::quote_:: <quoted_string> ::_quote:: | ::apostrophe_:: <apostrophed_string> ::_apostrophe::');
         $this->getRule('compound_type')->setDefaultId('#compound_type');
         $this->getRule('compound_type')->setPPRepresentation(' <name> ::parenthesis_:: type() ( ::comma:: type() )* ::_parenthesis::');
     }

--- a/src/Type/InnerParser.php
+++ b/src/Type/InnerParser.php
@@ -27,6 +27,7 @@ final class InnerParser extends Parser
                     '_parenthesis' => '>',
                     'empty_string' => '""|\'\'',
                     'number' => '(\+|\-)?(0|[1-9]\d*)(\.\d+)?',
+                    'null' => 'null',
                     'comma' => ',',
                     'name' => '(?:[a-zA-Z_\x7f-\xff][a-zA-Z0-9_\x7f-\xff]*\\\)*[a-zA-Z_\x7f-\xff][a-zA-Z0-9_\x7f-\xff]*',
                     'quote_:quoted_string' => '"',
@@ -47,31 +48,33 @@ final class InnerParser extends Parser
                 2 => new Concatenation(2, [1], '#simple_type'),
                 3 => new Token(3, 'number', null, -1, true),
                 4 => new Concatenation(4, [3], '#simple_type'),
-                5 => new Token(5, 'empty_string', null, -1, true),
+                5 => new Token(5, 'null', null, -1, true),
                 6 => new Concatenation(6, [5], '#simple_type'),
-                7 => new Token(7, 'quote_', null, -1, false),
-                8 => new Token(8, 'quoted_string', null, -1, true),
-                9 => new Token(9, '_quote', null, -1, false),
-                10 => new Concatenation(10, [7, 8, 9], '#simple_type'),
-                11 => new Token(11, 'apostrophe_', null, -1, false),
-                12 => new Token(12, 'apostrophed_string', null, -1, true),
-                13 => new Token(13, '_apostrophe', null, -1, false),
-                14 => new Concatenation(14, [11, 12, 13], '#simple_type'),
-                'simple_type' => new Choice('simple_type', [2, 4, 6, 10, 14], null),
-                16 => new Token(16, 'name', null, -1, true),
-                17 => new Token(17, 'parenthesis_', null, -1, false),
-                18 => new Token(18, 'comma', null, -1, false),
-                19 => new Concatenation(19, [18, 'type'], '#compound_type'),
-                20 => new Repetition(20, 0, -1, 19, null),
-                21 => new Token(21, '_parenthesis', null, -1, false),
-                'compound_type' => new Concatenation('compound_type', [16, 17, 'type', 20, 21], null),
+                7 => new Token(7, 'empty_string', null, -1, true),
+                8 => new Concatenation(8, [7], '#simple_type'),
+                9 => new Token(9, 'quote_', null, -1, false),
+                10 => new Token(10, 'quoted_string', null, -1, true),
+                11 => new Token(11, '_quote', null, -1, false),
+                12 => new Concatenation(12, [9, 10, 11], '#simple_type'),
+                13 => new Token(13, 'apostrophe_', null, -1, false),
+                14 => new Token(14, 'apostrophed_string', null, -1, true),
+                15 => new Token(15, '_apostrophe', null, -1, false),
+                16 => new Concatenation(16, [13, 14, 15], '#simple_type'),
+                'simple_type' => new Choice('simple_type', [2, 4, 6, 8, 12, 16], null),
+                18 => new Token(18, 'name', null, -1, true),
+                19 => new Token(19, 'parenthesis_', null, -1, false),
+                20 => new Token(20, 'comma', null, -1, false),
+                21 => new Concatenation(21, [20, 'type'], '#compound_type'),
+                22 => new Repetition(22, 0, -1, 21, null),
+                23 => new Token(23, '_parenthesis', null, -1, false),
+                'compound_type' => new Concatenation('compound_type', [18, 19, 'type', 22, 23], null),
             ],
             []
         );
 
         $this->getRule('type')->setPPRepresentation(' simple_type() | compound_type()');
         $this->getRule('simple_type')->setDefaultId('#simple_type');
-        $this->getRule('simple_type')->setPPRepresentation(' <name> | <number> | <empty_string> | ::quote_:: <quoted_string> ::_quote:: | ::apostrophe_:: <apostrophed_string> ::_apostrophe::');
+        $this->getRule('simple_type')->setPPRepresentation(' <name> | <number> | <null> | <empty_string> | ::quote_:: <quoted_string> ::_quote:: | ::apostrophe_:: <apostrophed_string> ::_apostrophe::');
         $this->getRule('compound_type')->setDefaultId('#compound_type');
         $this->getRule('compound_type')->setPPRepresentation(' <name> ::parenthesis_:: type() ( ::comma:: type() )* ::_parenthesis::');
     }

--- a/src/Type/TypeVisitor.php
+++ b/src/Type/TypeVisitor.php
@@ -44,6 +44,10 @@ final class TypeVisitor implements Visit
             return '';
         }
 
+        if ('null' === $token) {
+            return null;
+        }
+
         if ('number' === $token) {
             return false === strpos($value, '.') ? intval($value) : floatval($value);
         }

--- a/src/Type/TypeVisitor.php
+++ b/src/Type/TypeVisitor.php
@@ -40,6 +40,14 @@ final class TypeVisitor implements Visit
             return ['name' => $value, 'params' => []];
         }
 
+        if ('empty_string' === $token) {
+            return '';
+        }
+
+        if ('number' === $token) {
+            return false === strpos($value, '.') ? intval($value) : floatval($value);
+        }
+
         $escapeChar = 'quoted_string' === $token ? '"' : "'";
 
         if (false === strpos($value, $escapeChar)) {

--- a/src/Type/grammar.pp
+++ b/src/Type/grammar.pp
@@ -2,15 +2,17 @@
 
 %token parenthesis_ <
 %token _parenthesis >
+%token empty_string ""|''
+%token number        (\+|\-)?(0|[1-9]\d*)(\.\d+)?
 %token comma        ,
 %token name         (?:[a-zA-Z_\x7f-\xff][a-zA-Z0-9_\x7f-\xff]*\\)*[a-zA-Z_\x7f-\xff][a-zA-Z0-9_\x7f-\xff]*
 
 %token quote_                      "            -> quoted_string
-%token quoted_string:quoted_string (?:[^"]|"")+
+%token quoted_string:quoted_string [^"]+
 %token quoted_string:_quote        "            -> default
 
 %token apostrophe_                           '            -> apostrophed_string
-%token apostrophed_string:apostrophed_string (?:[^']|'')+
+%token apostrophed_string:apostrophed_string [^']+
 %token apostrophed_string:_apostrophe        '            -> default
 
 type:
@@ -18,6 +20,8 @@ type:
 
 #simple_type:
     <name>
+    | <number>
+    | <empty_string>
     | ::quote_:: <quoted_string> ::_quote::
     | ::apostrophe_:: <apostrophed_string> ::_apostrophe::
 

--- a/src/Type/grammar.pp
+++ b/src/Type/grammar.pp
@@ -4,6 +4,7 @@
 %token _parenthesis >
 %token empty_string ""|''
 %token number        (\+|\-)?(0|[1-9]\d*)(\.\d+)?
+%token null          null
 %token comma        ,
 %token name         (?:[a-zA-Z_\x7f-\xff][a-zA-Z0-9_\x7f-\xff]*\\)*[a-zA-Z_\x7f-\xff][a-zA-Z0-9_\x7f-\xff]*
 
@@ -21,6 +22,7 @@ type:
 #simple_type:
     <name>
     | <number>
+    | <null>
     | <empty_string>
     | ::quote_:: <quoted_string> ::_quote::
     | ::apostrophe_:: <apostrophed_string> ::_apostrophe::

--- a/tests/Serializer/Type/ParserTest.php
+++ b/tests/Serializer/Type/ParserTest.php
@@ -60,6 +60,10 @@ class ParserTest extends TestCase
             $type('Foo', [5.5]),
         ];
         yield [
+            'Foo<null>',
+            $type('Foo', [null]),
+        ];
+        yield [
             'Foo<\'a\',\'b\',\'c\'>',
             $type('Foo', ['a', 'b', 'c']),
         ];

--- a/tests/Serializer/Type/ParserTest.php
+++ b/tests/Serializer/Type/ParserTest.php
@@ -48,6 +48,26 @@ class ParserTest extends TestCase
             $type('array', [['name' => 'Foo', 'params' => []]]),
         ];
         yield [
+            'Foo<\'a\'>',
+            $type('Foo', ['a']),
+        ];
+        yield [
+            'Foo<5>',
+            $type('Foo', [5]),
+        ];
+        yield [
+            'Foo<5.5>',
+            $type('Foo', [5.5]),
+        ];
+        yield [
+            'Foo<\'a\',\'b\',\'c\'>',
+            $type('Foo', ['a', 'b', 'c']),
+        ];
+        yield [
+            'Foo<\'a\',\'\'>',
+            $type('Foo', ['a', '']),
+        ];
+        yield [
             'array<Foo,Bar>',
             $type('array', [['name' => 'Foo', 'params' => []], ['name' => 'Bar', 'params' => []]]),
         ];
@@ -71,14 +91,6 @@ class ParserTest extends TestCase
         yield [
             'Foo<"asdf asdf">',
             $type('Foo', ['asdf asdf']),
-        ];
-        yield [
-            'Foo<"""bar""">',
-            $type('Foo', ['"bar"']),
-        ];
-        yield [
-            "Foo<'a''b'>",
-            $type('Foo', ["a'b"]),
         ];
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Doc updated   | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | https://github.com/schmittjoh/JMSSerializerBundle/issues/706
| License       | MIT

@Majkl578 do you mind having a look at this?

