### PR TITLE
Fix for failing doctrine object constructor on embeddable class

### DIFF
--- a/src/Construction/DoctrineObjectConstructor.php
+++ b/src/Construction/DoctrineObjectConstructor.php
@@ -89,6 +89,12 @@ final class DoctrineObjectConstructor implements ObjectConstructorInterface
             $identifierList[$name] = $data[$dataName];
         }
 
+        if (empty($identifierList)) {
+            // $classMetadataFactory->isTransient() fails on embeddable class with file metadata driver
+            // https://github.com/doctrine/persistence/issues/37
+            return $this->fallbackConstructor->construct($visitor, $metadata, $data, $type, $context);
+        }
+
         // Entity update, load it from database
         $object = $objectManager->find($metadata->name, $identifierList);
 

--- a/tests/Fixtures/Doctrine/XmlMapping/JMS.Serializer.Tests.Fixtures.Doctrine.Embeddable.BlogPostSeo.dcm.xml
+++ b/tests/Fixtures/Doctrine/XmlMapping/JMS.Serializer.Tests.Fixtures.Doctrine.Embeddable.BlogPostSeo.dcm.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0"?>
+<doctrine-mapping xmlns="http://doctrine-project.org/schemas/orm/doctrine-mapping" xsi="http://www.w3.org/2001/XMLSchema-instance" schemaLocation="http://doctrine-project.org/schemas/orm/doctrine-mapping.xsd">
+  <embeddable name="JMS\Serializer\Tests\Fixtures\Doctrine\Embeddable\BlogPostSeo">
+    <field name="metaTitle" column="meta_title" type="string" nullable="false"/>
+  </embeddable>
+</doctrine-mapping>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Doc updated   | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | no
| License       | MIT

Actual issue is on doctrine/persistence component. I have registered an issue to them https://github.com/doctrine/persistence/issues/37
The case is that doctrine is using XML metadata driver returns isTransient() === false on embeddable class and this class could not be found in database as it has no identifiers.
I have added one additional check to ensure that we have identifier and test that uses different entity manager with XML metadata driver.