### PR TITLE
Fix result of code example

### DIFF
--- a/doc/cookbook/arrays.rst
+++ b/doc/cookbook/arrays.rst
@@ -39,7 +39,7 @@ In case of a JSON serialization:
     $serializer->serialize([], SerializationContext::create()->setInitialType('array<integer,integer>')); //  {}
     $serializer->serialize([1, 2], SerializationContext::create()->setInitialType('array<integer,integer>')); //  {"0" : 1, "1" : 2}
     $serializer->serialize(['a', 'b'], SerializationContext::create()->setInitialType('array<integer,integer>')); //  {"0" : "a", "1" : "b"}
-    $serializer->serialize(['c' => 'd'], SerializationContext::create()->setInitialType('array<string,string>')); //  {"d" : "d"}
+    $serializer->serialize(['c' => 'd'], SerializationContext::create()->setInitialType('array<string,string>')); //  {"c" : "d"}
 
 
 .. note ::


### PR DESCRIPTION
Fix result of last code example
$serializer->serialize(['c' => 'd'], SerializationContext::create()->setInitialType('array<string,string>')); should lead to the output //  {"c" : "d"}

| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| Doc updated   | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT

