### PR TITLE
Allow @Since and @Until within @VirtualProperty on class level

### DIFF
--- a/src/Annotation/Since.php
+++ b/src/Annotation/Since.php
@@ -6,7 +6,7 @@ namespace JMS\Serializer\Annotation;
 
 /**
  * @Annotation
- * @Target({"ALL"})
+ * @Target({"PROPERTY", "METHOD", "ANNOTATION"})
  */
 final class Since extends Version
 {

--- a/src/Annotation/Since.php
+++ b/src/Annotation/Since.php
@@ -6,7 +6,7 @@ namespace JMS\Serializer\Annotation;
 
 /**
  * @Annotation
- * @Target({"PROPERTY", "METHOD"})
+ * @Target({"ALL"})
  */
 final class Since extends Version
 {

--- a/src/Annotation/Until.php
+++ b/src/Annotation/Until.php
@@ -6,7 +6,7 @@ namespace JMS\Serializer\Annotation;
 
 /**
  * @Annotation
- * @Target({"PROPERTY", "METHOD"})
+ * @Target({"ALL"})
  */
 final class Until extends Version
 {

--- a/src/Annotation/Until.php
+++ b/src/Annotation/Until.php
@@ -6,7 +6,7 @@ namespace JMS\Serializer\Annotation;
 
 /**
  * @Annotation
- * @Target({"ALL"})
+ * @Target({"PROPERTY", "METHOD", "ANNOTATION"})
  */
 final class Until extends Version
 {

--- a/tests/Fixtures/ObjectWithVersionedVirtualProperties.php
+++ b/tests/Fixtures/ObjectWithVersionedVirtualProperties.php
@@ -12,6 +12,17 @@ use JMS\Serializer\Annotation\VirtualProperty;
 
 /**
  * dummy comment
+ *
+ * @VirtualProperty(
+ *     "classlow",
+ *     exp="object.getVirtualValue(1)",
+ *     options={@Until("8")}
+ * )
+ * @VirtualProperty(
+ *     "classhigh",
+ *     exp="object.getVirtualValue(8)",
+ *     options={@Since("6")}
+ * )
  */
 class ObjectWithVersionedVirtualProperties
 {
@@ -35,5 +46,15 @@ class ObjectWithVersionedVirtualProperties
     public function getVirualHighValue()
     {
         return 8;
+    }
+
+    /**
+     * @param int $int
+     *
+     * @return int
+     */
+    public function getVirtualValue($int)
+    {
+        return $int;
     }
 }

--- a/tests/Serializer/BaseSerializationTest.php
+++ b/tests/Serializer/BaseSerializationTest.php
@@ -1200,19 +1200,25 @@ abstract class BaseSerializationTest extends TestCase
 
     public function testVirtualVersions()
     {
+        $evaluator = new ExpressionEvaluator(new ExpressionLanguage());
+
+        $builder = SerializerBuilder::create();
+        $builder->setExpressionEvaluator($evaluator);
+        $serializer = $builder->build();
+
         self::assertEquals(
             $this->getContent('virtual_properties_low'),
-            $this->serialize(new ObjectWithVersionedVirtualProperties(), SerializationContext::create()->setVersion('2'))
+            $serializer->serialize(new ObjectWithVersionedVirtualProperties(), $this->getFormat(), SerializationContext::create()->setVersion('2'))
         );
 
         self::assertEquals(
             $this->getContent('virtual_properties_all'),
-            $this->serialize(new ObjectWithVersionedVirtualProperties(), SerializationContext::create()->setVersion('7'))
+            $serializer->serialize(new ObjectWithVersionedVirtualProperties(), $this->getFormat(), SerializationContext::create()->setVersion('7'))
         );
 
         self::assertEquals(
             $this->getContent('virtual_properties_high'),
-            $this->serialize(new ObjectWithVersionedVirtualProperties(), SerializationContext::create()->setVersion('9'))
+            $serializer->serialize(new ObjectWithVersionedVirtualProperties(), $this->getFormat(), SerializationContext::create()->setVersion('9'))
         );
     }
 

--- a/tests/Serializer/JsonSerializationTest.php
+++ b/tests/Serializer/JsonSerializationTest.php
@@ -78,9 +78,9 @@ class JsonSerializationTest extends BaseSerializationTest
             $outputs['groups_default'] = '{"bar":"bar","none":"none"}';
             $outputs['groups_advanced'] = '{"name":"John","manager":{"name":"John Manager","friends":[{"nickname":"nickname"},{"nickname":"nickname"}]},"friends":[{"nickname":"nickname","manager":{"nickname":"nickname"}},{"nickname":"nickname","manager":{"nickname":"nickname"}}]}';
             $outputs['virtual_properties'] = '{"exist_field":"value","virtual_value":"value","test":"other-name","typed_virtual_property":1}';
-            $outputs['virtual_properties_low'] = '{"low":1}';
-            $outputs['virtual_properties_high'] = '{"high":8}';
-            $outputs['virtual_properties_all'] = '{"low":1,"high":8}';
+            $outputs['virtual_properties_low'] = '{"classlow":1,"low":1}';
+            $outputs['virtual_properties_high'] = '{"classhigh":8,"high":8}';
+            $outputs['virtual_properties_all'] = '{"classlow":1,"classhigh":8,"low":1,"high":8}';
             $outputs['nullable'] = '{"foo":"bar","baz":null,"0":null}';
             $outputs['nullable_skip'] = '{"foo":"bar"}';
             $outputs['person_secret_show'] = '{"name":"mike","gender":"f"}';

--- a/tests/Serializer/xml/virtual_properties_all.xml
+++ b/tests/Serializer/xml/virtual_properties_all.xml
@@ -1,5 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <result>
+  <classlow>1</classlow>
+  <classhigh>8</classhigh>
   <low>1</low>
   <high>8</high>
 </result>

--- a/tests/Serializer/xml/virtual_properties_high.xml
+++ b/tests/Serializer/xml/virtual_properties_high.xml
@@ -1,4 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <result>
+  <classhigh>8</classhigh>
   <high>8</high>
 </result>

--- a/tests/Serializer/xml/virtual_properties_low.xml
+++ b/tests/Serializer/xml/virtual_properties_low.xml
@@ -1,4 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <result>
+  <classlow>1</classlow>
   <low>1</low>
 </result>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| Doc updated   | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #1048
| License       | MIT

As discussed in #1048, it would be nice if the `@Since` and `@Until` annotations could be used within the property parameter of `@VirtualProperty` on class level. It turns out, the serializer does work automatically as soon as the annotation is allowed on class level.

This is my first real experience with unit testing (however I absolutely understand the advantages, my main project is too large already to find a good starting point), so please give feedback if I've done stupid things ;) (Also, first PR, btw)