### PR TITLE
use Twig 2.7 namespaces

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
     },
     "require-dev": {
         "ext-pdo_sqlite": "*",
-        "twig/twig": "^1.12|^2.0",
+        "twig/twig": "^2.7",
         "doctrine/orm": "~2.1",
         "jackalope/jackalope-doctrine-dbal": "^1.1.5",
         "doctrine/phpcr-odm": "^1.3|^2.0",

--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
     },
     "require-dev": {
         "ext-pdo_sqlite": "*",
-        "twig/twig": "^2.7",
+        "twig/twig": "~1.34|~2.4",
         "doctrine/orm": "~2.1",
         "jackalope/jackalope-doctrine-dbal": "^1.1.5",
         "doctrine/phpcr-odm": "^1.3|^2.0",

--- a/src/Twig/SerializerExtension.php
+++ b/src/Twig/SerializerExtension.php
@@ -6,13 +6,16 @@ namespace JMS\Serializer\Twig;
 
 use JMS\Serializer\SerializationContext;
 use JMS\Serializer\SerializerInterface;
+use Twig\Extension\AbstractExtension;
+use Twig\TwigFilter;
+use Twig\TwigFunction;
 
 /**
  * Serializer helper twig extension
  *
  * Basically provides access to JMSSerializer from Twig
  */
-class SerializerExtension extends \Twig_Extension
+class SerializerExtension extends AbstractExtension
 {
     /**
      * @var SerializerInterface
@@ -35,26 +38,26 @@ class SerializerExtension extends \Twig_Extension
     }
 
     /**
-     * @return \Twig_Filter[]
+     * @return TwigFilter[]
      *
      * @phpcsSuppress SlevomatCodingStandard.TypeHints.TypeHintDeclaration.MissingReturnTypeHint
      */
     public function getFilters()
     {
         return [
-            new \Twig_SimpleFilter('serialize', [$this, 'serialize']),
+            new TwigFilter('serialize', [$this, 'serialize']),
         ];
     }
 
     /**
-     * @return \Twig_Function[]
+     * @return TwigFunction[]
      *
      * @phpcsSuppress SlevomatCodingStandard.TypeHints.TypeHintDeclaration.MissingReturnTypeHint
      */
     public function getFunctions()
     {
         return [
-            new \Twig_SimpleFunction('serialization_context', '\JMS\Serializer\SerializationContext::create'),
+            new TwigFunction('serialization_context', '\JMS\Serializer\SerializationContext::create'),
         ];
     }
 

--- a/src/Twig/SerializerRuntimeExtension.php
+++ b/src/Twig/SerializerRuntimeExtension.php
@@ -4,10 +4,14 @@ declare(strict_types=1);
 
 namespace JMS\Serializer\Twig;
 
+use Twig\Extension\AbstractExtension;
+use Twig\TwigFilter;
+use Twig\TwigFunction;
+
 /**
  * @author Asmir Mustafic <goetas@gmail.com>
  */
-final class SerializerRuntimeExtension extends \Twig_Extension
+final class SerializerRuntimeExtension extends AbstractExtension
 {
     /**
      * @return string
@@ -20,26 +24,26 @@ final class SerializerRuntimeExtension extends \Twig_Extension
     }
 
     /**
-     * @return \Twig_Filter[]
+     * @return TwigFilter[]
      *
      * @phpcsSuppress SlevomatCodingStandard.TypeHints.TypeHintDeclaration.MissingReturnTypeHint
      */
     public function getFilters()
     {
         return [
-            new \Twig_SimpleFilter('serialize', [SerializerRuntimeHelper::class, 'serialize']),
+            new TwigFilter('serialize', [SerializerRuntimeHelper::class, 'serialize']),
         ];
     }
 
     /**
-     * @return \Twig_Function[]
+     * @return TwigFunction[]
      *
      * @phpcsSuppress SlevomatCodingStandard.TypeHints.TypeHintDeclaration.MissingReturnTypeHint
      */
     public function getFunctions()
     {
         return [
-            new \Twig_SimpleFunction('serialization_context', '\JMS\Serializer\SerializationContext::create'),
+            new TwigFunction('serialization_context', '\JMS\Serializer\SerializationContext::create'),
         ];
     }
 }

--- a/tests/Twig/SerializerExtensionTest.php
+++ b/tests/Twig/SerializerExtensionTest.php
@@ -8,6 +8,8 @@ use JMS\Serializer\Twig\SerializerExtension;
 use JMS\Serializer\Twig\SerializerRuntimeExtension;
 use JMS\Serializer\Twig\SerializerRuntimeHelper;
 use PHPUnit\Framework\TestCase;
+use Twig\TwigFilter;
+use Twig\TwigFunction;
 
 class SerializerExtensionTest extends TestCase
 {
@@ -25,11 +27,11 @@ class SerializerExtensionTest extends TestCase
         self::assertEquals('jms_serializer', $serializerExtension->getName());
 
         $filters = $serializerExtension->getFilters();
-        self::assertInstanceOf('Twig_SimpleFilter', $filters[0]);
+        self::assertInstanceOf(TwigFilter::class, $filters[0]);
         self::assertSame([$serializerExtension, 'serialize'], $filters[0]->getCallable());
 
         self::assertEquals(
-            [new \Twig_SimpleFunction('serialization_context', '\JMS\Serializer\SerializationContext::create')],
+            [new TwigFunction('serialization_context', '\JMS\Serializer\SerializationContext::create')],
             $serializerExtension->getFunctions()
         );
     }
@@ -54,11 +56,11 @@ class SerializerExtensionTest extends TestCase
 
         self::assertEquals('jms_serializer', $serializerExtension->getName());
         self::assertEquals(
-            [new \Twig_SimpleFilter('serialize', [SerializerRuntimeHelper::class, 'serialize'])],
+            [new TwigFilter('serialize', [SerializerRuntimeHelper::class, 'serialize'])],
             $serializerExtension->getFilters()
         );
         self::assertEquals(
-            [new \Twig_SimpleFunction('serialization_context', '\JMS\Serializer\SerializationContext::create')],
+            [new TwigFunction('serialization_context', '\JMS\Serializer\SerializationContext::create')],
             $serializerExtension->getFunctions()
         );
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| Doc updated   | no
| BC breaks?    | yes
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT

Twig 2.7 moved to namespaced classes instead of old pre-PHP5.3 ones.
