### PR TITLE
Updated suggestion for `JsonSerializationVisitor::addData` replacement

### DIFF
--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -17,7 +17,7 @@ in case you have heavily used internal-api here are the most important the chang
 - Removed the abstract classes `GenericSerializationVisito`r and `GenericDeserializationVisitor`.
 - Removed deprecated method `VisitorInterface::getNavigator`, use `Context::getNavigator` instead
 - Removed deprecated method `JsonSerializationVisitor::addData`, 
-  use `:visitProperty(new StaticPropertyMetadata('', 'name', 'value'), null)` instead
+  use `:visitProperty(new StaticPropertyMetadata('', 'name', null), 'value')` instead
 - Removed Propel and PhpCollection support
 - Changed default date format from ISO8601 to RFC3339  
 - Event listeners/handlers class names are case sensitive now


### PR DESCRIPTION
When using `:visitProperty(new StaticPropertyMetadata('', 'name', 'value), null)` the 
 `\JMS\Serializer\GraphNavigator\SerializationGraphNavigator::accept()` method is called with `$data = null`, therefore `$type` will be set to `null`. Therefore, value configured in `StaticPropertyMetadata` will not be put in place (as long as it's not `null`). 

In order to make  `\JMS\Serializer\GraphNavigator\SerializationGraphNavigator::accept()` extract the correct type (via `gettype()`), the value needs to be set into `visitProperty()`. 

In conclusion, you should use `:visitProperty(new StaticPropertyMetadata('', 'name', null), 'value')`

| Q             | A
| ------------- | ---
| Bug fix?      |no
| New feature?  | no
| Doc updated   | yes
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | no
| License       | MIT

