### PR TITLE
[RFC] Emulate v1 nested groups by using a special __fallback group name

### DIFF
--- a/src/Exclusion/GroupsExclusionStrategy.php
+++ b/src/Exclusion/GroupsExclusionStrategy.php
@@ -19,6 +19,11 @@ final class GroupsExclusionStrategy implements ExclusionStrategyInterface
     private $groups = [];
 
     /**
+     * @var array|null
+     */
+    private $fallback = null;
+
+    /**
      * @var bool
      */
     private $nestedGroups = false;
@@ -37,6 +42,11 @@ final class GroupsExclusionStrategy implements ExclusionStrategyInterface
         }
 
         if ($this->nestedGroups) {
+            if (!empty($groups['__fallback'])) {
+                $this->fallback = $groups['__fallback'];
+                unset($groups['__fallback']);
+            }
+
             $this->groups = $groups;
         } else {
             foreach ($groups as $group) {
@@ -102,6 +112,10 @@ final class GroupsExclusionStrategy implements ExclusionStrategyInterface
         $single = array_filter($groups, 'is_string');
         foreach ($paths as $index => $path) {
             if (!array_key_exists($path, $groups)) {
+                if (!empty($this->fallback)) {
+                    $groups = $this->fallback;
+                }
+
                 break;
             }
 

--- a/tests/Exclusion/GroupsExclusionStrategyTest.php
+++ b/tests/Exclusion/GroupsExclusionStrategyTest.php
@@ -86,6 +86,11 @@ class GroupsExclusionStrategyTest extends TestCase
             [['foo', 'prop' => ['xx', 'prop2' => ['def', 'prop3' => ['def']]]], ['prop', 'prop2'], ['def', 'prop3' => ['def']]],
 
             [['foo', 'prop' => ['prop2' => ['prop3' => ['def']]]], ['prop', 'prop2'], ['foo', 'prop3' => ['def']]],
+
+            // v1 emulation
+            [['__fallback' => ['Default'], 'foo', 'prop' => ['bar']], ['prop2'], ['Default']],
+            [['__fallback' => ['Default'], 'foo', 'prop' => ['bar']], ['prop', 'prop2'], ['Default']],
+            [['__fallback' => ['Default'], 'foo', 'prop' => ['xx', 'prop2' => ['def'], 'prop3' => ['def']]], ['prop', 'prop2', 'propB'], ['Default']],
         ];
     }
 }

--- a/tests/Serializer/BaseSerializationTest.php
+++ b/tests/Serializer/BaseSerializationTest.php
@@ -1130,9 +1130,9 @@ abstract class BaseSerializationTest extends TestCase
         );
     }
 
-    public function testAdvancedGroups()
+    private function getAdvancedGroupsUser(): GroupsUser
     {
-        $adrien = new GroupsUser(
+        return new GroupsUser(
             'John',
             new GroupsUser(
                 'John Manager',
@@ -1156,6 +1156,10 @@ abstract class BaseSerializationTest extends TestCase
                 ),
             ]
         );
+    }
+    public function testAdvancedGroups()
+    {
+        $adrien = $this->getAdvancedGroupsUser();
 
         self::assertEquals(
             $this->getContent('groups_advanced'),
@@ -1167,6 +1171,35 @@ abstract class BaseSerializationTest extends TestCase
                     'manager_group',
                     'friends_group',
 
+                    'manager' => [
+                        GroupsExclusionStrategy::DEFAULT_GROUP,
+                        'friends_group',
+
+                        'friends' => ['nickname_group'],
+                    ],
+                    'friends' => [
+                        'manager_group',
+                        'nickname_group',
+                    ],
+                ])
+            )
+        );
+    }
+
+    public function testAdvancedGroupsWithPreviousGroupFallback()
+    {
+        $adrien = $adrien = $this->getAdvancedGroupsUser();
+
+        self::assertEquals(
+            $this->getContent('groups_advanced_v1'),
+            $this->serializer->serialize(
+                $adrien,
+                $this->getFormat(),
+                SerializationContext::create()->setGroups([
+                    GroupsExclusionStrategy::DEFAULT_GROUP,
+                    'manager_group',
+                    'friends_group',
+                    '__fallback' => [GroupsExclusionStrategy::DEFAULT_GROUP],
                     'manager' => [
                         GroupsExclusionStrategy::DEFAULT_GROUP,
                         'friends_group',

--- a/tests/Serializer/JsonSerializationTest.php
+++ b/tests/Serializer/JsonSerializationTest.php
@@ -77,6 +77,7 @@ class JsonSerializationTest extends BaseSerializationTest
             $outputs['groups_foobar'] = '{"foo":"foo","foobar":"foobar","bar":"bar"}';
             $outputs['groups_default'] = '{"bar":"bar","none":"none"}';
             $outputs['groups_advanced'] = '{"name":"John","manager":{"name":"John Manager","friends":[{"nickname":"nickname"},{"nickname":"nickname"}]},"friends":[{"nickname":"nickname","manager":{"nickname":"nickname"}},{"nickname":"nickname","manager":{"nickname":"nickname"}}]}';
+            $outputs['groups_advanced_v1'] = '{"name":"John","manager":{"name":"John Manager","friends":[{"nickname":"nickname"},{"nickname":"nickname"}]},"friends":[{"nickname":"nickname","manager":{"name":"John friend 1 manager"}},{"nickname":"nickname","manager":{"name":"John friend 2 manager"}}]}';
             $outputs['virtual_properties'] = '{"exist_field":"value","virtual_value":"value","test":"other-name","typed_virtual_property":1}';
             $outputs['virtual_properties_low'] = '{"classlow":1,"low":1}';
             $outputs['virtual_properties_high'] = '{"classhigh":8,"high":8}';

--- a/tests/Serializer/xml/groups_advanced_v1.xml
+++ b/tests/Serializer/xml/groups_advanced_v1.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<result>
+  <name><![CDATA[John]]></name>
+  <manager>
+    <name><![CDATA[John Manager]]></name>
+    <friends>
+      <entry>
+        <nickname><![CDATA[nickname]]></nickname>
+      </entry>
+      <entry>
+        <nickname><![CDATA[nickname]]></nickname>
+      </entry>
+    </friends>
+  </manager>
+  <friends>
+    <entry>
+      <nickname><![CDATA[nickname]]></nickname>
+      <manager>
+        <name><![CDATA[John friend 1 manager]]></name>
+      </manager>
+    </entry>
+    <entry>
+      <nickname><![CDATA[nickname]]></nickname>
+      <manager>
+        <name><![CDATA[John friend 2 manager]]></name>
+      </manager>
+    </entry>
+  </friends>
+</result>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| Doc updated   | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #1058
| License       | MIT

This tries to solve in a BC way #1058

I'm not happy with the solution to be hones, and I still think that a revert is the best option.

This PR allows you to do something as :

```php
// current v2 behaviour
$context = SerializationContext::create()->setGroups([
            'manager_group',
            'manager' => [
                'bla',
            ],
        ]);
$this->serializer->serialize($object, 'json', $context);


// emulate v2 behaviour using this PR feature
$context = SerializationContext::create()->setGroups([
            '__fallback' => ['Default'],
            'manager_group',
            'manager' => [
                'bla',
            ],
        ]);
$this->serializer->serialize($object, 'json', $context);
```