### PR TITLE
doc update: registerHandler() example

### DIFF
--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -51,7 +51,7 @@ If you have created custom handlers, you can add them to the serializer easily::
         JMS\Serializer\SerializerBuilder::create()
             ->addDefaultHandlers()
             ->configureHandlers(function(JMS\Serializer\Handler\HandlerRegistry $registry) {
-                $registry->registerHandler('serialization', 'MyObject', 'json',
+                $registry->registerHandler(JMS\Serializer\GraphNavigatorInterface::DIRECTION_SERIALIZATION, 'MyObject', 'json',
                     function($visitor, MyObject $obj, array $type) {
                         return $obj->getName();
                     }


### PR DESCRIPTION
`registerHandler()` expects first argument to be int, i.e. one of the constants from GraphNavigatorInterface

| Q             | A
| ------------- | ---
| Doc updated   | yes
| License       | MIT

