### PR TITLE
Fix Travis-CI scripts always passing

### DIFF
--- a/.travis/install_docs.sh
+++ b/.travis/install_docs.sh
@@ -1,3 +1,5 @@
 #!/usr/bin/env bash
 
+set -ex
+
 pip install -r doc/requirements.txt --user

--- a/.travis/install_test.sh
+++ b/.travis/install_test.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+set -ex
+
 if [[ $TRAVIS_PHP_VERSION  = '7.2' ]]; then PHPUNIT_FLAGS="--coverage-clover clover"; else PHPUNIT_FLAGS=""; fi
 if [[ $TRAVIS_PHP_VERSION != '7.2' ]]; then phpenv config-rm xdebug.ini; fi
 composer self-update

--- a/.travis/script_docs.sh
+++ b/.travis/script_docs.sh
@@ -1,3 +1,5 @@
 #!/usr/bin/env bash
 
+set -ex
+
 cd doc && sphinx-build -W -b html -d _build/doctrees . _build/html

--- a/.travis/script_test.sh
+++ b/.travis/script_test.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+set -ex
+
 vendor/bin/phpunit $PHPUNIT_FLAGS
 phpenv config-rm xdebug.ini || true
 php tests/benchmark.php json 3

--- a/.travis/success_test.sh
+++ b/.travis/success_test.sh
@@ -1,4 +1,6 @@
 #!/usr/bin/env bash
 
+set -ex
+
 if [[ $TRAVIS_PHP_VERSION = '7.2' ]]; then wget https://scrutinizer-ci.com/ocular.phar; fi
 if [[ $TRAVIS_PHP_VERSION = '7.2' ]]; then php ocular.phar code-coverage:upload --format=php-clover clover; fi

--- a/composer.json
+++ b/composer.json
@@ -41,7 +41,7 @@
         "symfony/form": "^3.0|^4.0",
         "symfony/filesystem": "^3.0|^4.0",
         "symfony/expression-language": "^3.0|^4.0",
-        "phpunit/phpunit": "^7.1",
+        "phpunit/phpunit": "^7.5",
         "doctrine/coding-standard": "^5.0"
     },
     "conflict": {

--- a/tests/Fixtures/Doctrine/Embeddable/BlogPostSeo.php
+++ b/tests/Fixtures/Doctrine/Embeddable/BlogPostSeo.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace JMS\Serializer\Tests\Fixtures\Doctrine;
+namespace JMS\Serializer\Tests\Fixtures\Doctrine\Embeddable;
 
 use Doctrine\ORM\Mapping as ORM;
 

--- a/tests/Fixtures/Doctrine/Embeddable/BlogPostWithEmbedded.php
+++ b/tests/Fixtures/Doctrine/Embeddable/BlogPostWithEmbedded.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace JMS\Serializer\Tests\Fixtures\Doctrine;
+namespace JMS\Serializer\Tests\Fixtures\Doctrine\Embeddable;
 
 use Doctrine\ORM\Mapping as ORM;
 

--- a/tests/Fixtures/Doctrine/Entity/Author.php
+++ b/tests/Fixtures/Doctrine/Entity/Author.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace JMS\Serializer\Tests\Fixtures\Doctrine;
+namespace JMS\Serializer\Tests\Fixtures\Doctrine\Entity;
 
 use Doctrine\ORM\Mapping as ORM;
 use JMS\Serializer\Annotation\SerializedName;

--- a/tests/Fixtures/Doctrine/Entity/BlogPost.php
+++ b/tests/Fixtures/Doctrine/Entity/BlogPost.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace JMS\Serializer\Tests\Fixtures\Doctrine;
+namespace JMS\Serializer\Tests\Fixtures\Doctrine\Entity;
 
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\ORM\Mapping as ORM;

--- a/tests/Fixtures/Doctrine/Entity/Comment.php
+++ b/tests/Fixtures/Doctrine/Entity/Comment.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace JMS\Serializer\Tests\Fixtures\Doctrine;
+namespace JMS\Serializer\Tests\Fixtures\Doctrine\Entity;
 
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\ORM\Mapping as ORM;

--- a/tests/Metadata/Driver/DoctrineDriverTest.php
+++ b/tests/Metadata/Driver/DoctrineDriverTest.php
@@ -25,7 +25,7 @@ class DoctrineDriverTest extends TestCase
 
     public function testMetadataForEmbedded()
     {
-        if (ORMVersion::compare('2.5')) {
+        if (ORMVersion::compare('2.5') >= 0) {
             $this->markTestSkipped('Not using Doctrine ORM >= 2.5 with Embedded entities');
         }
 

--- a/tests/Metadata/Driver/DoctrineDriverTest.php
+++ b/tests/Metadata/Driver/DoctrineDriverTest.php
@@ -8,6 +8,7 @@ use Doctrine\Common\Annotations\AnnotationReader;
 use Doctrine\ORM\Configuration;
 use Doctrine\ORM\EntityManager;
 use Doctrine\ORM\Mapping\Driver\AnnotationDriver as DoctrineDriver;
+use Doctrine\ORM\Version as ORMVersion;
 use JMS\Serializer\Metadata\Driver\AnnotationDriver;
 use JMS\Serializer\Metadata\Driver\DoctrineTypeDriver;
 use JMS\Serializer\Naming\IdenticalPropertyNamingStrategy;
@@ -24,6 +25,10 @@ class DoctrineDriverTest extends TestCase
 
     public function testMetadataForEmbedded()
     {
+        if (ORMVersion::compare('2.5')) {
+            $this->markTestSkipped('Not using Doctrine ORM >= 2.5 with Embedded entities');
+        }
+
         $refClass = new \ReflectionClass(BlogPostWithEmbedded::class);
         $meta = $this->getDoctrineDriver()->loadMetadataForClass($refClass);
         self::assertNotNull($meta);

--- a/tests/Metadata/Driver/DoctrineDriverTest.php
+++ b/tests/Metadata/Driver/DoctrineDriverTest.php
@@ -12,14 +12,14 @@ use Doctrine\ORM\Version as ORMVersion;
 use JMS\Serializer\Metadata\Driver\AnnotationDriver;
 use JMS\Serializer\Metadata\Driver\DoctrineTypeDriver;
 use JMS\Serializer\Naming\IdenticalPropertyNamingStrategy;
-use JMS\Serializer\Tests\Fixtures\Doctrine\BlogPostWithEmbedded;
+use JMS\Serializer\Tests\Fixtures\Doctrine\Embeddable\BlogPostWithEmbedded;
 use PHPUnit\Framework\TestCase;
 
 class DoctrineDriverTest extends TestCase
 {
     public function getMetadata()
     {
-        $refClass = new \ReflectionClass('JMS\Serializer\Tests\Fixtures\Doctrine\BlogPost');
+        $refClass = new \ReflectionClass('JMS\Serializer\Tests\Fixtures\Doctrine\Entity\BlogPost');
         return $this->getDoctrineDriver()->loadMetadataForClass($refClass);
     }
 
@@ -48,7 +48,7 @@ class DoctrineDriverTest extends TestCase
     {
         $metadata = $this->getMetadata();
         self::assertEquals(
-            ['name' => 'JMS\Serializer\Tests\Fixtures\Doctrine\Author', 'params' => []],
+            ['name' => 'JMS\Serializer\Tests\Fixtures\Doctrine\Entity\Author', 'params' => []],
             $metadata->propertyMetadata['author']->type
         );
     }
@@ -61,7 +61,7 @@ class DoctrineDriverTest extends TestCase
             [
                 'name' => 'ArrayCollection',
                 'params' => [
-                    ['name' => 'JMS\Serializer\Tests\Fixtures\Doctrine\Comment', 'params' => []],
+                    ['name' => 'JMS\Serializer\Tests\Fixtures\Doctrine\Entity\Comment', 'params' => []],
                 ],
             ],
             $metadata->propertyMetadata['comments']->type

--- a/tests/Serializer/Doctrine/ObjectConstructorTest.php
+++ b/tests/Serializer/Doctrine/ObjectConstructorTest.php
@@ -29,7 +29,7 @@ use JMS\Serializer\Naming\IdenticalPropertyNamingStrategy;
 use JMS\Serializer\Serializer;
 use JMS\Serializer\SerializerBuilder;
 use JMS\Serializer\SerializerInterface;
-use JMS\Serializer\Tests\Fixtures\Doctrine\Author;
+use JMS\Serializer\Tests\Fixtures\Doctrine\Entity\Author;
 use JMS\Serializer\Tests\Fixtures\Doctrine\IdentityFields\Server;
 use JMS\Serializer\Tests\Fixtures\DoctrinePHPCR\Author as DoctrinePHPCRAuthor;
 use JMS\Serializer\Visitor\DeserializationVisitorInterface;
@@ -269,7 +269,8 @@ class ObjectConstructorTest extends TestCase
     {
         $cfg = new Configuration();
         $cfg->setMetadataDriverImpl(new AnnotationDriver(new AnnotationReader(), [
-            __DIR__ . '/../../Fixtures/Doctrine',
+            __DIR__ . '/../../Fixtures/Doctrine/Entity',
+            __DIR__ . '/../../Fixtures/Doctrine/IdentityFields',
         ]));
         $cfg->setAutoGenerateProxyClasses(true);
         $cfg->setProxyNamespace('JMS\Serializer\DoctrineProxy');


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Doc updated   | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | no
| License       | MIT

Currently the tests are always marked as passed on Travis-CI due to lack of `set -ex` on the beginning of the tests script.
This is probably why we missed the failing tests introduced in 8ec6beadfa595957ebf907a1f5aa512216dc385a with Doctrine ORM < 2.5 when Embeddable has been introduced. 

- [x] Skip testing Embeddable entities on Doctrine ORM <2.5
- [x] Bump PHPUnit minimum version to 7.5 which introduced `assertIsCallable()`
- [x] Skip loading `BlogPostSeo` and `BlogPostWithEmbedded` metadata in `JMS\Serializer\Tests\Serializer\Doctrine\ObjectConstructorTest`