### PR TITLE
Allow loading different YAML extensions

### DIFF
--- a/tests/Metadata/Driver/yml/invalid_metadata/BlogPost.yml
+++ b/tests/Metadata/Driver/yml/invalid_metadata/BlogPost.yml
@@ -1,0 +1,6 @@
+JMS\Serializer\Tests\Fixtures\Person:
+    custom_accessor_order: ["age", "name"]
+
+    properties:
+        age: ~
+        name: ~

--- a/tests/Metadata/Driver/yml/multiple_types/BlogPost.yml
+++ b/tests/Metadata/Driver/yml/multiple_types/BlogPost.yml
@@ -1,0 +1,7 @@
+JMS\Serializer\Tests\Fixtures\BlogPost:
+    xml_root_name: blog-post
+    exclusion_policy: NONE
+    properties:
+        title:
+            type: string
+            exclude: true

--- a/tests/Metadata/Driver/yml/multiple_types/Person.yaml
+++ b/tests/Metadata/Driver/yml/multiple_types/Person.yaml
@@ -1,0 +1,4 @@
+JMS\Serializer\Tests\Fixtures\Person:
+    exclusion_policy: ALL
+    properties:
+        name: ~


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| Doc updated   | no
| BC breaks?    | no
| Deprecations? | yes (TBD)
| Tests pass?   | yes
| Fixed tickets | #1077 
| License       | MIT

Collaspse `AbstractFileDriver` into `YamlDriver` to allow multiple extensions (`yaml`, `yml`) to processed. Updated some tests

Fixes #1077 

cc. @goetas 