### PR TITLE
Remove strict return type

### DIFF
--- a/src/Serializer.php
+++ b/src/Serializer.php
@@ -148,7 +148,7 @@ final class Serializer implements SerializerInterface, ArrayTransformerInterface
     /**
      * {@InheritDoc}
      */
-    public function serialize($data, string $format, ?SerializationContext $context = null, ?string $type = null): string
+    public function serialize($data, string $format, ?SerializationContext $context = null, ?string $type = null)
     {
         if (null === $context) {
             $context = $this->serializationContextFactory->createSerializationContext();

--- a/src/SerializerInterface.php
+++ b/src/SerializerInterface.php
@@ -15,8 +15,10 @@ interface SerializerInterface
      * Serializes the given data to the specified output format.
      *
      * @param mixed $data
+     *
+     * @return mixed
      */
-    public function serialize($data, string $format, ?SerializationContext $context = null, ?string $type = null): string;
+    public function serialize($data, string $format, ?SerializationContext $context = null, ?string $type = null);
 
     /**
      * Deserializes the given data to the specified type.

--- a/tests/Twig/SerializerExtensionTest.php
+++ b/tests/Twig/SerializerExtensionTest.php
@@ -20,7 +20,8 @@ class SerializerExtensionTest extends TestCase
         $mockSerializer
             ->expects($this->once())
             ->method('serialize')
-            ->with($this->equalTo($obj), $this->equalTo('json'));
+            ->with($this->equalTo($obj), $this->equalTo('json'))
+            ->willReturn('{}');
         $serializerExtension = new SerializerExtension($mockSerializer);
         $serializerExtension->serialize($obj);
 
@@ -44,7 +45,8 @@ class SerializerExtensionTest extends TestCase
         $mockSerializer
             ->expects($this->once())
             ->method('serialize')
-            ->with($this->equalTo($obj), $this->equalTo('json'));
+            ->with($this->equalTo($obj), $this->equalTo('json'))
+            ->willReturn('{}');
 
         $serializerExtension = new SerializerRuntimeHelper($mockSerializer);
         $serializerExtension->serialize($obj);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Doc updated   | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT

According to JMS\Serializer\VisitorInterface method getResult() allows to return a mixed type of result but in JMS\Serializer\SerializerInterface method serialize() has a strict return type 'string'. I suppose this is a small bug which does not allow to use visitors with different return types.