### PR TITLE
Support to use same handler for subclasses

### DIFF
--- a/src/Handler/HandlerRegistry.php
+++ b/src/Handler/HandlerRegistry.php
@@ -70,6 +70,29 @@ class HandlerRegistry implements HandlerRegistryInterface
      */
     public function getHandler(int $direction, string $typeName, string $format)
     {
+        $currentType = $typeName;
+        do {
+            $handler = $this->getSingleHandler($direction, $currentType, $format);
+            if (null !== $handler) {
+                return $handler;
+            }
+        } while ($currentType = get_parent_class($currentType));
+
+        $interfaces = class_implements($typeName);
+        if ($interfaces !== false) {
+            foreach ($interfaces as $interface) {
+                $handler = $this->getSingleHandler($direction, $interface, $format);
+                if (null !== $handler) {
+                    return $handler;
+                }
+            }
+        }
+
+        return null;
+    }
+
+    protected function getSingleHandler(int $direction, string $typeName, string $format)
+    {
         if (!isset($this->handlers[$direction][$typeName][$format])) {
             return null;
         }

--- a/src/Handler/LazyHandlerRegistry.php
+++ b/src/Handler/LazyHandlerRegistry.php
@@ -46,7 +46,7 @@ final class LazyHandlerRegistry extends HandlerRegistry
     /**
      * {@inheritdoc}
      */
-    public function getHandler(int $direction, string $typeName, string $format)
+    protected function getSingleHandler(int $direction, string $typeName, string $format)
     {
         if (isset($this->initializedHandlers[$direction][$typeName][$format])) {
             return $this->initializedHandlers[$direction][$typeName][$format];

--- a/tests/Handler/HandlerRegistryTest.php
+++ b/tests/Handler/HandlerRegistryTest.php
@@ -6,10 +6,14 @@ namespace JMS\Serializer\Tests\Handler;
 
 use JMS\Serializer\GraphNavigatorInterface;
 use JMS\Serializer\Handler\HandlerRegistry;
+use JMS\Serializer\Handler\HandlerRegistryInterface;
 use PHPUnit\Framework\TestCase;
 
 class HandlerRegistryTest extends TestCase
 {
+    /**
+     * @var HandlerRegistryInterface
+     */
     protected $handlerRegistry;
 
     protected function setUp()
@@ -37,6 +41,26 @@ class HandlerRegistryTest extends TestCase
         self::assertSame($xmlDeserializationHandler, $this->handlerRegistry->getHandler(GraphNavigatorInterface::DIRECTION_DESERIALIZATION, '\stdClass', 'xml'));
     }
 
+    public function testSerializeClassHierarchy(): void
+    {
+        $handler = new DummyHandler();
+        $this->handlerRegistry->registerHandler(GraphNavigatorInterface::DIRECTION_SERIALIZATION, DummyParent::class, 'json', $handler);
+        $this->handlerRegistry->registerHandler(GraphNavigatorInterface::DIRECTION_DESERIALIZATION, DummyParent::class, 'json', $handler);
+
+        self::assertSame($handler, $this->handlerRegistry->getHandler(GraphNavigatorInterface::DIRECTION_SERIALIZATION, DummyChild::class, 'json'));
+        self::assertSame($handler, $this->handlerRegistry->getHandler(GraphNavigatorInterface::DIRECTION_DESERIALIZATION, DummyChild::class, 'json'));
+    }
+
+    public function testSerializeInterface(): void
+    {
+        $handler = new DummyHandler();
+        $this->handlerRegistry->registerHandler(GraphNavigatorInterface::DIRECTION_SERIALIZATION, SomeInterface::class, 'json', $handler);
+        $this->handlerRegistry->registerHandler(GraphNavigatorInterface::DIRECTION_DESERIALIZATION, SomeInterface::class, 'json', $handler);
+
+        self::assertSame($handler, $this->handlerRegistry->getHandler(GraphNavigatorInterface::DIRECTION_SERIALIZATION, SomeImpl::class, 'json'));
+        self::assertSame($handler, $this->handlerRegistry->getHandler(GraphNavigatorInterface::DIRECTION_DESERIALIZATION, SomeImpl::class, 'json'));
+    }
+
     protected function createHandlerRegistry()
     {
         return new HandlerRegistry();
@@ -48,4 +72,21 @@ class DummyHandler
     public function __call($name, $arguments)
     {
     }
+}
+
+class DummyParent
+{
+    public $value;
+}
+
+class DummyChild extends DummyParent
+{
+}
+
+interface SomeInterface
+{
+}
+
+class SomeImpl implements SomeInterface
+{
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| Doc updated   | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #260
| License       | MIT

This PR adds a feature to use the same serialization/deserialization handler for class hierarchy in `HandlerRegistry` and `LazyHandlerRegistry`. 

Example:
```php
class A {
  public $value;
}

class B extends A {}

$handler = new MyHandler();
$handlerRegistry->registerHandler(GraphNavigatorInterface::DIRECTION_SERIALIZATION, A::class, 'json', $handler);

...

// Will call serialization handler for A if handler for B is not explicitly registered
$serializer->serialize(new B, 'json');
```
