### PR TITLE
Add Psalm to pipeline

### DIFF
--- a/.psalm/baseline.xml
+++ b/.psalm/baseline.xml
@@ -1,0 +1,468 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<files psalm-version="3.4.1@99a2d866611c6478490bfba1377a30d527e6b874">
+  <file src="src/Accessor/DefaultAccessorStrategy.php">
+    <PossiblyInvalidArgument occurrences="1">
+      <code>$metadata-&gt;expression</code>
+    </PossiblyInvalidArgument>
+    <PossiblyInvalidFunctionCall occurrences="2">
+      <code>$this-&gt;readAccessors[$metadata-&gt;class]($object, $metadata-&gt;name)</code>
+      <code>$this-&gt;writeAccessors[$metadata-&gt;class]($object, $metadata-&gt;name, $value)</code>
+    </PossiblyInvalidFunctionCall>
+    <PossiblyNullPropertyAssignmentValue occurrences="1">
+      <code>$evaluator</code>
+    </PossiblyNullPropertyAssignmentValue>
+    <TooManyArguments occurrences="1">
+      <code>getValue</code>
+    </TooManyArguments>
+    <UndefinedMethod occurrences="4">
+      <code>$this-&gt;propertyReflectionCache[$metadata-&gt;class]</code>
+      <code>$this-&gt;propertyReflectionCache[$metadata-&gt;class]</code>
+      <code>$this-&gt;propertyReflectionCache[$metadata-&gt;class]</code>
+      <code>$this-&gt;propertyReflectionCache[$metadata-&gt;class]</code>
+    </UndefinedMethod>
+  </file>
+  <file src="src/Builder/DefaultDriverFactory.php">
+    <PossiblyNullPropertyAssignmentValue occurrences="1">
+      <code>$expressionEvaluator</code>
+    </PossiblyNullPropertyAssignmentValue>
+  </file>
+  <file src="src/Construction/DoctrineObjectConstructor.php">
+    <UndefinedInterfaceMethod occurrences="1">
+      <code>getReference</code>
+    </UndefinedInterfaceMethod>
+    <UndefinedPropertyFetch occurrences="1">
+      <code>$metadata-&gt;propertyMetadata[$name]-&gt;serializedName</code>
+    </UndefinedPropertyFetch>
+  </file>
+  <file src="src/Context.php">
+    <PropertyTypeCoercion occurrences="2">
+      <code>$factory</code>
+      <code>$strategy</code>
+    </PropertyTypeCoercion>
+  </file>
+  <file src="src/ContextFactory/CallableContextFactory.php">
+    <MismatchingDocblockReturnType occurrences="1">
+      <code>mixed</code>
+    </MismatchingDocblockReturnType>
+  </file>
+  <file src="src/EventDispatcher/EventDispatcher.php">
+    <PossiblyNullIterator occurrences="1">
+      <code>$this-&gt;classListeners[$eventName][$objectClass][$format]</code>
+    </PossiblyNullIterator>
+  </file>
+  <file src="src/EventDispatcher/Subscriber/DoctrineProxySubscriber.php">
+    <UndefinedClass occurrences="2">
+      <code>MongoDBPersistentCollection</code>
+      <code>MongoDBPersistentCollection</code>
+    </UndefinedClass>
+  </file>
+  <file src="src/EventDispatcher/Subscriber/SymfonyValidatorValidatorSubscriber.php">
+    <UndefinedMethod occurrences="1">
+      <code>getObject</code>
+    </UndefinedMethod>
+  </file>
+  <file src="src/GraphNavigator.php">
+    <PossiblyNullPropertyAssignmentValue occurrences="1">
+      <code>$context-&gt;getExclusionStrategy()</code>
+    </PossiblyNullPropertyAssignmentValue>
+  </file>
+  <file src="src/GraphNavigator/DeserializationGraphNavigator.php">
+    <ArgumentTypeCoercion occurrences="5">
+      <code>$propertyMetadata</code>
+      <code>$propertyMetadata</code>
+      <code>$propertyMetadata</code>
+      <code>$propertyMetadata</code>
+      <code>$propertyMetadata</code>
+    </ArgumentTypeCoercion>
+    <InvalidReturnStatement occurrences="1">
+      <code>$this-&gt;metadataFactory-&gt;getMetadataForClass($metadata-&gt;discriminatorMap[$typeValue])</code>
+    </InvalidReturnStatement>
+    <InvalidReturnType occurrences="1">
+      <code>?ClassMetadata</code>
+    </InvalidReturnType>
+    <PossiblyNullArgument occurrences="3">
+      <code>$metadata</code>
+      <code>$metadata</code>
+      <code>$object</code>
+    </PossiblyNullArgument>
+    <UndefinedPropertyFetch occurrences="2">
+      <code>$propertyMetadata-&gt;readOnly</code>
+      <code>$propertyMetadata-&gt;type</code>
+    </UndefinedPropertyFetch>
+  </file>
+  <file src="src/GraphNavigator/Factory/DeserializationGraphNavigatorFactory.php">
+    <PossiblyNullPropertyAssignmentValue occurrences="2">
+      <code>$dispatcher</code>
+      <code>$expressionEvaluator</code>
+    </PossiblyNullPropertyAssignmentValue>
+  </file>
+  <file src="src/GraphNavigator/Factory/SerializationGraphNavigatorFactory.php">
+    <PossiblyNullPropertyAssignmentValue occurrences="1">
+      <code>$expressionEvaluator</code>
+    </PossiblyNullPropertyAssignmentValue>
+  </file>
+  <file src="src/GraphNavigator/SerializationGraphNavigator.php">
+    <ArgumentTypeCoercion occurrences="5">
+      <code>$propertyMetadata</code>
+      <code>$propertyMetadata</code>
+      <code>$propertyMetadata</code>
+      <code>$propertyMetadata</code>
+      <code>$propertyMetadata</code>
+    </ArgumentTypeCoercion>
+    <UndefinedMethod occurrences="1">
+      <code>shouldSerializeNull</code>
+    </UndefinedMethod>
+  </file>
+  <file src="src/Handler/ArrayCollectionHandler.php">
+    <InvalidArgument occurrences="1">
+      <code>$context-&gt;getMetadataFactory()-&gt;getMetadataForClass(\get_class($collection))</code>
+    </InvalidArgument>
+    <TooManyArguments occurrences="1">
+      <code>visitArray</code>
+    </TooManyArguments>
+  </file>
+  <file src="src/Handler/DateHandler.php">
+    <NullArgument occurrences="1">
+      <code>null</code>
+    </NullArgument>
+  </file>
+  <file src="src/Handler/FormErrorHandler.php">
+    <InvalidNullableReturnType occurrences="1">
+      <code>string</code>
+    </InvalidNullableReturnType>
+    <NullableReturnStatement occurrences="1">
+      <code>$this-&gt;getErrorMessage($formError)</code>
+    </NullableReturnStatement>
+    <PossiblyInvalidArgument occurrences="2">
+      <code>$error</code>
+      <code>$error</code>
+    </PossiblyInvalidArgument>
+    <PossiblyNullArgument occurrences="2">
+      <code>$this-&gt;getErrorMessage($formError)</code>
+      <code>$error-&gt;getMessagePluralization()</code>
+    </PossiblyNullArgument>
+  </file>
+  <file src="src/Handler/HandlerRegistry.php">
+    <InvalidArrayAccess occurrences="2">
+      <code>$this-&gt;handlers[$direction][$typeName]</code>
+      <code>$this-&gt;handlers[$direction][$typeName]</code>
+    </InvalidArrayAccess>
+    <InvalidArrayAssignment occurrences="1">
+      <code>$this-&gt;handlers[$direction][$typeName]</code>
+    </InvalidArrayAssignment>
+  </file>
+  <file src="src/Handler/LazyHandlerRegistry.php">
+    <InvalidArrayAccess occurrences="2">
+      <code>$this-&gt;handlers[$direction][$typeName]</code>
+      <code>$this-&gt;handlers[$direction][$typeName]</code>
+    </InvalidArrayAccess>
+  </file>
+  <file src="src/Handler/StdClassHandler.php">
+    <InvalidArgument occurrences="2">
+      <code>$classMetadata</code>
+      <code>$classMetadata</code>
+    </InvalidArgument>
+    <TooManyArguments occurrences="2">
+      <code>startVisitingObject</code>
+      <code>endVisitingObject</code>
+    </TooManyArguments>
+  </file>
+  <file src="src/JsonDeserializationVisitor.php">
+    <InvalidNullableReturnType occurrences="1">
+      <code>object</code>
+    </InvalidNullableReturnType>
+    <MismatchingDocblockReturnType occurrences="5">
+      <code>string</code>
+      <code>bool</code>
+      <code>int</code>
+      <code>float</code>
+      <code>array</code>
+    </MismatchingDocblockReturnType>
+    <NullableReturnStatement occurrences="1">
+      <code>$obj</code>
+    </NullableReturnStatement>
+  </file>
+  <file src="src/JsonSerializationVisitor.php">
+    <MoreSpecificImplementedParamType occurrences="7">
+      <code>$data</code>
+      <code>$data</code>
+      <code>$data</code>
+      <code>$data</code>
+      <code>$data</code>
+      <code>$data</code>
+      <code>$data</code>
+    </MoreSpecificImplementedParamType>
+    <PossiblyInvalidPropertyAssignmentValue occurrences="1">
+      <code>true === $metadata-&gt;isMap ? new \ArrayObject() : []</code>
+    </PossiblyInvalidPropertyAssignmentValue>
+  </file>
+  <file src="src/Metadata/ClassMetadata.php">
+    <ArgumentTypeCoercion occurrences="3">
+      <code>$this-&gt;propertyMetadata</code>
+      <code>$this-&gt;propertyMetadata</code>
+      <code>$this-&gt;propertyMetadata</code>
+    </ArgumentTypeCoercion>
+    <InvalidPropertyAssignmentValue occurrences="3">
+      <code>$this-&gt;preSerializeMethods</code>
+      <code>$this-&gt;postSerializeMethods</code>
+      <code>$this-&gt;postDeserializeMethods</code>
+    </InvalidPropertyAssignmentValue>
+    <InvalidScalarArgument occurrences="1">
+      <code>$this-&gt;customOrder</code>
+    </InvalidScalarArgument>
+    <TypeDoesNotContainType occurrences="2">
+      <code>\is_string($uri)</code>
+      <code>\is_string($prefix)</code>
+    </TypeDoesNotContainType>
+  </file>
+  <file src="src/Metadata/Driver/AbstractDoctrineTypeDriver.php">
+    <ArgumentTypeCoercion occurrences="3">
+      <code>$propertyMetadata</code>
+      <code>$propertyMetadata</code>
+      <code>$propertyMetadata</code>
+    </ArgumentTypeCoercion>
+    <UndefinedPropertyFetch occurrences="1">
+      <code>$propertyMetadata-&gt;type</code>
+    </UndefinedPropertyFetch>
+  </file>
+  <file src="src/Metadata/Driver/AnnotationDriver.php">
+    <ImplicitToStringCast occurrences="2">
+      <code>$this-&gt;parseExpression('!(' . $annot-&gt;if . ')')</code>
+      <code>$this-&gt;parseExpression($annot-&gt;if)</code>
+    </ImplicitToStringCast>
+    <PossiblyNullPropertyAssignmentValue occurrences="2">
+      <code>$expressionEvaluator</code>
+      <code>$annot-&gt;namespace ? (string) $annot-&gt;namespace : null</code>
+    </PossiblyNullPropertyAssignmentValue>
+  </file>
+  <file src="src/Metadata/Driver/DoctrinePHPCRTypeDriver.php">
+    <NoInterfaceProperties occurrences="2">
+      <code>$doctrineMetadata-&gt;parentMapping</code>
+      <code>$doctrineMetadata-&gt;node</code>
+    </NoInterfaceProperties>
+    <UndefinedInterfaceMethod occurrences="1">
+      <code>getFieldMapping</code>
+    </UndefinedInterfaceMethod>
+  </file>
+  <file src="src/Metadata/Driver/DoctrineTypeDriver.php">
+    <NoInterfaceProperties occurrences="2">
+      <code>$doctrineMetadata-&gt;discriminatorMap</code>
+      <code>$doctrineMetadata-&gt;discriminatorColumn</code>
+    </NoInterfaceProperties>
+    <UndefinedInterfaceMethod occurrences="2">
+      <code>isRootEntity</code>
+      <code>isInheritanceTypeNone</code>
+    </UndefinedInterfaceMethod>
+  </file>
+  <file src="src/Metadata/Driver/XmlDriver.php">
+    <ImplicitToStringCast occurrences="2">
+      <code>$this-&gt;parseExpression((string) $excludeIf)</code>
+      <code>$this-&gt;parseExpression('!(' . (string) $excludeIf . ')')</code>
+    </ImplicitToStringCast>
+    <PossiblyNullPropertyAssignmentValue occurrences="1">
+      <code>$expressionEvaluator</code>
+    </PossiblyNullPropertyAssignmentValue>
+    <PossiblyNullPropertyFetch occurrences="46">
+      <code>$elem-&gt;attributes()-&gt;{'exclusion-policy'}</code>
+      <code>$elem-&gt;attributes()-&gt;exclude</code>
+      <code>$elem-&gt;attributes()-&gt;{'access-type'}</code>
+      <code>$elem-&gt;attributes()-&gt;{'accessor-order'}</code>
+      <code>$elem-&gt;attributes()-&gt;{'custom-accessor-order'}</code>
+      <code>$elem-&gt;attributes()-&gt;{'xml-root-name'}</code>
+      <code>$elem-&gt;attributes()-&gt;{'xml-root-namespace'}</code>
+      <code>$elem-&gt;attributes()-&gt;{'xml-root-prefix'}</code>
+      <code>$elem-&gt;attributes()-&gt;{'read-only'}</code>
+      <code>$elem-&gt;attributes()-&gt;{'discriminator-field-name'}</code>
+      <code>$entry-&gt;attributes()-&gt;value</code>
+      <code>$elem-&gt;attributes()-&gt;{'discriminator-disabled'}</code>
+      <code>$xmlNamespace-&gt;attributes()-&gt;prefix</code>
+      <code>$xmlNamespace-&gt;attributes()-&gt;uri</code>
+      <code>$xmlDiscriminator-&gt;attributes()-&gt;attribute</code>
+      <code>$xmlDiscriminator-&gt;attributes()-&gt;cdata</code>
+      <code>$xmlDiscriminator-&gt;attributes()-&gt;namespace</code>
+      <code>$method-&gt;attributes()-&gt;name</code>
+      <code>$method-&gt;attributes()-&gt;expression</code>
+      <code>$method-&gt;attributes()-&gt;method</code>
+      <code>$pElem-&gt;attributes()-&gt;exclude</code>
+      <code>$pElem-&gt;attributes()-&gt;expose</code>
+      <code>$pElem-&gt;attributes()-&gt;{'exclude-if'}</code>
+      <code>$pElem-&gt;attributes()-&gt;{'skip-when-empty'}</code>
+      <code>$pElem-&gt;attributes()-&gt;{'expose-if'}</code>
+      <code>$pElem-&gt;attributes()-&gt;{'since-version'}</code>
+      <code>$pElem-&gt;attributes()-&gt;{'until-version'}</code>
+      <code>$pElem-&gt;attributes()-&gt;{'serialized-name'}</code>
+      <code>$pElem-&gt;attributes()-&gt;type</code>
+      <code>$pElem-&gt;attributes()-&gt;groups</code>
+      <code>$pElem-&gt;attributes()-&gt;{'xml-attribute'}</code>
+      <code>$pElem-&gt;attributes()-&gt;{'xml-attribute-map'}</code>
+      <code>$pElem-&gt;attributes()-&gt;{'xml-value'}</code>
+      <code>$pElem-&gt;attributes()-&gt;{'xml-key-value-pairs'}</code>
+      <code>$pElem-&gt;attributes()-&gt;{'max-depth'}</code>
+      <code>$pElem-&gt;attributes()-&gt;{'read-only'}</code>
+      <code>$pElem-&gt;attributes()-&gt;{'accessor-getter'}</code>
+      <code>$pElem-&gt;attributes()-&gt;{'accessor-setter'}</code>
+      <code>$pElem-&gt;attributes()-&gt;{'access-type'}</code>
+      <code>$pElem-&gt;attributes()-&gt;inline</code>
+      <code>$pElem-&gt;attributes()-&gt;name</code>
+      <code>$method-&gt;attributes()-&gt;type</code>
+      <code>$method-&gt;attributes()-&gt;name</code>
+      <code>$method-&gt;attributes()-&gt;name</code>
+      <code>$method-&gt;attributes()-&gt;name</code>
+      <code>$method-&gt;attributes()-&gt;name</code>
+    </PossiblyNullPropertyFetch>
+  </file>
+  <file src="src/Metadata/Driver/YamlDriver.php">
+    <ImplicitToStringCast occurrences="2">
+      <code>$this-&gt;parseExpression((string) $pConfig['exclude_if'])</code>
+      <code>$this-&gt;parseExpression('!(' . $pConfig['expose_if'] . ')')</code>
+    </ImplicitToStringCast>
+    <PossiblyNullPropertyAssignmentValue occurrences="1">
+      <code>$expressionEvaluator</code>
+    </PossiblyNullPropertyAssignmentValue>
+  </file>
+  <file src="src/Metadata/PropertyMetadata.php">
+    <PossiblyNullPropertyAssignmentValue occurrences="3">
+      <code>$getter</code>
+      <code>$setter</code>
+      <code>null</code>
+    </PossiblyNullPropertyAssignmentValue>
+  </file>
+  <file src="src/Serializer.php">
+    <InvalidPropertyAssignmentValue occurrences="1">
+      <code>$typeParser ?? new Parser()</code>
+    </InvalidPropertyAssignmentValue>
+    <UndefinedDocblockClass occurrences="2">
+      <code>TypeParser</code>
+      <code>$this-&gt;typeParser</code>
+    </UndefinedDocblockClass>
+  </file>
+  <file src="src/SerializerBuilder.php">
+    <PropertyTypeCoercion occurrences="1">
+      <code>$reader</code>
+    </PropertyTypeCoercion>
+  </file>
+  <file src="src/Type/InnerParser.php">
+    <InvalidScalarArgument occurrences="1">
+      <code>1</code>
+    </InvalidScalarArgument>
+    <NullArgument occurrences="1">
+      <code>null</code>
+    </NullArgument>
+  </file>
+  <file src="src/Type/TypeVisitor.php">
+    <ArgumentTypeCoercion occurrences="2">
+      <code>$element</code>
+      <code>$element</code>
+    </ArgumentTypeCoercion>
+    <InvalidReturnStatement occurrences="1">
+      <code>false === strpos($value, '.') ? intval($value) : floatval($value)</code>
+    </InvalidReturnStatement>
+    <InvalidReturnType occurrences="1">
+      <code>string|mixed[]</code>
+    </InvalidReturnType>
+    <NullableReturnStatement occurrences="1">
+      <code>null</code>
+    </NullableReturnStatement>
+    <UndefinedInterfaceMethod occurrences="1">
+      <code>getId</code>
+    </UndefinedInterfaceMethod>
+  </file>
+  <file src="src/Visitor/DeserializationVisitorInterface.php">
+    <MismatchingDocblockReturnType occurrences="6">
+      <code>mixed</code>
+      <code>mixed</code>
+      <code>mixed</code>
+      <code>mixed</code>
+      <code>mixed</code>
+      <code>mixed</code>
+    </MismatchingDocblockReturnType>
+  </file>
+  <file src="src/XmlDeserializationVisitor.php">
+    <InvalidArrayOffset occurrences="1">
+      <code>$data[$endPos++]</code>
+    </InvalidArrayOffset>
+    <InvalidNullableReturnType occurrences="1">
+      <code>object</code>
+    </InvalidNullableReturnType>
+    <MismatchingDocblockReturnType occurrences="5">
+      <code>string</code>
+      <code>bool</code>
+      <code>int</code>
+      <code>float</code>
+      <code>array</code>
+    </MismatchingDocblockReturnType>
+    <NullableReturnStatement occurrences="1">
+      <code>$rs</code>
+    </NullableReturnStatement>
+    <PossiblyFalseArgument occurrences="1">
+      <code>$startPos</code>
+    </PossiblyFalseArgument>
+    <PossiblyFalseOperand occurrences="3">
+      <code>$endPos</code>
+      <code>$endPos</code>
+      <code>$startPos</code>
+    </PossiblyFalseOperand>
+  </file>
+  <file src="src/XmlSerializationVisitor.php">
+    <ArgumentTypeCoercion occurrences="3">
+      <code>$this-&gt;currentNode</code>
+      <code>$this-&gt;currentNode</code>
+      <code>$this-&gt;currentNode</code>
+    </ArgumentTypeCoercion>
+    <ImplementedReturnTypeMismatch occurrences="2">
+      <code>void</code>
+      <code>void</code>
+    </ImplementedReturnTypeMismatch>
+    <InvalidReturnStatement occurrences="1">
+      <code>$this-&gt;currentMetadata</code>
+    </InvalidReturnStatement>
+    <InvalidReturnType occurrences="1">
+      <code>?PropertyMetadata</code>
+    </InvalidReturnType>
+    <MoreSpecificImplementedParamType occurrences="5">
+      <code>$data</code>
+      <code>$data</code>
+      <code>$data</code>
+      <code>$data</code>
+      <code>$data</code>
+    </MoreSpecificImplementedParamType>
+    <NullReference occurrences="1">
+      <code>appendChild</code>
+    </NullReference>
+    <PossiblyNullArgument occurrences="4">
+      <code>$this-&gt;currentNode</code>
+      <code>$this-&gt;currentNode</code>
+      <code>$this-&gt;currentNode</code>
+      <code>$this-&gt;currentNode</code>
+    </PossiblyNullArgument>
+    <PossiblyNullPropertyFetch occurrences="2">
+      <code>$this-&gt;currentNode-&gt;childNodes</code>
+      <code>$this-&gt;currentNode-&gt;parentNode</code>
+    </PossiblyNullPropertyFetch>
+    <PossiblyNullReference occurrences="6">
+      <code>appendChild</code>
+      <code>appendChild</code>
+      <code>appendChild</code>
+      <code>appendChild</code>
+      <code>removeChild</code>
+      <code>isDefaultNamespace</code>
+    </PossiblyNullReference>
+    <PossiblyUndefinedVariable occurrences="1">
+      <code>$element</code>
+    </PossiblyUndefinedVariable>
+    <TooFewArguments occurrences="1">
+      <code>createDocument</code>
+    </TooFewArguments>
+    <TypeDoesNotContainNull occurrences="1">
+      <code>null === $this-&gt;document-&gt;documentElement</code>
+    </TypeDoesNotContainNull>
+    <UndefinedPropertyFetch occurrences="6">
+      <code>$this-&gt;currentMetadata-&gt;xmlElementCData</code>
+      <code>$this-&gt;currentMetadata-&gt;xmlEntryName</code>
+      <code>$this-&gt;currentMetadata-&gt;xmlKeyAttribute</code>
+      <code>$this-&gt;currentMetadata-&gt;xmlEntryNamespace</code>
+      <code>$this-&gt;currentMetadata-&gt;xmlKeyValuePairs</code>
+      <code>$metadata-&gt;reflection</code>
+    </UndefinedPropertyFetch>
+  </file>
+</files>

--- a/.travis/script_test.sh
+++ b/.travis/script_test.sh
@@ -2,7 +2,7 @@
 
 set -ex
 
-vendor/bin/psalm.phar || true # As we are only now starting to run Psalm we don't expect it to succed right now.
+vendor/bin/psalm.phar
 vendor/bin/phpunit $PHPUNIT_FLAGS
 phpenv config-rm xdebug.ini || true
 php tests/benchmark.php json 3

--- a/.travis/script_test.sh
+++ b/.travis/script_test.sh
@@ -2,7 +2,7 @@
 
 set -ex
 
-vendor/bin/psalm.phar
+vendor/bin/psalm.phar --show-info=false
 vendor/bin/phpunit $PHPUNIT_FLAGS
 phpenv config-rm xdebug.ini || true
 php tests/benchmark.php json 3

--- a/.travis/script_test.sh
+++ b/.travis/script_test.sh
@@ -2,6 +2,7 @@
 
 set -ex
 
+vendor/bin/psalm.phar || true # As we are only now starting to run Psalm we don't expect it to succed right now.
 vendor/bin/phpunit $PHPUNIT_FLAGS
 phpenv config-rm xdebug.ini || true
 php tests/benchmark.php json 3

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,6 +19,16 @@ The most common errors can be automatically fixed just by running `vendor/bin/ph
 
 We're using [`composer/composer`](https://github.com/composer/composer) to manage dependencies
 
+## Static Analysis
+
+We use [Psalm](https://psalm.dev/) to run static analysis checks on the codebase. You can
+check for errors by calling `vendor/bin/psalm.phar --show-info=false`.
+
+Issues from before the point we started using Psalm are listed in the 'baseline file', and are ignored when running
+psalm. If you have made substantial changes, or you have fixed one of these errors and want to ensure it doesn't come
+back, run `vendor/bin/psalm.phar --update-baseline` and commit the changes it will make
+in [baseline.xml](./.psalm/baseline.xml).
+
 ## Unit-Tests
 
 Please try to add a test for your pull-request. This project uses [PHPUnit](https://phpunit.de/) as testing framework.

--- a/composer.json
+++ b/composer.json
@@ -42,7 +42,8 @@
         "symfony/filesystem": "^3.0|^4.0",
         "symfony/expression-language": "^3.0|^4.0",
         "phpunit/phpunit": "^7.5",
-        "doctrine/coding-standard": "^5.0"
+        "doctrine/coding-standard": "^5.0",
+        "psalm/phar": "3.4.1"
     },
     "conflict": {
         "hoa/core": "*",

--- a/psalm.xml
+++ b/psalm.xml
@@ -1,0 +1,53 @@
+<?xml version="1.0"?>
+<psalm
+    totallyTyped="false"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns="https://getpsalm.org/schema/config"
+    xsi:schemaLocation="https://getpsalm.org/schema/config vendor/vimeo/psalm/config.xsd"
+>
+    <projectFiles>
+        <directory name="src" />
+        <ignoreFiles>
+            <directory name="vendor" />
+        </ignoreFiles>
+    </projectFiles>
+
+    <issueHandlers>
+        <LessSpecificReturnType errorLevel="info" />
+
+        <!-- level 3 issues - slightly lazy code writing, but provably low false-negatives -->
+
+        <DeprecatedMethod errorLevel="info" />
+        <DeprecatedProperty errorLevel="info" />
+        <DeprecatedClass errorLevel="info" />
+        <DeprecatedConstant errorLevel="info" />
+        <DeprecatedInterface errorLevel="info" />
+        <DeprecatedTrait errorLevel="info" />
+
+        <InternalMethod errorLevel="info" />
+        <InternalProperty errorLevel="info" />
+        <InternalClass errorLevel="info" />
+
+        <MissingClosureReturnType errorLevel="info" />
+        <MissingReturnType errorLevel="info" />
+        <MissingPropertyType errorLevel="info" />
+        <InvalidDocblock errorLevel="info" />
+        <MisplacedRequiredParam errorLevel="info" />
+
+        <PropertyNotSetInConstructor errorLevel="info" />
+        <MissingConstructor errorLevel="info" />
+        <MissingClosureParamType errorLevel="info" />
+        <MissingParamType errorLevel="info" />
+
+        <RedundantCondition errorLevel="info" />
+
+        <DocblockTypeContradiction errorLevel="info" />
+        <RedundantConditionGivenDocblockType errorLevel="info" />
+
+        <UnresolvableInclude errorLevel="info" />
+
+        <RawObjectIteration errorLevel="info" />
+
+        <InvalidStringClass errorLevel="info" />
+    </issueHandlers>
+</psalm>

--- a/psalm.xml
+++ b/psalm.xml
@@ -4,6 +4,7 @@
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xmlns="https://getpsalm.org/schema/config"
     xsi:schemaLocation="https://getpsalm.org/schema/config vendor/vimeo/psalm/config.xsd"
+    errorBaseline=".psalm/baseline.xml"
 >
     <projectFiles>
         <directory name="src" />

--- a/psalm.xml
+++ b/psalm.xml
@@ -32,7 +32,6 @@
         <MissingClosureReturnType errorLevel="info" />
         <MissingReturnType errorLevel="info" />
         <MissingPropertyType errorLevel="info" />
-        <InvalidDocblock errorLevel="info" />
         <MisplacedRequiredParam errorLevel="info" />
 
         <PropertyNotSetInConstructor errorLevel="info" />

--- a/psalm.xml
+++ b/psalm.xml
@@ -16,19 +16,6 @@
     <issueHandlers>
         <LessSpecificReturnType errorLevel="info" />
 
-        <!-- level 3 issues - slightly lazy code writing, but provably low false-negatives -->
-
-        <DeprecatedMethod errorLevel="info" />
-        <DeprecatedProperty errorLevel="info" />
-        <DeprecatedClass errorLevel="info" />
-        <DeprecatedConstant errorLevel="info" />
-        <DeprecatedInterface errorLevel="info" />
-        <DeprecatedTrait errorLevel="info" />
-
-        <InternalMethod errorLevel="info" />
-        <InternalProperty errorLevel="info" />
-        <InternalClass errorLevel="info" />
-
         <MissingClosureReturnType errorLevel="info" />
         <MissingReturnType errorLevel="info" />
         <MissingPropertyType errorLevel="info" />
@@ -43,11 +30,5 @@
 
         <DocblockTypeContradiction errorLevel="info" />
         <RedundantConditionGivenDocblockType errorLevel="info" />
-
-        <UnresolvableInclude errorLevel="info" />
-
-        <RawObjectIteration errorLevel="info" />
-
-        <InvalidStringClass errorLevel="info" />
     </issueHandlers>
 </psalm>

--- a/src/Metadata/Driver/YamlDriver.php
+++ b/src/Metadata/Driver/YamlDriver.php
@@ -342,6 +342,7 @@ class YamlDriver extends AbstractFileDriver
      */
     protected function getExtensions(): array
     {
+        /** @psalm-suppress DeprecatedMethod */
         return array_unique([$this->getExtension(), 'yaml', 'yml']);
     }
 

--- a/src/SerializerInterface.php
+++ b/src/SerializerInterface.php
@@ -23,7 +23,7 @@ interface SerializerInterface
      *
      * @return mixed
      *
-     * @psalm-template T
+     * @psalm-templateeeeeeeeeeeeeee T
      * @psalm-param class-string<T> $type
      * @psalm-return T
      */

--- a/src/SerializerInterface.php
+++ b/src/SerializerInterface.php
@@ -23,7 +23,7 @@ interface SerializerInterface
      *
      * @return mixed
      *
-     * @psalm-templateeeeeeeeeeeeeee T
+     * @psalm-template T
      * @psalm-param class-string<T> $type
      * @psalm-return T
      */


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| Doc updated   | no
| BC breaks?    | no <!-- don't forget updating UPGRADING.md file -->
| Deprecations? | no <!-- don't forget updating UPGRADING.md file -->
| Tests pass?   | yes
| Fixed tickets | 
| License       | MIT

As discussed at https://github.com/schmittjoh/serializer/pull/1091#issuecomment-498553779 , this PR adds [psalm](https://psalm.dev/) to the travis config, and will cause a build failure if psalm detects a new issue, for example an [InvalidDocblock](https://psalm.dev/docs/issues/#invaliddocblock) in [SerializerInterface](https://github.com/schmittjoh/serializer/blob/464c634626a45f9616f99672ac614022feadf32f/src/SerializerInterface.php#L28) , where I added psalm-specific annotations yesterday.

It's normal for any static analyser to find many issues on first run, and since it would be too much work to fix these all at once, the existing issues are listed in .psalm/baseline.xml and will not fail the build. However they do give a good idea of what sort of issues psalm will complain about in future, so I would suggest reviewing this (or the output at https://travis-ci.org/bdsl/serializer/jobs/541397116 ) before merging this PR.

Since this PR is all about the build pipeline, I suggest reviewing the build history at https://travis-ci.org/bdsl/serializer/builds