### PR TITLE
Implement "empty" XML namespace handling

### DIFF
--- a/src/XmlDeserializationVisitor.php
+++ b/src/XmlDeserializationVisitor.php
@@ -314,6 +314,14 @@ final class XmlDeserializationVisitor extends AbstractVisitor implements NullAwa
             if (!$node->count()) {
                 throw new NotAcceptableException();
             }
+        } elseif ('' === $metadata->xmlNamespace) {
+            // See #1087 - element must be like: <element xmlns="" /> - https://www.w3.org/TR/REC-xml-names/#iri-use
+            // Use of an empty string in a namespace declaration turns it into an "undeclaration".
+            $nodes = $data->xpath('./' . $name);
+            if (empty($nodes)) {
+                throw new NotAcceptableException();
+            }
+            $node = reset($nodes);
         } else {
             $namespaces = $data->getDocNamespaces();
             if (isset($namespaces[''])) {

--- a/tests/Fixtures/ObjectWithXmlNamespaces.php
+++ b/tests/Fixtures/ObjectWithXmlNamespaces.php
@@ -48,12 +48,19 @@ class ObjectWithXmlNamespaces
      */
     private $language;
 
-    public function __construct($title, $author, \DateTime $createdAt, $language)
+    /**
+     * @Type("string")
+     * @XmlElement(namespace="")
+     */
+    private $emptyNsElement;
+
+    public function __construct($title, $author, \DateTime $createdAt, $language, $emptyNsElement)
     {
         $this->title = $title;
         $this->author = $author;
         $this->createdAt = $createdAt;
         $this->language = $language;
+        $this->emptyNsElement = $emptyNsElement;
         $this->etag = sha1($this->createdAt->format(\DateTime::ATOM));
     }
 }

--- a/tests/Fixtures/ObjectWithXmlRootNamespace.php
+++ b/tests/Fixtures/ObjectWithXmlRootNamespace.php
@@ -6,6 +6,7 @@ namespace JMS\Serializer\Tests\Fixtures;
 
 use JMS\Serializer\Annotation\Type;
 use JMS\Serializer\Annotation\XmlAttribute;
+use JMS\Serializer\Annotation\XmlElement;
 use JMS\Serializer\Annotation\XmlRoot;
 
 /**
@@ -41,12 +42,19 @@ class ObjectWithXmlRootNamespace
      */
     private $language;
 
-    public function __construct($title, $author, \DateTime $createdAt, $language)
+    /**
+     * @Type("string")
+     * @XmlElement(namespace="")
+     */
+    private $emptyNsElement;
+
+    public function __construct($title, $author, \DateTime $createdAt, $language, $emptyNsElement)
     {
         $this->title = $title;
         $this->author = $author;
         $this->createdAt = $createdAt;
         $this->language = $language;
+        $this->emptyNsElement = $emptyNsElement;
         $this->etag = sha1($this->createdAt->format(\DateTime::ATOM));
     }
 }

--- a/tests/Serializer/XmlSerializationTest.php
+++ b/tests/Serializer/XmlSerializationTest.php
@@ -370,7 +370,7 @@ class XmlSerializationTest extends BaseSerializationTest
 
     public function testObjectWithXmlNamespaces()
     {
-        $object = new ObjectWithXmlNamespaces('This is a nice title.', 'Foo Bar', new \DateTime('2011-07-30 00:00', new \DateTimeZone('UTC')), 'en');
+        $object = new ObjectWithXmlNamespaces('This is a nice title.', 'Foo Bar', new \DateTime('2011-07-30 00:00', new \DateTimeZone('UTC')), 'en', 'value for empty namespace property');
 
         $serialized = $this->serialize($object);
         self::assertEquals($this->getContent('object_with_xml_namespaces'), $serialized);
@@ -385,6 +385,7 @@ class XmlSerializationTest extends BaseSerializationTest
         self::assertEquals('en', $this->xpathFirstToString($xml, './@ns1:language'));
         self::assertEquals('This is a nice title.', $this->xpathFirstToString($xml, './ns1:title'));
         self::assertEquals('Foo Bar', $this->xpathFirstToString($xml, './ns3:author'));
+        self::assertEquals('value for empty namespace property', $this->xpathFirstToString($xml, './empty_ns_element'));
 
         $deserialized = $this->deserialize($this->getContent('object_with_xml_namespacesalias'), get_class($object));
         self::assertEquals('2011-07-30T00:00:00+00:00', $this->getField($deserialized, 'createdAt')->format(\DateTime::ATOM));
@@ -392,6 +393,7 @@ class XmlSerializationTest extends BaseSerializationTest
         self::assertAttributeSame('e86ce85cdb1253e4fc6352f5cf297248bceec62b', 'etag', $deserialized);
         self::assertAttributeSame('en', 'language', $deserialized);
         self::assertAttributeEquals('Foo Bar', 'author', $deserialized);
+        self::assertEquals('value for empty namespace property', $this->getField($deserialized, 'emptyNsElement'));
     }
 
     public function testObjectWithXmlNamespacesAndBackReferencedNamespaces()
@@ -430,7 +432,7 @@ class XmlSerializationTest extends BaseSerializationTest
 
     public function testObjectWithXmlRootNamespace()
     {
-        $object = new ObjectWithXmlRootNamespace('This is a nice title.', 'Foo Bar', new \DateTime('2011-07-30 00:00', new \DateTimeZone('UTC')), 'en');
+        $object = new ObjectWithXmlRootNamespace('This is a nice title.', 'Foo Bar', new \DateTime('2011-07-30 00:00', new \DateTimeZone('UTC')), 'en', 'value for empty namespace property');
         self::assertEquals($this->getContent('object_with_xml_root_namespace'), $this->serialize($object));
     }
 

--- a/tests/Serializer/xml/object_with_xml_namespaces.xml
+++ b/tests/Serializer/xml/object_with_xml_namespaces.xml
@@ -2,4 +2,5 @@
 <ex:test-object xmlns:ex="http://example.com/namespace" xmlns:gd="http://schemas.google.com/g/2005" xmlns:atom="http://www.w3.org/2005/Atom" xmlns:ns-fde543a0="http://purl.org/dc/elements/1.1/" created_at="2011-07-30T00:00:00+00:00" gd:etag="e86ce85cdb1253e4fc6352f5cf297248bceec62b" ns-fde543a0:language="en">
   <ns-fde543a0:title xmlns:ns-fde543a0="http://purl.org/dc/elements/1.1/"><![CDATA[This is a nice title.]]></ns-fde543a0:title>
   <atom:author><![CDATA[Foo Bar]]></atom:author>
+  <empty_ns_element><![CDATA[value for empty namespace property]]></empty_ns_element>
 </ex:test-object>

--- a/tests/Serializer/xml/object_with_xml_namespacesalias.xml
+++ b/tests/Serializer/xml/object_with_xml_namespacesalias.xml
@@ -2,4 +2,5 @@
 <test-object xmlns="http://example.com/namespace" xmlns:name1="http://schemas.google.com/g/2005" xmlns:name2="http://www.w3.org/2005/Atom" xmlns:name3="http://purl.org/dc/elements/1.1/" created_at="2011-07-30T00:00:00+00:00" name1:etag="e86ce85cdb1253e4fc6352f5cf297248bceec62b" name3:language="en">
   <name3:title><![CDATA[This is a nice title.]]></name3:title>
   <name2:author><![CDATA[Foo Bar]]></name2:author>
+  <empty_ns_element xmlns=""><![CDATA[value for empty namespace property]]></empty_ns_element>
 </test-object>

--- a/tests/Serializer/xml/object_with_xml_root_namespace.xml
+++ b/tests/Serializer/xml/object_with_xml_root_namespace.xml
@@ -2,4 +2,5 @@
 <test-object xmlns="http://example.com/namespace" created_at="2011-07-30T00:00:00+00:00" etag="e86ce85cdb1253e4fc6352f5cf297248bceec62b" language="en">
   <title><![CDATA[This is a nice title.]]></title>
   <author><![CDATA[Foo Bar]]></author>
+  <empty_ns_element xmlns=""><![CDATA[value for empty namespace property]]></empty_ns_element>
 </test-object>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | yes
| Doc updated   | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #1087
| License       | MIT

This is a basic implementation of `xmlns=""` handling.

The implementation works for me (see the tests).