### PR TITLE
Support conditional exclude for classes

### DIFF
--- a/doc/cookbook/exclusion_strategies.rst
+++ b/doc/cookbook/exclusion_strategies.rst
@@ -272,12 +272,16 @@ Dynamic exclusion strategy
 If the previous exclusion strategies are not enough, is possible to use the ``ExpressionLanguageExclusionStrategy``
 that uses the `symfony expression language`_ to
 allow a more sophisticated exclusion strategies using ``@Exclude(if="expression")`` and ``@Expose(if="expression")`` methods.
+This also works on class level, but is only evaluated during ``serialze`` and does not have any effect during ``deserialze``.
 
 
 .. code-block :: php
 
     <?php
 
+    /**
+     * @Exclude(if="true")
+    */
     class MyObject
     {
         /**
@@ -314,7 +318,7 @@ By default the serializer exposes three variables (`object`, `context` and `prop
 
 .. code-block :: php
 
-        <?php
+    <?php
 
     class MyObject
     {

--- a/src/Exclusion/ExpressionLanguageExclusionStrategy.php
+++ b/src/Exclusion/ExpressionLanguageExclusionStrategy.php
@@ -8,6 +8,7 @@ use JMS\Serializer\Context;
 use JMS\Serializer\Expression\CompilableExpressionEvaluatorInterface;
 use JMS\Serializer\Expression\Expression;
 use JMS\Serializer\Expression\ExpressionEvaluatorInterface;
+use JMS\Serializer\Metadata\ClassMetadata;
 use JMS\Serializer\Metadata\PropertyMetadata;
 use JMS\Serializer\SerializationContext;
 
@@ -29,6 +30,33 @@ final class ExpressionLanguageExclusionStrategy
     public function __construct(ExpressionEvaluatorInterface $expressionEvaluator)
     {
         $this->expressionEvaluator = $expressionEvaluator;
+    }
+
+
+    /**
+     * {@inheritDoc}
+     */
+    public function shouldSkipClass(ClassMetadata $class, Context $navigatorContext): bool
+    {
+        if (null === $class->excludeIf) {
+            return false;
+        }
+
+        $variables = [
+            'context' => $navigatorContext,
+            'property_metadata' => $class,
+        ];
+        if ($navigatorContext instanceof SerializationContext) {
+            $variables['object'] = $navigatorContext->getObject();
+        } else {
+            $variables['object'] = null;
+        }
+
+        if (($class->excludeIf instanceof Expression) && ($this->expressionEvaluator instanceof CompilableExpressionEvaluatorInterface)) {
+            return $this->expressionEvaluator->evaluateParsed($class->excludeIf, $variables);
+        }
+
+        return $this->expressionEvaluator->evaluate($class->excludeIf, $variables);
     }
 
     /**

--- a/src/Exclusion/ExpressionLanguageExclusionStrategy.php
+++ b/src/Exclusion/ExpressionLanguageExclusionStrategy.php
@@ -44,7 +44,7 @@ final class ExpressionLanguageExclusionStrategy
 
         $variables = [
             'context' => $navigatorContext,
-            'property_metadata' => $class,
+            'class_metadata' => $class,
         ];
         if ($navigatorContext instanceof SerializationContext) {
             $variables['object'] = $navigatorContext->getObject();

--- a/src/GraphNavigator/SerializationGraphNavigator.php
+++ b/src/GraphNavigator/SerializationGraphNavigator.php
@@ -217,6 +217,12 @@ final class SerializationGraphNavigator extends GraphNavigator implements GraphN
                     throw new ExcludedClassException();
                 }
 
+                if (null !== $this->expressionExclusionStrategy && $this->expressionExclusionStrategy->shouldSkipClass($metadata, $this->context)) {
+                    $this->context->stopVisiting($data);
+
+                    throw new ExcludedClassException();
+                }
+
                 $this->context->pushClassMetadata($metadata);
 
                 foreach ($metadata->preSerializeMethods as $method) {

--- a/src/Metadata/ClassMetadata.php
+++ b/src/Metadata/ClassMetadata.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace JMS\Serializer\Metadata;
 
 use JMS\Serializer\Exception\InvalidMetadataException;
+use JMS\Serializer\Expression\Expression;
 use JMS\Serializer\Ordering\AlphabeticalPropertyOrderingStrategy;
 use JMS\Serializer\Ordering\CustomPropertyOrderingStrategy;
 use JMS\Serializer\Ordering\IdenticalPropertyOrderingStrategy;
@@ -127,7 +128,7 @@ class ClassMetadata extends MergeableClassMetadata
     public $xmlDiscriminatorNamespace;
 
     /**
-     * @var string
+     * @var string|Expression
      */
     public $excludeIf;
 

--- a/src/Metadata/ClassMetadata.php
+++ b/src/Metadata/ClassMetadata.php
@@ -126,6 +126,11 @@ class ClassMetadata extends MergeableClassMetadata
      */
     public $xmlDiscriminatorNamespace;
 
+    /**
+     * @var string
+     */
+    public $excludeIf;
+
     public function setDiscriminator(string $fieldName, array $map, array $groups = []): void
     {
         if (empty($fieldName)) {
@@ -288,6 +293,7 @@ class ClassMetadata extends MergeableClassMetadata
             $this->discriminatorValue,
             $this->discriminatorMap,
             $this->discriminatorGroups,
+            $this->excludeIf,
             parent::serialize(),
             'discriminatorGroups' => $this->discriminatorGroups,
             'xmlDiscriminatorAttribute' => $this->xmlDiscriminatorAttribute,
@@ -328,6 +334,7 @@ class ClassMetadata extends MergeableClassMetadata
             $this->discriminatorValue,
             $this->discriminatorMap,
             $this->discriminatorGroups,
+            $this->excludeIf,
             $parentStr,
         ] = $unserialized;
 

--- a/src/Metadata/Driver/AnnotationDriver.php
+++ b/src/Metadata/Driver/AnnotationDriver.php
@@ -99,7 +99,11 @@ class AnnotationDriver implements DriverInterface
             } elseif ($annot instanceof XmlNamespace) {
                 $classMetadata->registerNamespace($annot->uri, $annot->prefix);
             } elseif ($annot instanceof Exclude) {
-                $excludeAll = true;
+                if (null !== $annot->if) {
+                    $classMetadata->excludeIf = $this->parseExpression('!(' . $annot->if . ')');
+                } else {
+                    $excludeAll = true;
+                }
             } elseif ($annot instanceof AccessType) {
                 $classAccessType = $annot->type;
             } elseif ($annot instanceof ReadOnly) {

--- a/src/Metadata/Driver/XmlDriver.php
+++ b/src/Metadata/Driver/XmlDriver.php
@@ -67,6 +67,11 @@ class XmlDriver extends AbstractFileDriver
         $exclusionPolicy = strtoupper((string) $elem->attributes()->{'exclusion-policy'}) ?: 'NONE';
         $exclude = $elem->attributes()->exclude;
         $excludeAll = null !== $exclude ? 'true' === strtolower((string) $exclude) : false;
+
+        if (null !== $excludeIf = $elem->attributes()->{'exclude-if'}) {
+            $metadata->excludeIf = $this->parseExpression((string) $excludeIf);
+        }
+
         $classAccessType = (string) ($elem->attributes()->{'access-type'} ?: PropertyMetadata::ACCESS_TYPE_PROPERTY);
 
         $propertiesMetadata = [];

--- a/src/Metadata/Driver/XmlDriver.php
+++ b/src/Metadata/Driver/XmlDriver.php
@@ -69,7 +69,7 @@ class XmlDriver extends AbstractFileDriver
         $excludeAll = null !== $exclude ? 'true' === strtolower((string) $exclude) : false;
 
         if (null !== $excludeIf = $elem->attributes()->{'exclude-if'}) {
-            $metadata->excludeIf = $this->parseExpression((string) $excludeIf);
+            $metadata->excludeIf = $this->parseExpression('!(' . (string) $excludeIf . ')');
         }
 
         $classAccessType = (string) ($elem->attributes()->{'access-type'} ?: PropertyMetadata::ACCESS_TYPE_PROPERTY);

--- a/src/Metadata/Driver/YamlDriver.php
+++ b/src/Metadata/Driver/YamlDriver.php
@@ -109,6 +109,11 @@ class YamlDriver extends AbstractFileDriver
 
         $exclusionPolicy = isset($config['exclusion_policy']) ? strtoupper($config['exclusion_policy']) : 'NONE';
         $excludeAll = isset($config['exclude']) ? (bool) $config['exclude'] : false;
+
+        if (isset($config['exclude_if'])) {
+            $metadata->excludeIf = $this->parseExpression((string) $config['exclude_if']);
+        }
+
         $classAccessType = $config['access_type'] ?? PropertyMetadata::ACCESS_TYPE_PROPERTY;
         $readOnlyClass = isset($config['read_only']) ? (bool) $config['read_only'] : false;
         $this->addClassProperties($metadata, $config);

--- a/src/Metadata/Driver/YamlDriver.php
+++ b/src/Metadata/Driver/YamlDriver.php
@@ -111,7 +111,7 @@ class YamlDriver extends AbstractFileDriver
         $excludeAll = isset($config['exclude']) ? (bool) $config['exclude'] : false;
 
         if (isset($config['exclude_if'])) {
-            $metadata->excludeIf = $this->parseExpression((string) $config['exclude_if']);
+            $metadata->excludeIf = $this->parseExpression('!(' . (string) $config['exclude_if'] . ')');
         }
 
         $classAccessType = $config['access_type'] ?? PropertyMetadata::ACCESS_TYPE_PROPERTY;

--- a/src/Metadata/PropertyMetadata.php
+++ b/src/Metadata/PropertyMetadata.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace JMS\Serializer\Metadata;
 
 use JMS\Serializer\Exception\InvalidMetadataException;
+use JMS\Serializer\Expression\Expression;
 use Metadata\PropertyMetadata as BasePropertyMetadata;
 
 class PropertyMetadata extends BasePropertyMetadata
@@ -124,7 +125,7 @@ class PropertyMetadata extends BasePropertyMetadata
     public $maxDepth = null;
 
     /**
-     * @var string
+     * @var string|Expression
      */
     public $excludeIf = null;
 

--- a/tests/Fixtures/PersonAccount.php
+++ b/tests/Fixtures/PersonAccount.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace JMS\Serializer\Tests\Fixtures;
+
+use JMS\Serializer\Annotation as Serializer;
+
+/**
+ * @Serializer\Exclude(if="object && object.expired != true")
+ */
+class PersonAccount
+{
+    /**
+     * @Serializer\Type("string")
+     */
+    public $name;
+
+    /**
+     * @Serializer\Type("boolean")
+     */
+    public $expired;
+}

--- a/tests/Fixtures/PersonWithAccounts.php
+++ b/tests/Fixtures/PersonWithAccounts.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace JMS\Serializer\Tests\Fixtures;
+
+use JMS\Serializer\Annotation as Serializer;
+
+class PersonWithAccounts
+{
+    /**
+     * @Serializer\Type("string")
+     */
+    public $name;
+
+    /**
+     * @Serializer\Type("array<JMS\Serializer\Tests\Fixtures\PersonAccount>")
+     */
+    public $accounts = [];
+}

--- a/tests/Metadata/Driver/BaseDriverTest.php
+++ b/tests/Metadata/Driver/BaseDriverTest.php
@@ -568,6 +568,16 @@ abstract class BaseDriverTest extends TestCase
         self::assertEquals($p, $m->propertyMetadata['age']);
     }
 
+    public function testExclusionIfOnClass()
+    {
+        $class = 'JMS\Serializer\Tests\Fixtures\PersonAccount';
+        $m = $this->getDriver()->loadMetadataForClass(new \ReflectionClass($class));
+
+        $c = new ClassMetadata($class);
+        $c->excludeIf = $this->getExpressionEvaluator()->parse('!(object && object.expired != true)', ['context', 'class_metadata', 'object']);
+        self::assertEquals($c->excludeIf->serialize(), $m->excludeIf->serialize());
+    }
+
     public function testObjectWithVirtualPropertiesAndDuplicatePropNameExcludeAll()
     {
         $class = ObjectWithVirtualPropertiesAndDuplicatePropNameExcludeAll::class;

--- a/tests/Metadata/Driver/xml/PersonAccount.xml
+++ b/tests/Metadata/Driver/xml/PersonAccount.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<serializer>
+    <class name="JMS\Serializer\Tests\Fixtures\PersonAccount" exclude-if="object &amp;&amp; object.expired != true">
+        <property name="name" type="string" />
+        <property name="expired" type="boolean"/>
+    </class>
+</serializer>

--- a/tests/Metadata/Driver/yml/PersonAccount.yaml
+++ b/tests/Metadata/Driver/yml/PersonAccount.yaml
@@ -1,0 +1,6 @@
+JMS\Serializer\Tests\Fixtures\PersonAccount:
+  exclude_if: 'object && object.expired != true'
+  properties:
+    title:
+      name: string
+      expired: boolean

--- a/tests/Serializer/GraphNavigatorTest.php
+++ b/tests/Serializer/GraphNavigatorTest.php
@@ -211,12 +211,13 @@ class TestSubscribingHandler implements SubscribingHandlerInterface
 
     public static function getSubscribingMethods()
     {
-        return [[
-            'type' => 'JsonSerializable',
-            'format' => self::FORMAT,
-            'direction' => GraphNavigatorInterface::DIRECTION_SERIALIZATION,
-            'method' => 'serialize',
-        ],
+        return [
+            [
+                'type' => 'JsonSerializable',
+                'format' => self::FORMAT,
+                'direction' => GraphNavigatorInterface::DIRECTION_SERIALIZATION,
+                'method' => 'serialize',
+            ],
         ];
     }
 }


### PR DESCRIPTION
Hi,

after further checking #1098, I've noticed that this functionality just isn't there yet. I've created a first draft PR for supporting condtional excludes on class level.

The PR includes the changes in class metadata and SerializationGraphNavigator as well as the annotation driver. 

Still missing is:
* Evaluate condition in DeserializationGraphNavigator
* Other Metadata drivers
* Unit tests

While all existing tests are passing, I was not able to add the corresponding unit tests for this case. I'm also not sure if there are any unintended side effects by not completely excluding the class if there is an \@Exclude annotation like it is done at the moment, but keeping it and do the evaluation during serialization.

Thanks for your help!

| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| Doc updated   | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #1098
| License       | MIT

