### PR TITLE
Revert "Move type check when deserializing into the graph navigator"

### DIFF
--- a/src/Exception/RuntimeException.php
+++ b/src/Exception/RuntimeException.php
@@ -11,4 +11,12 @@ namespace JMS\Serializer\Exception;
  */
 class RuntimeException extends \RuntimeException implements Exception
 {
+    public static function noMetadataForProperty(string $class, string $prop): self
+    {
+        return new RuntimeException(sprintf(
+            'You must define a type for %s::$%s.',
+            $class,
+            $prop
+        ));
+    }
 }

--- a/src/GraphNavigator/DeserializationGraphNavigator.php
+++ b/src/GraphNavigator/DeserializationGraphNavigator.php
@@ -198,10 +198,6 @@ final class DeserializationGraphNavigator extends GraphNavigator implements Grap
                         continue;
                     }
 
-                    if (!$propertyMetadata->type) {
-                        throw new RuntimeException(sprintf('You must define a type for %s::$%s.', $propertyMetadata->class, $propertyMetadata->name));
-                    }
-
                     $this->context->pushPropertyMetadata($propertyMetadata);
                     try {
                         $v = $this->visitor->visitProperty($propertyMetadata, $data);

--- a/src/JsonDeserializationVisitor.php
+++ b/src/JsonDeserializationVisitor.php
@@ -164,11 +164,7 @@ final class JsonDeserializationVisitor extends AbstractVisitor implements Deseri
 
         if (true === $metadata->inline) {
             if (!$metadata->type) {
-                throw new RuntimeException(sprintf(
-                    'You must define a type for %s::$%s.',
-                    $metadata->class,
-                    $metadata->name
-                ));
+                throw RuntimeException::noMetadataForProperty($metadata->class, $metadata->name);
             }
             return $this->navigator->accept($data, $metadata->type);
         }
@@ -178,7 +174,7 @@ final class JsonDeserializationVisitor extends AbstractVisitor implements Deseri
         }
 
         if (!$metadata->type) {
-            throw new RuntimeException(sprintf('You must define a type for %s::$%s.', $metadata->class, $metadata->name));
+            throw RuntimeException::noMetadataForProperty($metadata->class, $metadata->name);
         }
 
         return null !== $data[$name] ? $this->navigator->accept($data[$name], $metadata->type) : null;

--- a/src/JsonDeserializationVisitor.php
+++ b/src/JsonDeserializationVisitor.php
@@ -152,8 +152,10 @@ final class JsonDeserializationVisitor extends AbstractVisitor implements Deseri
      */
     public function visitProperty(PropertyMetadata $metadata, $data)
     {
+        $name = $metadata->serializedName;
+
         if (null === $data) {
-            return null;
+            return;
         }
 
         if (!\is_array($data)) {
@@ -161,12 +163,22 @@ final class JsonDeserializationVisitor extends AbstractVisitor implements Deseri
         }
 
         if (true === $metadata->inline) {
+            if (!$metadata->type) {
+                throw new RuntimeException(sprintf(
+                    'You must define a type for %s::$%s.',
+                    $metadata->class,
+                    $metadata->name
+                ));
+            }
             return $this->navigator->accept($data, $metadata->type);
         }
 
-        $name = $metadata->serializedName;
         if (!array_key_exists($name, $data)) {
             throw new NotAcceptableException();
+        }
+
+        if (!$metadata->type) {
+            throw new RuntimeException(sprintf('You must define a type for %s::$%s.', $metadata->class, $metadata->name));
         }
 
         return null !== $data[$name] ? $this->navigator->accept($data[$name], $metadata->type) : null;

--- a/src/XmlDeserializationVisitor.php
+++ b/src/XmlDeserializationVisitor.php
@@ -281,15 +281,18 @@ final class XmlDeserializationVisitor extends AbstractVisitor implements NullAwa
     {
         $name = $metadata->serializedName;
 
-        if (!$metadata->type) {
-            throw new RuntimeException(sprintf('You must define a type for %s::$%s.', $metadata->class, $metadata->name));
-        }
         if (true === $metadata->inline) {
+            if (!$metadata->type) {
+                throw new RuntimeException(sprintf('You must define a type for %s::$%s.', $metadata->class, $metadata->name));
+            }
             return $this->navigator->accept($data, $metadata->type);
         }
         if ($metadata->xmlAttribute) {
             $attributes = $data->attributes($metadata->xmlNamespace);
             if (isset($attributes[$name])) {
+                if (!$metadata->type) {
+                    throw new RuntimeException(sprintf('You must define a type for %s::$%s.', $metadata->class, $metadata->name));
+                }
                 return $this->navigator->accept($attributes[$name], $metadata->type);
             }
 
@@ -297,6 +300,9 @@ final class XmlDeserializationVisitor extends AbstractVisitor implements NullAwa
         }
 
         if ($metadata->xmlValue) {
+            if (!$metadata->type) {
+                throw new RuntimeException(sprintf('You must define a type for %s::$%s.', $metadata->class, $metadata->name));
+            }
             return $this->navigator->accept($data, $metadata->type);
         }
 
@@ -307,6 +313,9 @@ final class XmlDeserializationVisitor extends AbstractVisitor implements NullAwa
             }
 
             $this->setCurrentMetadata($metadata);
+            if (!$metadata->type) {
+                throw new RuntimeException(sprintf('You must define a type for %s::$%s.', $metadata->class, $metadata->name));
+            }
             $v = $this->navigator->accept($enclosingElem, $metadata->type);
             $this->revertCurrentMetadata();
             return $v;
@@ -344,6 +353,9 @@ final class XmlDeserializationVisitor extends AbstractVisitor implements NullAwa
             $this->setCurrentMetadata($metadata);
         }
 
+        if (!$metadata->type) {
+            throw new RuntimeException(sprintf('You must define a type for %s::$%s.', $metadata->class, $metadata->name));
+        }
         return $this->navigator->accept($node, $metadata->type);
     }
 

--- a/src/XmlDeserializationVisitor.php
+++ b/src/XmlDeserializationVisitor.php
@@ -283,7 +283,7 @@ final class XmlDeserializationVisitor extends AbstractVisitor implements NullAwa
 
         if (true === $metadata->inline) {
             if (!$metadata->type) {
-                throw new RuntimeException(sprintf('You must define a type for %s::$%s.', $metadata->class, $metadata->name));
+                throw RuntimeException::noMetadataForProperty($metadata->class, $metadata->name);
             }
             return $this->navigator->accept($data, $metadata->type);
         }
@@ -291,7 +291,7 @@ final class XmlDeserializationVisitor extends AbstractVisitor implements NullAwa
             $attributes = $data->attributes($metadata->xmlNamespace);
             if (isset($attributes[$name])) {
                 if (!$metadata->type) {
-                    throw new RuntimeException(sprintf('You must define a type for %s::$%s.', $metadata->class, $metadata->name));
+                    throw RuntimeException::noMetadataForProperty($metadata->class, $metadata->name);
                 }
                 return $this->navigator->accept($attributes[$name], $metadata->type);
             }
@@ -301,7 +301,7 @@ final class XmlDeserializationVisitor extends AbstractVisitor implements NullAwa
 
         if ($metadata->xmlValue) {
             if (!$metadata->type) {
-                throw new RuntimeException(sprintf('You must define a type for %s::$%s.', $metadata->class, $metadata->name));
+                throw RuntimeException::noMetadataForProperty($metadata->class, $metadata->name);
             }
             return $this->navigator->accept($data, $metadata->type);
         }
@@ -314,7 +314,7 @@ final class XmlDeserializationVisitor extends AbstractVisitor implements NullAwa
 
             $this->setCurrentMetadata($metadata);
             if (!$metadata->type) {
-                throw new RuntimeException(sprintf('You must define a type for %s::$%s.', $metadata->class, $metadata->name));
+                throw RuntimeException::noMetadataForProperty($metadata->class, $metadata->name);
             }
             $v = $this->navigator->accept($enclosingElem, $metadata->type);
             $this->revertCurrentMetadata();
@@ -354,7 +354,7 @@ final class XmlDeserializationVisitor extends AbstractVisitor implements NullAwa
         }
 
         if (!$metadata->type) {
-            throw new RuntimeException(sprintf('You must define a type for %s::$%s.', $metadata->class, $metadata->name));
+            throw RuntimeException::noMetadataForProperty($metadata->class, $metadata->name);
         }
         return $this->navigator->accept($node, $metadata->type);
     }

--- a/src/XmlDeserializationVisitor.php
+++ b/src/XmlDeserializationVisitor.php
@@ -281,6 +281,9 @@ final class XmlDeserializationVisitor extends AbstractVisitor implements NullAwa
     {
         $name = $metadata->serializedName;
 
+        if (!$metadata->type) {
+            throw new RuntimeException(sprintf('You must define a type for %s::$%s.', $metadata->class, $metadata->name));
+        }
         if (true === $metadata->inline) {
             return $this->navigator->accept($data, $metadata->type);
         }

--- a/tests/Fixtures/ParentNoMetadata.php
+++ b/tests/Fixtures/ParentNoMetadata.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace JMS\Serializer\Tests\Fixtures;
+
+class ParentNoMetadata
+{
+    public $foo;
+}

--- a/tests/Fixtures/ParentNoMetadataChildObject.php
+++ b/tests/Fixtures/ParentNoMetadataChildObject.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace JMS\Serializer\Tests\Fixtures;
+
+use JMS\Serializer\Annotation as Serializer;
+
+class ParentNoMetadataChildObject extends ParentNoMetadata
+{
+    /**
+     * @Serializer\Type("string")
+     *
+     * @var string
+     */
+    public $bar;
+}

--- a/tests/Serializer/BaseSerializationTest.php
+++ b/tests/Serializer/BaseSerializationTest.php
@@ -86,6 +86,7 @@ use JMS\Serializer\Tests\Fixtures\ObjectWithVersionedVirtualProperties;
 use JMS\Serializer\Tests\Fixtures\ObjectWithVirtualProperties;
 use JMS\Serializer\Tests\Fixtures\Order;
 use JMS\Serializer\Tests\Fixtures\ParentDoNotSkipWithEmptyChild;
+use JMS\Serializer\Tests\Fixtures\ParentNoMetadataChildObject;
 use JMS\Serializer\Tests\Fixtures\ParentSkipWithEmptyChild;
 use JMS\Serializer\Tests\Fixtures\PersonSecret;
 use JMS\Serializer\Tests\Fixtures\PersonSecretMore;
@@ -146,6 +147,15 @@ abstract class BaseSerializationTest extends TestCase
             $this->getContent('nullable'),
             $this->serializer->serialize($arr, $this->getFormat(), SerializationContext::create()->setSerializeNull(true))
         );
+    }
+
+    public function testNoMetadataNeededWhenDeSerializingNotUsedProperty()
+    {
+        /** @var ParentNoMetadataChildObject $dObj */
+        $object = $this->deserialize($this->getContent('ParentNoMetadataChildObject'), ParentNoMetadataChildObject::class);
+
+        self::assertSame('John', $object->bar);
+        self::assertNull($object->foo);
     }
 
     public function testDeserializeObjectWithMissingTypedArrayProp()

--- a/tests/Serializer/GraphNavigatorTest.php
+++ b/tests/Serializer/GraphNavigatorTest.php
@@ -6,7 +6,6 @@ namespace JMS\Serializer\Tests\Serializer;
 
 use Doctrine\Common\Annotations\AnnotationReader;
 use JMS\Serializer\Accessor\DefaultAccessorStrategy;
-use JMS\Serializer\Annotation as Serializer;
 use JMS\Serializer\Construction\UnserializeObjectConstructor;
 use JMS\Serializer\DeserializationContext;
 use JMS\Serializer\EventDispatcher\EventDispatcher;
@@ -164,11 +163,6 @@ class GraphNavigatorTest extends TestCase
 
 class SerializableClass
 {
-    /**
-     * @Serializer\Type("string")
-     *
-     * @var string
-     */
     public $foo = 'bar';
 }
 

--- a/tests/Serializer/JsonSerializationTest.php
+++ b/tests/Serializer/JsonSerializationTest.php
@@ -123,6 +123,7 @@ class JsonSerializationTest extends BaseSerializationTest
             $outputs['iterator'] = '{"iterator":{"foo":"bar","bar":"foo"}}';
             $outputs['array_iterator'] = '{"iterator":{"foo":"bar","bar":"foo"}}';
             $outputs['generator'] = '{"generator":{"foo":"bar","bar":"foo"}}';
+            $outputs['ParentNoMetadataChildObject'] = '{"bar":"John"}';
         }
 
         if (!isset($outputs[$key])) {

--- a/tests/Serializer/xml/ParentNoMetadataChildObject.xml
+++ b/tests/Serializer/xml/ParentNoMetadataChildObject.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<result>
+  <bar><![CDATA[John]]></bar>
+</result>


### PR DESCRIPTION
Reverts #1080

Closes https://github.com/schmittjoh/serializer/issues/1102


This bugfix resolves a regression introduced in #1080 and reported in #1102

The thing is that the JSON visitor complains about a missing type right before visiting that property. 
Te XML visitor complains immediately, even if the property is not present in the data to visit.

To align the behavior of the two visitors I have relaxed the XML visitor. This unfortunately now had duplicated the check for metadata... that is kinda ugly (and should be fixed).