### PR TITLE
Fix typos in UPGRADING.md

### DIFF
--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -35,7 +35,7 @@ If you are on version `1.x`, it is suggested to migrate directly to `3.0.0` (sin
 - Removed the abstract classes `GenericSerializationVisitor` and `GenericDeserializationVisitor`.
 - Removed deprecated method `VisitorInterface::getNavigator`, use `Context::getNavigator` instead
 - Removed deprecated method `JsonSerializationVisitor::addData`, 
-  use `::visitProperty(new StaticPropertyMetadata('', 'name', null), 'value')` instead
+  use `::visitProperty(new StaticPropertyMetadata('', 'name', 'value'), null)` instead
 - Removed Propel and PhpCollection support
 - Changed default date format from ISO8601 to RFC3339  
 - Event listeners/handlers class names are case sensitive now

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -6,7 +6,7 @@ Upgrading from 2.x to 3.x should require almost no effort.
 The only change is the revert of "deeper branch group exclusion strategy" introduced in 2.0.0 and now reverted as it
 was in 1.x. If you are not using this feature, then upgrading requires no changes at all.
 
-The deprecations introduced in 2.x are still present in 3.0.0, said feature are most likley to be removed in an next major. 
+The deprecations introduced in 2.x are still present in 3.0.0, said features are most likley to be removed in an next major. 
 
 From 1.x to 3.0.0
 =================
@@ -15,12 +15,12 @@ Please follow the upgrade **"From 1.13.0 to 2.0.0"**, skipping the section:
 
 > "deeper branch group exclusion strategy" has a different behaviour, the latest group is used instead of falling back to "Default"
 
-The deprecations introduced in 2.x are still present in 3.0.0, said feature are most likley to be removed in an next major.
+The deprecations introduced in 2.x are still present in 3.0.0, said features are most likley to be removed in an next major.
 
 From 1.13.0 to 2.0.0
 ====================
 
-If you are on version `1.x`, is suggested to migrate directly to `3.0.0` (since `2.x` is not maintained anymore).
+If you are on version `1.x`, it is suggested to migrate directly to `3.0.0` (since `2.x` is not maintained anymore).
 
 **Main changes**
 
@@ -31,11 +31,11 @@ If you are on version `1.x`, is suggested to migrate directly to `3.0.0` (since 
 - "deeper branch group exclusion strategy" has a different behaviour, the latest group is used instead of falling back 
   to "Default" 
 - Most of the classes are marked as `final`, inheritance is discouraged for all the cases, use composition instead
-- Most of the visor configurations and options have been move to visitor factories
-- Removed the abstract classes `GenericSerializationVisito`r and `GenericDeserializationVisitor`.
+- Most of the visitor configurations and options have been moved to visitor factories
+- Removed the abstract classes `GenericSerializationVisitor` and `GenericDeserializationVisitor`.
 - Removed deprecated method `VisitorInterface::getNavigator`, use `Context::getNavigator` instead
 - Removed deprecated method `JsonSerializationVisitor::addData`, 
-  use `:visitProperty(new StaticPropertyMetadata('', 'name', null), 'value')` instead
+  use `::visitProperty(new StaticPropertyMetadata('', 'name', null), 'value')` instead
 - Removed Propel and PhpCollection support
 - Changed default date format from ISO8601 to RFC3339  
 - Event listeners/handlers class names are case sensitive now
@@ -49,10 +49,10 @@ If you are on version `1.x`, is suggested to migrate directly to `3.0.0` (since 
 - Changed `GraphNavigator::accept` signature
 - Removed `Serializer::setSerializationContextFactory` and `Serializer::setDeserializationContextFactory`
 - Removed `Serializer::getMetadataFactory` 
-- As default now JSON preserve trailing zeros when serializing a float
+- As default now JSON preserves trailing zeros when serializing a float
 - When using a discriminator map, parent class should either be declared abstract, or included into the discriminator
   map
-- For the `Context` class (and its childs `SerializationContext` and `DeserializationContext`), `$attributes` property has become `private`, so it's no longer accesible; use `getAttribute()` instead
+- For the `Context` class (and its childs `SerializationContext` and `DeserializationContext`), `$attributes` property has become `private`, so it's no longer accessible; use `getAttribute()` instead
 - When implementing custom type handlers and `$context->shouldSerializeNull()` is `false` (it is `false` by default),
   handlers should throw `NotAcceptableException` exception when `null` is visited.
   
@@ -86,11 +86,11 @@ If you are on version `1.x`, is suggested to migrate directly to `3.0.0` (since 
 - `JsonSerializationVisitor::setData` will be removed, 
   use `::visitProperty(new StaticPropertyMetadata('', 'name', 'value'), null)` instead 
 - `JsonSerializationVisitor::hasData` will be removed 
-- `VisitorInterface` is internal use `SerializationVisitorInterface` and `DeserializationVisitorInterface` instead
-- `GraphNavigator` is internal use `GraphNavigatorInterface` instead
+- `VisitorInterface` is internal, use `SerializationVisitorInterface` and `DeserializationVisitorInterface` instead
+- `GraphNavigator` is internal, use `GraphNavigatorInterface` instead
 
 **Other**
- - elements (as classes, interfaces, methods, properties...)
+- Elements (as classes, interfaces, methods, properties...)
   marked as `@internal` shall not be used in user-land code. BC is not guaranteed on this elements.
-- PSR4 is used  
+- PSR-4 is used  
 - [Here](https://github.com/schmittjoh/serializer/milestone/3) a list of issues and pull requests landed in 2.0


### PR DESCRIPTION
First the document says the new way is to call
`JsonSerializationVisitor::visitProperty(new StaticPropertyMetadata('', 'name', null), 'value')`

Later it says one should call instead
`JsonSerializationVisitor::visitProperty(new StaticPropertyMetadata('', 'name', 'value'), null)`

I'm not sure which one is correct.