### PR TITLE
adds "toArray" and "fromArray" method suggestions to IDEs for autowired s…

### DIFF
--- a/src/SerializerInterface.php
+++ b/src/SerializerInterface.php
@@ -28,4 +28,20 @@ interface SerializerInterface
      * @psalm-return T
      */
     public function deserialize(string $data, string $type, string $format, ?DeserializationContext $context = null);
+    
+    /**
+     * Converts the given data to an array.
+     *
+     * @param mixed $data
+     *
+     * @return array
+     */
+    public function toArray($data, ?SerializationContext $context = null, ?string $type = null): array;
+    
+    /**
+     * Converts the given array to the specified type.
+     *
+     * @param mixed $data
+     */
+    public function fromArray(array $data, string $type, ?DeserializationContext $context = null);
 }

--- a/src/SerializerInterface.php
+++ b/src/SerializerInterface.php
@@ -28,7 +28,7 @@ interface SerializerInterface
      * @psalm-return T
      */
     public function deserialize(string $data, string $type, string $format, ?DeserializationContext $context = null);
-    
+
     /**
      * Converts the given data to an array.
      *
@@ -37,7 +37,7 @@ interface SerializerInterface
      * @return array
      */
     public function toArray($data, ?SerializationContext $context = null, ?string $type = null): array;
-    
+
     /**
      * Converts the given array to the specified type.
      *

--- a/src/SerializerInterface.php
+++ b/src/SerializerInterface.php
@@ -42,6 +42,8 @@ interface SerializerInterface
      * Converts the given array to the specified type.
      *
      * @param mixed $data
+     *
+     * @return mixed
      */
     public function fromArray(array $data, string $type, ?DeserializationContext $context = null);
 }


### PR DESCRIPTION
adds toArray and fromArray method suggestions to IDEs for autowired serializer

since the methods 'toArray' and 'fromArray' are not included in the SerializerInterface, IDEs (e.g. PhpStorm) do not suggest them under available methods when the serializer is injected via autowiring.

| Q             | A
| ------------- | ---
| Bug fix?      | yes/no
| New feature?  | yes/no
| Doc updated   | yes/no
| BC breaks?    | yes/no <!-- don't forget updating UPGRADING.md file -->
| Deprecations? | yes/no <!-- don't forget updating UPGRADING.md file -->
| Tests pass?   | yes/no
| Fixed tickets | #... <!-- #-prefixed issue number(s), if any -->
| License       | MIT

