### PR TITLE
JsonSerializationVisitor::visitProperty documentation update

### DIFF
--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -34,8 +34,8 @@ If you are on version `1.x`, it is suggested to migrate directly to `3.0.0` (sin
 - Most of the visitor configurations and options have been moved to visitor factories
 - Removed the abstract classes `GenericSerializationVisitor` and `GenericDeserializationVisitor`.
 - Removed deprecated method `VisitorInterface::getNavigator`, use `Context::getNavigator` instead
-- Removed deprecated method `JsonSerializationVisitor::addData`, 
-  use `::visitProperty(new StaticPropertyMetadata('', 'name', 'value'), null)` instead
+- Removed deprecated method `JsonSerializationVisitor::setData`, 
+  use `::visitProperty(new StaticPropertyMetadata('', 'name', null), 'value')` instead
 - Removed Propel and PhpCollection support
 - Changed default date format from ISO8601 to RFC3339  
 - Event listeners/handlers class names are case sensitive now
@@ -84,7 +84,7 @@ If you are on version `1.x`, it is suggested to migrate directly to `3.0.0` (sin
 **Deprecations** (will be removed in 3.0)
 
 - `JsonSerializationVisitor::setData` will be removed, 
-  use `::visitProperty(new StaticPropertyMetadata('', 'name', 'value'), null)` instead 
+  use `::visitProperty(new StaticPropertyMetadata('', 'name', null), 'value')` instead 
 - `JsonSerializationVisitor::hasData` will be removed 
 - `VisitorInterface` is internal, use `SerializationVisitorInterface` and `DeserializationVisitorInterface` instead
 - `GraphNavigator` is internal, use `GraphNavigatorInterface` instead

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -34,7 +34,7 @@ If you are on version `1.x`, it is suggested to migrate directly to `3.0.0` (sin
 - Most of the visitor configurations and options have been moved to visitor factories
 - Removed the abstract classes `GenericSerializationVisitor` and `GenericDeserializationVisitor`.
 - Removed deprecated method `VisitorInterface::getNavigator`, use `Context::getNavigator` instead
-- Removed deprecated method `JsonSerializationVisitor::setData`, 
+- Removed deprecated method `JsonSerializationVisitor::addData`, 
   use `::visitProperty(new StaticPropertyMetadata('', 'name', null), 'value')` instead
 - Removed Propel and PhpCollection support
 - Changed default date format from ISO8601 to RFC3339  

--- a/src/JsonSerializationVisitor.php
+++ b/src/JsonSerializationVisitor.php
@@ -166,7 +166,7 @@ final class JsonSerializationVisitor extends AbstractVisitor implements Serializ
     }
 
     /**
-     * @deprecated Use visitProperty(new StaticPropertyMetadata(null, 'name', 'value'), null) instead
+     * @deprecated Use visitProperty(new StaticPropertyMetadata('', 'name', null), 'value') instead
      *
      * Allows you to replace existing data on the current object element.
      *


### PR DESCRIPTION
correct usage of JsonSerializationVisitor::visitProperty

| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| Doc updated   | yes
| BC breaks?    | no <!-- don't forget updating UPGRADING.md file -->
| Deprecations? | no <!-- don't forget updating UPGRADING.md file -->
| Tests pass?   | yes
| Fixed tickets | #1116 
| License       | MIT

Update documentation regarding the usage of JsonSerializationVisitor::visitProperty
