### PR TITLE
Explain once and for all the use of StaticPropertyMetadata

### DIFF
--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -35,7 +35,7 @@ If you are on version `1.x`, it is suggested to migrate directly to `3.0.0` (sin
 - Removed the abstract classes `GenericSerializationVisitor` and `GenericDeserializationVisitor`.
 - Removed deprecated method `VisitorInterface::getNavigator`, use `Context::getNavigator` instead
 - Removed deprecated method `JsonSerializationVisitor::addData`, 
-  use `::visitProperty(new StaticPropertyMetadata('', 'name', 'value'), null)` instead
+  use `::visitProperty(new StaticPropertyMetadata('', 'name', 'value'), 'value')` instead
 - Removed Propel and PhpCollection support
 - Changed default date format from ISO8601 to RFC3339  
 - Event listeners/handlers class names are case sensitive now
@@ -84,7 +84,7 @@ If you are on version `1.x`, it is suggested to migrate directly to `3.0.0` (sin
 **Deprecations** (will be removed in 3.0)
 
 - `JsonSerializationVisitor::setData` will be removed, 
-  use `::visitProperty(new StaticPropertyMetadata('', 'name', 'value'), null)` instead 
+  use `::visitProperty(new StaticPropertyMetadata('', 'name', 'value'), 'value')` instead 
 - `JsonSerializationVisitor::hasData` will be removed 
 - `VisitorInterface` is internal, use `SerializationVisitorInterface` and `DeserializationVisitorInterface` instead
 - `GraphNavigator` is internal, use `GraphNavigatorInterface` instead

--- a/src/JsonSerializationVisitor.php
+++ b/src/JsonSerializationVisitor.php
@@ -166,7 +166,7 @@ final class JsonSerializationVisitor extends AbstractVisitor implements Serializ
     }
 
     /**
-     * @deprecated Use visitProperty(new StaticPropertyMetadata(null, 'name', 'value'), null) instead
+     * @deprecated Use `::visitProperty(new StaticPropertyMetadata(null, 'name', 'value'), 'value')` instead
      *
      * Allows you to replace existing data on the current object element.
      *


### PR DESCRIPTION

| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| Doc updated   | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes/no
| Fixed tickets | -
| License       | MIT


This tries to solve once and for all what has been attempted in https://github.com/schmittjoh/serializer/pull/1117 https://github.com/schmittjoh/serializer/pull/1107 and  https://github.com/schmittjoh/serializer/pull/1107

Also reported in https://github.com/schmittjoh/serializer/issues/1116  https://github.com/schmittjoh/serializer/issues/1030 

The value has to be specified twice. The first for the actual value, the second is for nullability checks and type auto detection.

