### PR TITLE
Implement short expose syntax for XML as it is available for YAML

### DIFF
--- a/src/Metadata/Driver/XmlDriver.php
+++ b/src/Metadata/Driver/XmlDriver.php
@@ -160,15 +160,16 @@ class XmlDriver extends AbstractFileDriver
                 }
                 $pName = $property->getName();
                 $propertiesMetadata[] = new PropertyMetadata($name, $pName);
-                $pElems = $elem->xpath("./property[@name = '" . $pName . "']");
 
+                $pElems = $elem->xpath("./property[@name = '" . $pName . "']");
                 $propertiesNodes[] = $pElems ? reset($pElems) : null;
             }
 
             foreach ($propertiesMetadata as $propertyKey => $pMetadata) {
                 $isExclude = false;
                 $isExpose = $pMetadata instanceof VirtualPropertyMetadata
-                    || $pMetadata instanceof ExpressionPropertyMetadata;
+                    || $pMetadata instanceof ExpressionPropertyMetadata
+                    || isset($propertiesNodes[$propertyKey]);
 
                 $pElem = $propertiesNodes[$propertyKey];
                 if (!empty($pElem)) {

--- a/tests/Metadata/Driver/AnnotationDriverTest.php
+++ b/tests/Metadata/Driver/AnnotationDriverTest.php
@@ -8,6 +8,7 @@ use Doctrine\Common\Annotations\AnnotationReader;
 use JMS\Serializer\Metadata\Driver\AnnotationDriver;
 use JMS\Serializer\Naming\IdenticalPropertyNamingStrategy;
 use JMS\Serializer\Tests\Fixtures\AllExcludedObject;
+use Metadata\Driver\DriverInterface;
 
 class AnnotationDriverTest extends BaseDriverTest
 {
@@ -20,7 +21,7 @@ class AnnotationDriverTest extends BaseDriverTest
         self::assertArrayHasKey('bar', $m->propertyMetadata);
     }
 
-    protected function getDriver()
+    protected function getDriver(?string $subDir = null, bool $addUnderscoreDir = true): DriverInterface
     {
         return new AnnotationDriver(new AnnotationReader(), new IdenticalPropertyNamingStrategy(), null, $this->getExpressionEvaluator());
     }
@@ -28,5 +29,10 @@ class AnnotationDriverTest extends BaseDriverTest
     public function testCanDefineMetadataForInternalClass()
     {
         $this->markTestSkipped('Can not define annotation metadata for internal classes');
+    }
+
+    public function testShortExposeSyntax(): void
+    {
+        $this->markTestSkipped('Short expose syntax not supported on annotations');
     }
 }

--- a/tests/Metadata/Driver/BaseDriverTest.php
+++ b/tests/Metadata/Driver/BaseDriverTest.php
@@ -24,6 +24,7 @@ use JMS\Serializer\Tests\Fixtures\ObjectWithVirtualPropertiesAndDuplicatePropNam
 use JMS\Serializer\Tests\Fixtures\ObjectWithVirtualPropertiesAndDuplicatePropNameExcludeAll;
 use JMS\Serializer\Tests\Fixtures\ObjectWithVirtualPropertiesAndExcludeAll;
 use JMS\Serializer\Tests\Fixtures\ParentSkipWithEmptyChild;
+use JMS\Serializer\Tests\Fixtures\Person;
 use Metadata\Driver\DriverInterface;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\ExpressionLanguage\ExpressionFunction;
@@ -616,10 +617,18 @@ abstract class BaseDriverTest extends TestCase
         self::assertArrayNotHasKey('iShallNotBeAccessed', $first->propertyMetadata);
     }
 
+    public function testShortExposeSyntax(): void
+    {
+        $m = $this->getDriver('short_expose')->loadMetadataForClass(new \ReflectionClass(Person::class));
+
+        self::assertArrayHasKey('name', $m->propertyMetadata);
+        self::assertArrayNotHasKey('age', $m->propertyMetadata);
+    }
+
     /**
      * @return DriverInterface
      */
-    abstract protected function getDriver();
+    abstract protected function getDriver(?string $subDir = null, bool $addUnderscoreDir = true): DriverInterface;
 
     protected function getExpressionEvaluator()
     {

--- a/tests/Metadata/Driver/XmlDriverTest.php
+++ b/tests/Metadata/Driver/XmlDriverTest.php
@@ -8,6 +8,7 @@ use JMS\Serializer\Exception\InvalidMetadataException;
 use JMS\Serializer\Metadata\Driver\XmlDriver;
 use JMS\Serializer\Metadata\PropertyMetadata;
 use JMS\Serializer\Naming\IdenticalPropertyNamingStrategy;
+use Metadata\Driver\DriverInterface;
 use Metadata\Driver\FileLocator;
 
 class XmlDriverTest extends BaseDriverTest
@@ -90,16 +91,16 @@ class XmlDriverTest extends BaseDriverTest
         self::assertContains('second.test.group', $first->propertyMetadata['currency']->groups);
     }
 
-    protected function getDriver()
+    protected function getDriver(?string $subDir = null, bool $addUnderscoreDir = true): DriverInterface
     {
-        $append = '';
-        if (1 === func_num_args()) {
-            $append = '/' . func_get_arg(0);
+        $dirs = [
+            'JMS\Serializer\Tests\Fixtures' => __DIR__ . '/xml' . ($subDir ? '/' . $subDir : ''),
+        ];
+
+        if ($addUnderscoreDir) {
+            $dirs[''] = __DIR__ . '/xml/_' . ($subDir ? '/' . $subDir : '');
         }
 
-        return new XmlDriver(new FileLocator([
-            'JMS\Serializer\Tests\Fixtures' => __DIR__ . '/xml' . $append,
-            '' => __DIR__ . '/xml/_' . $append,
-        ]), new IdenticalPropertyNamingStrategy(), null, $this->getExpressionEvaluator());
+        return new XmlDriver(new FileLocator($dirs), new IdenticalPropertyNamingStrategy(), null, $this->getExpressionEvaluator());
     }
 }

--- a/tests/Metadata/Driver/YamlDriverTest.php
+++ b/tests/Metadata/Driver/YamlDriverTest.php
@@ -10,19 +10,20 @@ use JMS\Serializer\Metadata\PropertyMetadata;
 use JMS\Serializer\Naming\IdenticalPropertyNamingStrategy;
 use JMS\Serializer\Tests\Fixtures\BlogPost;
 use JMS\Serializer\Tests\Fixtures\Person;
+use Metadata\Driver\DriverInterface;
 use Metadata\Driver\FileLocator;
 
 class YamlDriverTest extends BaseDriverTest
 {
     public function testAccessorOrderIsInferred(): void
     {
-        $m = $this->getDriverForSubDir('accessor_inferred')->loadMetadataForClass(new \ReflectionClass(Person::class));
+        $m = $this->getDriver('accessor_inferred')->loadMetadataForClass(new \ReflectionClass(Person::class));
         self::assertEquals(['age', 'name'], array_keys($m->propertyMetadata));
     }
 
     public function testShortExposeSyntax(): void
     {
-        $m = $this->getDriverForSubDir('short_expose')->loadMetadataForClass(new \ReflectionClass(Person::class));
+        $m = $this->getDriver('short_expose')->loadMetadataForClass(new \ReflectionClass(Person::class));
 
         self::assertArrayHasKey('name', $m->propertyMetadata);
         self::assertArrayNotHasKey('age', $m->propertyMetadata);
@@ -30,7 +31,7 @@ class YamlDriverTest extends BaseDriverTest
 
     public function testBlogPost(): void
     {
-        $m = $this->getDriverForSubDir('exclude_all')->loadMetadataForClass(new \ReflectionClass(BlogPost::class));
+        $m = $this->getDriver('exclude_all')->loadMetadataForClass(new \ReflectionClass(BlogPost::class));
 
         self::assertArrayHasKey('title', $m->propertyMetadata);
 
@@ -42,7 +43,7 @@ class YamlDriverTest extends BaseDriverTest
 
     public function testBlogPostExcludeNoneStrategy(): void
     {
-        $m = $this->getDriverForSubDir('exclude_none')->loadMetadataForClass(new \ReflectionClass(BlogPost::class));
+        $m = $this->getDriver('exclude_none')->loadMetadataForClass(new \ReflectionClass(BlogPost::class));
 
         self::assertArrayNotHasKey('title', $m->propertyMetadata);
 
@@ -54,7 +55,7 @@ class YamlDriverTest extends BaseDriverTest
 
     public function testBlogPostCaseInsensitive(): void
     {
-        $m = $this->getDriverForSubDir('case')->loadMetadataForClass(new \ReflectionClass(BlogPost::class));
+        $m = $this->getDriver('case')->loadMetadataForClass(new \ReflectionClass(BlogPost::class));
 
         $p = new PropertyMetadata($m->name, 'title');
         $p->serializedName = 'title';
@@ -64,7 +65,7 @@ class YamlDriverTest extends BaseDriverTest
 
     public function testBlogPostAccessor(): void
     {
-        $m = $this->getDriverForSubDir('accessor')->loadMetadataForClass(new \ReflectionClass(BlogPost::class));
+        $m = $this->getDriver('accessor')->loadMetadataForClass(new \ReflectionClass(BlogPost::class));
 
         self::assertArrayHasKey('title', $m->propertyMetadata);
 
@@ -79,19 +80,19 @@ class YamlDriverTest extends BaseDriverTest
     {
         $this->expectException(InvalidMetadataException::class);
 
-        $this->getDriverForSubDir('invalid_metadata')->loadMetadataForClass(new \ReflectionClass(BlogPost::class));
+        $this->getDriver('invalid_metadata')->loadMetadataForClass(new \ReflectionClass(BlogPost::class));
     }
 
     public function testLoadingYamlFileWithLongExtension(): void
     {
-        $m = $this->getDriverForSubDir('multiple_types')->loadMetadataForClass(new \ReflectionClass(Person::class));
+        $m = $this->getDriver('multiple_types')->loadMetadataForClass(new \ReflectionClass(Person::class));
 
         self::assertArrayHasKey('name', $m->propertyMetadata);
     }
 
     public function testLoadingMultipleMetadataExtensions(): void
     {
-        $classNames = $this->getDriverForSubDir('multiple_types', false)->getAllClassNames();
+        $classNames = $this->getDriver('multiple_types', false)->getAllClassNames();
 
         self::assertEquals(
             [
@@ -102,7 +103,7 @@ class YamlDriverTest extends BaseDriverTest
         );
     }
 
-    private function getDriverForSubDir($subDir = null, bool $addUnderscoreDir = true): YamlDriver
+    protected function getDriver(?string $subDir = null, bool $addUnderscoreDir = true): DriverInterface
     {
         $dirs = [
             'JMS\Serializer\Tests\Fixtures' => __DIR__ . '/yml' . ($subDir ? '/' . $subDir : ''),
@@ -113,10 +114,5 @@ class YamlDriverTest extends BaseDriverTest
         }
 
         return new YamlDriver(new FileLocator($dirs), new IdenticalPropertyNamingStrategy(), null, $this->getExpressionEvaluator());
-    }
-
-    protected function getDriver()
-    {
-        return $this->getDriverForSubDir();
     }
 }

--- a/tests/Metadata/Driver/xml/short_expose/Person.xml
+++ b/tests/Metadata/Driver/xml/short_expose/Person.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<serializer>
+    <class name="JMS\Serializer\Tests\Fixtures\Person" exclusion-policy="ALL">
+        <property name="name"/>
+    </class>
+</serializer>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| Doc updated   | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT

When specifying `exclusion-policy=ALL`, mentioning a property makes it implicitly exposed 

```xml
<?xml version="1.0" encoding="UTF-8"?>
<serializer>
    <class name="JMS\Serializer\Tests\Fixtures\Person" exclusion-policy="ALL">
        <property name="name"/>
    </class>
</serializer>
```

