### PR TITLE
Allow to get a raw result from the serializer

### DIFF
--- a/src/Serializer.php
+++ b/src/Serializer.php
@@ -200,6 +200,8 @@ final class Serializer implements SerializerInterface, ArrayTransformerInterface
     }
 
     /**
+     * @param mixed $data
+     *
      * @return mixed
      */
     public function toRawResult($data, ?SerializationContext $context = null, ?string $type = null)

--- a/src/Serializer.php
+++ b/src/Serializer.php
@@ -200,9 +200,9 @@ final class Serializer implements SerializerInterface, ArrayTransformerInterface
     }
 
     /**
-     * {@InheritDoc}
+     * @return mixed
      */
-    public function toRawResult($data, ?SerializationContext $context = null, ?string $type = null): array
+    public function toRawResult($data, ?SerializationContext $context = null, ?string $type = null)
     {
         if (null === $context) {
             $context = $this->serializationContextFactory->createSerializationContext();

--- a/src/Serializer.php
+++ b/src/Serializer.php
@@ -185,15 +185,7 @@ final class Serializer implements SerializerInterface, ArrayTransformerInterface
      */
     public function toArray($data, ?SerializationContext $context = null, ?string $type = null): array
     {
-        if (null === $context) {
-            $context = $this->serializationContextFactory->createSerializationContext();
-        }
-
-        $visitor = $this->getVisitor(GraphNavigatorInterface::DIRECTION_SERIALIZATION, 'json');
-        $navigator = $this->getNavigator(GraphNavigatorInterface::DIRECTION_SERIALIZATION);
-
-        $type = $this->findInitialType($type, $context);
-        $result = $this->visit($navigator, $visitor, $context, $data, 'json', $type);
+        $result = $this->toRawResult($data, $context, $type);
         $result = $this->convertArrayObjects($result);
 
         if (!\is_array($result)) {
@@ -205,6 +197,23 @@ final class Serializer implements SerializerInterface, ArrayTransformerInterface
         }
 
         return $result;
+    }
+
+    /**
+     * {@InheritDoc}
+     */
+    public function toRawResult($data, ?SerializationContext $context = null, ?string $type = null): array
+    {
+        if (null === $context) {
+            $context = $this->serializationContextFactory->createSerializationContext();
+        }
+
+        $visitor = $this->getVisitor(GraphNavigatorInterface::DIRECTION_SERIALIZATION, 'json');
+        $navigator = $this->getNavigator(GraphNavigatorInterface::DIRECTION_SERIALIZATION);
+
+        $type = $this->findInitialType($type, $context);
+
+        return $this->visit($navigator, $visitor, $context, $data, 'json', $type);
     }
 
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | -
| New feature?  | -
| Doc updated   | -
| BC breaks?    | -
| Deprecations? | -
| Tests pass?   | -
| Fixed tickets | #...
| License       | MIT

In the 1.x version of the jms/serializer it was possible to implement custom serializer format which doesn't return a string.

To make this again to reuse the JMS serializer logi a rawResult could be make available without that convertArrayObject is called on it.
