### PR TITLE
Remove unnecessary cast

### DIFF
--- a/src/Visitor/Factory/JsonSerializationVisitorFactory.php
+++ b/src/Visitor/Factory/JsonSerializationVisitorFactory.php
@@ -24,7 +24,7 @@ final class JsonSerializationVisitorFactory implements SerializationVisitorFacto
 
     public function setOptions(int $options): self
     {
-        $this->options = (int) $options;
+        $this->options = $options;
         return $this;
     }
 }


### PR DESCRIPTION
We're already setting as an integer the `$options` parameter.

| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| Doc updated   | no
| BC breaks?    | no <!-- don't forget updating UPGRADING.md file -->
| Deprecations? | no <!-- don't forget updating UPGRADING.md file -->
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT

