### PR TITLE
Remove PHP 7.4 from `allow_failures` matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,8 +27,6 @@ matrix:
         - php: 7.3
         - php: "7.4snapshot"
     fast_finish: true
-    allow_failures:
-      - php: "7.4snapshot"
 
 install:
   - if [ -x .travis/install_${TARGET}.sh ]; then .travis/install_${TARGET}.sh; fi;


### PR DESCRIPTION
In order to ensure that this project is forward compatible with PHP 7.4, let's allow the jobs to fail.

| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| Doc updated   | no
| BC breaks?    | no <!-- don't forget updating UPGRADING.md file -->
| Deprecations? | no <!-- don't forget updating UPGRADING.md file -->
| Tests pass?   | no
| Fixed tickets | -
| License       | MIT

