### PR TITLE
Support new doctrine ODM proxy objects

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -33,7 +33,7 @@
         "doctrine/orm": "~2.1",
         "jackalope/jackalope-doctrine-dbal": "^1.1.5",
         "doctrine/phpcr-odm": "^1.3|^2.0",
-        "ocramius/proxy-manager": "^2.0",
+        "ocramius/proxy-manager": "^1.0|^2.0",
         "psr/container": "^1.0",
         "symfony/dependency-injection": "^3.0|^4.0",
         "symfony/yaml": "^3.3|^4.0",

--- a/composer.json
+++ b/composer.json
@@ -33,6 +33,7 @@
         "doctrine/orm": "~2.1",
         "jackalope/jackalope-doctrine-dbal": "^1.1.5",
         "doctrine/phpcr-odm": "^1.3|^2.0",
+        "ocramius/proxy-manager": "^2.0",
         "psr/container": "^1.0",
         "symfony/dependency-injection": "^3.0|^4.0",
         "symfony/yaml": "^3.3|^4.0",

--- a/tests/Fixtures/SimpleObjectLazyLoading.php
+++ b/tests/Fixtures/SimpleObjectLazyLoading.php
@@ -1,0 +1,69 @@
+<?php
+
+declare(strict_types=1);
+
+namespace JMS\Serializer\Tests\Fixtures;
+
+use Closure;
+use ProxyManager\Proxy\LazyLoadingInterface;
+
+class SimpleObjectLazyLoading extends SimpleObject implements LazyLoadingInterface
+{
+    public $__isInitialized__ = false;
+
+    private $initializer;
+
+    private $baz = 'baz';
+
+    public function __load()
+    {
+        if (!$this->__isInitialized__) {
+            $this->camelCase = 'proxy-boo';
+            $this->__isInitialized__ = true;
+        }
+    }
+
+    public function __isInitialized()
+    {
+        return $this->__isInitialized__;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function setProxyInitializer(?Closure $initializer = null)
+    {
+        $this->initializer = $initializer;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getProxyInitializer(): ?Closure
+    {
+        return $this->initializer;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function initializeProxy(): bool
+    {
+        if (!$this->__isInitialized__) {
+            $this->camelCase = 'proxy-boo';
+            $this->__isInitialized__ = true;
+
+            return !$this->initializer || call_user_func($this->initializer);
+        }
+
+        return true;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function isProxyInitialized(): bool
+    {
+        return $this->__isInitialized__;
+    }
+}

--- a/tests/Serializer/EventDispatcher/Subscriber/DoctrineProxySubscriberTest.php
+++ b/tests/Serializer/EventDispatcher/Subscriber/DoctrineProxySubscriberTest.php
@@ -11,6 +11,7 @@ use JMS\Serializer\EventDispatcher\Subscriber\DoctrineProxySubscriber;
 use JMS\Serializer\Metadata\ClassMetadata;
 use JMS\Serializer\Tests\Fixtures\ExclusionStrategy\AlwaysExcludeExclusionStrategy;
 use JMS\Serializer\Tests\Fixtures\SimpleObject;
+use JMS\Serializer\Tests\Fixtures\SimpleObjectLazyLoading;
 use JMS\Serializer\Tests\Fixtures\SimpleObjectProxy;
 use Metadata\MetadataFactoryInterface;
 use PHPUnit\Framework\TestCase;
@@ -144,6 +145,15 @@ class DoctrineProxySubscriberTest extends TestCase
         $this->subscriber->onPreSerialize($event);
 
         self::assertSame(['name' => SimpleObject::class, 'params' => ['baz']], $event->getType());
+    }
+
+    public function testRewritesLazyLoadingClassName()
+    {
+        $event = $this->createEvent($obj = new SimpleObjectLazyLoading('a', 'b'), ['name' => get_class($obj), 'params' => []]);
+        $this->subscriber->onPreSerialize($event);
+
+        self::assertEquals(['name' => get_parent_class($obj), 'params' => []], $event->getType());
+        self::assertTrue($obj->__isInitialized());
     }
 
     protected function setUp(): void


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| Doc updated   | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT

As from version 2.0 `doctrine/mongodb-odm` uses `ocramius/proxy-manager` serializer needs to handle `LazyLoadingInterface` same as doctrine proxy objects.