### PR TITLE
Add visit static property function in serializer visitor

### DIFF
--- a/src/JsonSerializationVisitor.php
+++ b/src/JsonSerializationVisitor.php
@@ -8,6 +8,7 @@ use JMS\Serializer\Exception\NotAcceptableException;
 use JMS\Serializer\Exception\RuntimeException;
 use JMS\Serializer\Metadata\ClassMetadata;
 use JMS\Serializer\Metadata\PropertyMetadata;
+use JMS\Serializer\Metadata\StaticPropertyMetadata;
 use JMS\Serializer\Visitor\SerializationVisitorInterface;
 
 final class JsonSerializationVisitor extends AbstractVisitor implements SerializationVisitorInterface
@@ -153,6 +154,14 @@ final class JsonSerializationVisitor extends AbstractVisitor implements Serializ
         } else {
             $this->data[$metadata->serializedName] = $v;
         }
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function visitStaticProperty(string $name, $v): void
+    {
+        $this->visitProperty(new StaticPropertyMetadata('', $name, $v), $v);
     }
 
     /**

--- a/src/Visitor/SerializationVisitorInterface.php
+++ b/src/Visitor/SerializationVisitorInterface.php
@@ -81,6 +81,11 @@ interface SerializationVisitorInterface extends VisitorInterface
     public function visitProperty(PropertyMetadata $metadata, $data): void;
 
     /**
+     * @param mixed $data
+     */
+    public function visitStaticProperty(string $name, $data): void;
+
+    /**
      * Called after all properties of the object have been visited.
      *
      * @param mixed $data

--- a/src/XmlSerializationVisitor.php
+++ b/src/XmlSerializationVisitor.php
@@ -8,6 +8,7 @@ use JMS\Serializer\Exception\NotAcceptableException;
 use JMS\Serializer\Exception\RuntimeException;
 use JMS\Serializer\Metadata\ClassMetadata;
 use JMS\Serializer\Metadata\PropertyMetadata;
+use JMS\Serializer\Metadata\StaticPropertyMetadata;
 use JMS\Serializer\Visitor\SerializationVisitorInterface;
 
 /**
@@ -328,6 +329,14 @@ final class XmlSerializationVisitor extends AbstractVisitor implements Serializa
         }
 
         $this->hasValue = false;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function visitStaticProperty(string $name, $v): void
+    {
+        $this->visitProperty(new StaticPropertyMetadata('', $name, $v), $v);
     }
 
     private function isInLineCollection(PropertyMetadata $metadata): bool


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| Doc updated   | yes/no
| BC breaks?    | yes/no?
| Deprecations? | no 
| Tests pass?   | yes/no
| Fixed tickets | #... <!-- #-prefixed issue number(s), if any -->
| License       | MIT

When I upgraded to the newest jms/serializer most of my code did duplicated because I needed to replace the simple line of:

```php
visitor->addData('creatorFullName', $creatorFullName);
```

with the uncomfortable call of:

```php
$visitor->visitProperty(
    new StaticPropertyMetadata('', 'creatorFullName', $creatorFullName),
    $creatorFullName
);
```

For me this is the most used function in my custom serialization subscriber. 
