### PR TITLE
SubscribingHandlerInterface > Add correct typehint to `getSubscribingMethods`

### DIFF
--- a/src/Handler/SubscribingHandlerInterface.php
+++ b/src/Handler/SubscribingHandlerInterface.php
@@ -20,7 +20,7 @@ interface SubscribingHandlerInterface
      *
      * The direction and method keys can be omitted.
      *
-     * @return array
+     * @return iterable<array{format:int, type:class-string} | array{direction:int, format:string, type:class-string, method:string}>
      *
      * @phpcsSuppress SlevomatCodingStandard.TypeHints.TypeHintDeclaration.MissingReturnTypeHint
      */


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| Doc updated   | no
| BC breaks?    | no
| Deprecations? | no 
| Tests pass?   | yes
| License       | MIT

This makes PHPStan happy.
