### PR TITLE
Improved return type for fluent methods in Context

### DIFF
--- a/src/Context.php
+++ b/src/Context.php
@@ -121,6 +121,8 @@ abstract class Context
 
     /**
      * @param mixed $value
+     *
+     * @return $this
      */
     public function setAttribute(string $key, $value): self
     {
@@ -139,6 +141,9 @@ abstract class Context
         throw new LogicException('This context was already initialized and is immutable; you cannot modify it anymore.');
     }
 
+    /**
+     * @return $this
+     */
     public function addExclusionStrategy(ExclusionStrategyInterface $strategy): self
     {
         $this->assertMutable();
@@ -161,6 +166,9 @@ abstract class Context
         return $this;
     }
 
+    /**
+     * @return $this
+     */
     public function setVersion(string $version): self
     {
         $this->attributes['version'] = $version;
@@ -170,6 +178,8 @@ abstract class Context
 
     /**
      * @param array|string $groups
+     *
+     * @return $this
      */
     public function setGroups($groups): self
     {
@@ -182,6 +192,9 @@ abstract class Context
         return $this;
     }
 
+    /**
+     * @return $this
+     */
     public function enableMaxDepthChecks(): self
     {
         $this->attributes['max_depth_checks'] = true;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Doc updated   | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT

While the `self` return type is true, it is too loose. What is actually returned is `$this` (i.e. the class extending this abstract class). This means the following code is - strictly spoken - invalid:

```php
$serializationContext = SerializationContext::create()
  ->setSerializeNull(true)
  ->setGroups(['api'])
;

$this->serializer->serialize($subject, 'json', $serializationContext)
```

As PHP does not have the `static` return type [until PHP 8](https://wiki.php.net/rfc/static_return_type), I think adding this PHPdoc is the best possible solution to make static analysers and IDEs happy.