### PR TITLE
PHP7.4 ternary operator deprecation

### DIFF
--- a/src/JMS/Serializer/SerializationContext.php
+++ b/src/JMS/Serializer/SerializationContext.php
@@ -122,6 +122,6 @@ class SerializationContext extends Context
     {
         return $this->initialType
             ? $this->initialType
-            : $this->attributes->containsKey('initial_type') ? $this->attributes->get('initial_type')->get() : null;
+            : ($this->attributes->containsKey('initial_type') ? $this->attributes->get('initial_type')->get() : null);
     }
 }


### PR DESCRIPTION
For whatever reasons, it is possible to be stuck in jms/serializer v1.* but still have to use PHP7.4

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Doc updated   | no need
| BC breaks?    | no <!-- don't forget updating UPGRADING.md file -->
| Deprecations? | no <!-- don't forget updating UPGRADING.md file -->
| Tests pass?   | should pass
| Fixed tickets | #... <!-- #-prefixed issue number(s), if any -->
| License       | MIT

