### PR TITLE
Assert types before trying to convert data

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,6 +17,8 @@
     ],
     "require": {
         "php": "^7.2",
+        "ext-simplexml":" *",
+        "ext-libxml":" *",
         "jms/metadata": "^2.0",
         "doctrine/annotations": "^1.0",
         "doctrine/instantiator": "^1.0.3",

--- a/src/AbstractVisitor.php
+++ b/src/AbstractVisitor.php
@@ -4,6 +4,11 @@ declare(strict_types=1);
 
 namespace JMS\Serializer;
 
+use JMS\Serializer\Exception\NonCastableTypeException;
+use JMS\Serializer\Exception\NonFloatCastableTypeException;
+use JMS\Serializer\Exception\NonIntCastableTypeException;
+use JMS\Serializer\Exception\NonStringCastableTypeException;
+
 /**
  * @internal
  */
@@ -37,6 +42,43 @@ abstract class AbstractVisitor implements VisitorInterface
             return $typeArray['params'][1];
         } else {
             return $typeArray['params'][0];
+        }
+    }
+
+    /**
+     * logic according to strval https://www.php.net/manual/en/function.strval.php
+     * "You cannot use strval() on arrays or on objects that do not implement the __toString() method."
+     */
+    protected function assertValueCanBeCastToString($value)
+    {
+        if (is_array($value)) {
+            throw new NonStringCastableTypeException($value);
+        }
+
+        if (is_object($value) && method_exists($value, '__toString') === false) {
+            throw new NonStringCastableTypeException($value);
+        }
+    }
+
+    /**
+     * logic according to intval https://www.php.net/manual/en/function.intval.php
+     * "intval() should not be used on objects, as doing so will emit an E_NOTICE level error and return 1."
+     */
+    protected function assertValueCanBeCastToInt($value)
+    {
+        if (is_object($value) && !$value instanceof \SimpleXMLElement) {
+            throw new NonIntCastableTypeException($value);
+        }
+    }
+
+    /**
+     *  logic according to floatval https://www.php.net/manual/en/function.floatval.php
+     * "floatval() should not be used on objects, as doing so will emit an E_NOTICE level error and return 1."
+     */
+    protected function assertValueCanCastToFloat($value)
+    {
+        if (is_object($value) && !$value instanceof \SimpleXMLElement) {
+            throw new NonFloatCastableTypeException($value);
         }
     }
 }

--- a/src/AbstractVisitor.php
+++ b/src/AbstractVisitor.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace JMS\Serializer;
 
-use JMS\Serializer\Exception\NonCastableTypeException;
 use JMS\Serializer\Exception\NonFloatCastableTypeException;
 use JMS\Serializer\Exception\NonIntCastableTypeException;
 use JMS\Serializer\Exception\NonStringCastableTypeException;
@@ -48,14 +47,16 @@ abstract class AbstractVisitor implements VisitorInterface
     /**
      * logic according to strval https://www.php.net/manual/en/function.strval.php
      * "You cannot use strval() on arrays or on objects that do not implement the __toString() method."
+     *
+     * @param mixed $value
      */
-    protected function assertValueCanBeCastToString($value)
+    protected function assertValueCanBeCastToString($value): void
     {
         if (is_array($value)) {
             throw new NonStringCastableTypeException($value);
         }
 
-        if (is_object($value) && method_exists($value, '__toString') === false) {
+        if (is_object($value) && !method_exists($value, '__toString')) {
             throw new NonStringCastableTypeException($value);
         }
     }
@@ -63,8 +64,10 @@ abstract class AbstractVisitor implements VisitorInterface
     /**
      * logic according to intval https://www.php.net/manual/en/function.intval.php
      * "intval() should not be used on objects, as doing so will emit an E_NOTICE level error and return 1."
+     *
+     * @param mixed $value
      */
-    protected function assertValueCanBeCastToInt($value)
+    protected function assertValueCanBeCastToInt($value): void
     {
         if (is_object($value) && !$value instanceof \SimpleXMLElement) {
             throw new NonIntCastableTypeException($value);
@@ -74,8 +77,10 @@ abstract class AbstractVisitor implements VisitorInterface
     /**
      *  logic according to floatval https://www.php.net/manual/en/function.floatval.php
      * "floatval() should not be used on objects, as doing so will emit an E_NOTICE level error and return 1."
+     *
+     * @param mixed $value
      */
-    protected function assertValueCanCastToFloat($value)
+    protected function assertValueCanCastToFloat($value): void
     {
         if (is_object($value) && !$value instanceof \SimpleXMLElement) {
             throw new NonFloatCastableTypeException($value);

--- a/src/Exception/NonCastableTypeException.php
+++ b/src/Exception/NonCastableTypeException.php
@@ -1,0 +1,29 @@
+<?php declare(strict_types=1);
+
+namespace JMS\Serializer\Exception;
+
+class NonCastableTypeException extends RuntimeException
+{
+    /**
+     * @var mixed
+     */
+    private $value;
+
+    public function __construct($expectedType, $value)
+    {
+        $this->value = $value;
+
+        parent::__construct(
+            sprintf(
+                'Cannot convert value of type "%s" to %s',
+                gettype($value),
+                $expectedType
+            )
+        );
+    }
+
+    public function getValue()
+    {
+        return $this->value;
+    }
+}

--- a/src/Exception/NonCastableTypeException.php
+++ b/src/Exception/NonCastableTypeException.php
@@ -1,4 +1,6 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
 
 namespace JMS\Serializer\Exception;
 
@@ -9,7 +11,10 @@ class NonCastableTypeException extends RuntimeException
      */
     private $value;
 
-    public function __construct($expectedType, $value)
+    /**
+     * @param mixed $value
+     */
+    public function __construct(string $expectedType, $value)
     {
         $this->value = $value;
 
@@ -22,6 +27,9 @@ class NonCastableTypeException extends RuntimeException
         );
     }
 
+    /**
+     * @return mixed
+     */
     public function getValue()
     {
         return $this->value;

--- a/src/Exception/NonFloatCastableTypeException.php
+++ b/src/Exception/NonFloatCastableTypeException.php
@@ -1,9 +1,14 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
 
 namespace JMS\Serializer\Exception;
 
 class NonFloatCastableTypeException extends NonCastableTypeException
 {
+    /**
+     * @param mixed $value
+     */
     public function __construct($value)
     {
         parent::__construct('float', $value);

--- a/src/Exception/NonFloatCastableTypeException.php
+++ b/src/Exception/NonFloatCastableTypeException.php
@@ -1,0 +1,11 @@
+<?php declare(strict_types=1);
+
+namespace JMS\Serializer\Exception;
+
+class NonFloatCastableTypeException extends NonCastableTypeException
+{
+    public function __construct($value)
+    {
+        parent::__construct('float', $value);
+    }
+}

--- a/src/Exception/NonIntCastableTypeException.php
+++ b/src/Exception/NonIntCastableTypeException.php
@@ -1,9 +1,14 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
 
 namespace JMS\Serializer\Exception;
 
 class NonIntCastableTypeException extends NonCastableTypeException
 {
+    /**
+     * @param mixed $value
+     */
     public function __construct($value)
     {
         parent::__construct('int', $value);

--- a/src/Exception/NonIntCastableTypeException.php
+++ b/src/Exception/NonIntCastableTypeException.php
@@ -1,0 +1,11 @@
+<?php declare(strict_types=1);
+
+namespace JMS\Serializer\Exception;
+
+class NonIntCastableTypeException extends NonCastableTypeException
+{
+    public function __construct($value)
+    {
+        parent::__construct('int', $value);
+    }
+}

--- a/src/Exception/NonStringCastableTypeException.php
+++ b/src/Exception/NonStringCastableTypeException.php
@@ -1,9 +1,14 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
 
 namespace JMS\Serializer\Exception;
 
 class NonStringCastableTypeException extends NonCastableTypeException
 {
+    /**
+     * @param mixed $value
+     */
     public function __construct($value)
     {
         parent::__construct('string', $value);

--- a/src/Exception/NonStringCastableTypeException.php
+++ b/src/Exception/NonStringCastableTypeException.php
@@ -1,0 +1,11 @@
+<?php declare(strict_types=1);
+
+namespace JMS\Serializer\Exception;
+
+class NonStringCastableTypeException extends NonCastableTypeException
+{
+    public function __construct($value)
+    {
+        parent::__construct('string', $value);
+    }
+}

--- a/src/JsonDeserializationVisitor.php
+++ b/src/JsonDeserializationVisitor.php
@@ -54,6 +54,8 @@ final class JsonDeserializationVisitor extends AbstractVisitor implements Deseri
      */
     public function visitString($data, array $type): string
     {
+        $this->assertValueCanBeCastToString($data);
+
         return (string) $data;
     }
 
@@ -70,6 +72,8 @@ final class JsonDeserializationVisitor extends AbstractVisitor implements Deseri
      */
     public function visitInteger($data, array $type): int
     {
+        $this->assertValueCanBeCastToInt($data);
+
         return (int) $data;
     }
 
@@ -78,6 +82,8 @@ final class JsonDeserializationVisitor extends AbstractVisitor implements Deseri
      */
     public function visitDouble($data, array $type): float
     {
+        $this->assertValueCanCastToFloat($data);
+
         return (float) $data;
     }
 

--- a/src/XmlDeserializationVisitor.php
+++ b/src/XmlDeserializationVisitor.php
@@ -121,6 +121,8 @@ final class XmlDeserializationVisitor extends AbstractVisitor implements NullAwa
      */
     public function visitString($data, array $type): string
     {
+        $this->assertValueCanBeCastToString($data);
+
         return (string) $data;
     }
     /**
@@ -128,6 +130,8 @@ final class XmlDeserializationVisitor extends AbstractVisitor implements NullAwa
      */
     public function visitBoolean($data, array $type): bool
     {
+        $this->assertValueCanBeCastToString($data);
+
         $data = (string) $data;
 
         if ('true' === $data || '1' === $data) {
@@ -143,6 +147,8 @@ final class XmlDeserializationVisitor extends AbstractVisitor implements NullAwa
      */
     public function visitInteger($data, array $type): int
     {
+        $this->assertValueCanBeCastToInt($data);
+
         return (int) $data;
     }
     /**
@@ -150,6 +156,8 @@ final class XmlDeserializationVisitor extends AbstractVisitor implements NullAwa
      */
     public function visitDouble($data, array $type): float
     {
+        $this->assertValueCanCastToFloat($data);
+
         return (float) $data;
     }
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| Doc updated   | no
| BC breaks?    | yes <!-- don't forget updating UPGRADING.md file -->
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | https://github.com/schmittjoh/serializer/issues/880
| License       | MIT

As suggested in https://github.com/schmittjoh/serializer/issues/880, I used the naive approach and just assert the type of all scalars when deserializing. Feedback welcome as I'm not sure if this is the best approach.

Also I'm not sure to what degree you would consider this to be a BC break, would love to have your input on that.

