### PR TITLE
do not hide Exceptions from custom handlers but correctly handle null

### DIFF
--- a/src/GraphNavigator/SerializationGraphNavigator.php
+++ b/src/GraphNavigator/SerializationGraphNavigator.php
@@ -195,9 +195,11 @@ final class SerializationGraphNavigator extends GraphNavigator implements GraphN
                 if (null !== $handler = $this->handlerRegistry->getHandler(GraphNavigatorInterface::DIRECTION_SERIALIZATION, $type['name'], $this->format)) {
                     try {
                         $rs = \call_user_func($handler, $this->visitor, $data, $type, $this->context);
-                    } finally {
+                    } catch (NotAcceptableException $e) {
                         $this->context->stopVisiting($data);
+                        throw $e;
                     }
+                    $this->context->stopVisiting($data);
 
                     return $rs;
                 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Doc updated   | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #1168
| License       | MIT

This solve the issue of #1168 by catching and handling the specific `NotAcceptableException` case. All other Exceptions are not caught so Exceptions thrown in handlers are visible as requested.