### PR TITLE
Handle ObjectConstructor returning NULL

### DIFF
--- a/src/GraphNavigator/DeserializationGraphNavigator.php
+++ b/src/GraphNavigator/DeserializationGraphNavigator.php
@@ -184,6 +184,13 @@ final class DeserializationGraphNavigator extends GraphNavigator implements Grap
 
                 $object = $this->objectConstructor->construct($this->visitor, $metadata, $data, $type, $this->context);
 
+                if (null === $object) {
+                    $this->context->popClassMetadata();
+                    $this->context->decreaseDepth();
+
+                    return $this->visitor->visitNull($data, $type);
+                }
+
                 $this->visitor->startVisitingObject($metadata, $object, $type);
                 foreach ($metadata->propertyMetadata as $propertyMetadata) {
                     if (null !== $this->exclusionStrategy && $this->exclusionStrategy->shouldSkipProperty($propertyMetadata, $this->context)) {

--- a/tests/Serializer/GraphNavigatorTest.php
+++ b/tests/Serializer/GraphNavigatorTest.php
@@ -6,6 +6,7 @@ namespace JMS\Serializer\Tests\Serializer;
 
 use Doctrine\Common\Annotations\AnnotationReader;
 use JMS\Serializer\Accessor\DefaultAccessorStrategy;
+use JMS\Serializer\Construction\ObjectConstructorInterface;
 use JMS\Serializer\Construction\UnserializeObjectConstructor;
 use JMS\Serializer\DeserializationContext;
 use JMS\Serializer\EventDispatcher\EventDispatcher;
@@ -154,6 +155,19 @@ class GraphNavigatorTest extends TestCase
         $this->expectException(\RuntimeException::class);
         $this->expectExceptionMessage($msg);
         $navigator->accept($object, ['name' => $typeName, 'params' => []]);
+    }
+
+    /**
+     * @doesNotPerformAssertions
+     */
+    public function testNavigatorDoesNotCrashWhenObjectConstructorReturnsNull()
+    {
+        $objectConstructor = $this->getMockBuilder(ObjectConstructorInterface::class)->getMock();
+        $objectConstructor->method('construct')->willReturn(null);
+        $navigator = new DeserializationGraphNavigator($this->metadataFactory, $this->handlerRegistry, $objectConstructor, $this->accessor, $this->dispatcher);
+        $navigator->initialize($this->deserializationVisitor, $this->deserializationContext);
+
+        $navigator->accept(['id' => 1234], ['name' => SerializableClass::class]);
     }
 
     protected function setUp(): void


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Doc updated   | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
| License       | MIT

The DeserializationGraphNavigator calls the construct method on an instance of ObjectConstructorInterface. According to the return type hint of that method, it is allowed to return NULL. However, when this occurs, the navigator will pass NULL to the startVisitingObject method
of the visitor. startVisitingObject expects an object to be passed in, thus causing the serializer to crash with a type error.

We can prevent this error by calling the `visitNull` method if we detect that the ObjectConstructor has returned NULL instead of an object.
