### PR TITLE
Check data type before casting

### DIFF
--- a/src/JsonDeserializationVisitor.php
+++ b/src/JsonDeserializationVisitor.php
@@ -54,6 +54,10 @@ final class JsonDeserializationVisitor extends AbstractVisitor implements Deseri
      */
     public function visitString($data, array $type): string
     {
+        if (!\is_string($data)) {
+            throw new RuntimeException(sprintf('Expected string, but got %s: %s', \gettype($data), json_encode($data)));
+        }
+
         return (string) $data;
     }
 
@@ -62,6 +66,10 @@ final class JsonDeserializationVisitor extends AbstractVisitor implements Deseri
      */
     public function visitBoolean($data, array $type): bool
     {
+        if (!\is_bool($data)) {
+            throw new RuntimeException(sprintf('Expected boolean, but got %s: %s', \gettype($data), json_encode($data)));
+        }
+
         return (bool) $data;
     }
 
@@ -70,6 +78,10 @@ final class JsonDeserializationVisitor extends AbstractVisitor implements Deseri
      */
     public function visitInteger($data, array $type): int
     {
+        if (!\is_int($data)) {
+            throw new RuntimeException(sprintf('Expected boolean, but got %s: %s', \gettype($data), json_encode($data)));
+        }
+
         return (int) $data;
     }
 
@@ -78,6 +90,10 @@ final class JsonDeserializationVisitor extends AbstractVisitor implements Deseri
      */
     public function visitDouble($data, array $type): float
     {
+        if (!\is_float($data)) {
+            throw new RuntimeException(sprintf('Expected double, but got %s: %s', \gettype($data), json_encode($data)));
+        }
+
         return (float) $data;
     }
 


### PR DESCRIPTION
| Q                     | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Doc updated   | no `(I'll update it if needed)`
| BC breaks?    | yes
| Deprecations? | no
| Tests pass?   | no `(I'll add them if the idea is accepted)`
| Fixed tickets | #... <!-- #-prefixed issue number(s), if any -->
| License       | MIT

Hi @schmittjoh 

I took the liberty of creating this PR to check the idea behind this set of proposed changes.

The idea is to avoid some edge cases that could happen when for instance, an array is sent to a property that is defined to be a string. currently it does the casting without validating the data type, unlike what happens in the array visitor.

Let me know what do you think of this approach to cover this edge case.
