### PR TITLE
added optional expression parameter to the ReadOnly annotation

### DIFF
--- a/doc/reference/annotations.rst
+++ b/doc/reference/annotations.rst
@@ -279,6 +279,9 @@ is read only and cannot be set during deserialization.
 
 A property can be marked as non read only with ``@ReadOnly(false)`` annotation (useful when a class is marked as read only).
 
+If the ``ExpressionLanguageExclusionStrategy`` exclusion strategy is enabled, will
+be possible to use ``@ReadOnly(if="expression")`` to dynamically set to read-only.
+
 @PreSerialize
 ~~~~~~~~~~~~~
 This annotation can be defined on a method which is supposed to be called before

--- a/doc/reference/xml_reference.rst
+++ b/doc/reference/xml_reference.rst
@@ -7,7 +7,7 @@ XML Reference
     <serializer>
         <class name="Fully\Qualified\ClassName" exclusion-policy="ALL" xml-root-name="foo-bar" exclude="true"
             accessor-order="custom" custom-accessor-order="propertyName1,propertyName2,...,propertyNameN"
-            access-type="public_method" discriminator-field-name="type" discriminator-disabled="false" read-only="false">
+            access-type="public_method" discriminator-field-name="type" discriminator-disabled="false" read-only="bool|expr">
             <xml-namespace prefix="atom" uri="http://www.w3.org/2005/Atom"/>
             <xml-discriminator attribute="true" cdata="false" namespace=""/>
             <discriminator-class value="some-value">ClassName</discriminator-class>
@@ -30,7 +30,7 @@ XML Reference
                       accessor-getter="getSomeProperty"
                       accessor-setter="setSomeProperty"
                       inline="true"
-                      read-only="true"
+                      read-only="bool|expr"
                       groups="foo,bar"
                       xml-key-value-pairs="true"
                       xml-attribute-map="true"
@@ -84,7 +84,7 @@ XML Reference
                       accessor-getter="getSomeProperty"
                       accessor-setter="setSomeProperty"
                       inline="true"
-                      read-only="true"
+                      read-only="bool|expr"
                       groups="foo,bar"
                       xml-key-value-pairs="true"
                       xml-attribute-map="true"

--- a/doc/reference/yml_reference.rst
+++ b/doc/reference/yml_reference.rst
@@ -8,7 +8,7 @@ YAML Reference
         xml_root_name: foobar
         xml_root_namespace: http://your.default.namespace
         exclude: true
-        read_only: false
+        read_only: bool|expr
         access_type: public_method # defaults to property
         accessor_order: custom
         custom_accessor_order: [propertyName1, propertyName2, ..., propertyNameN]
@@ -54,7 +54,7 @@ YAML Reference
                 xml_attribute: true
                 xml_value: true
                 inline: true
-                read_only: true
+                read_only: bool|expr
                 xml_key_value_pairs: true
                 xml_list:
                     inline: true

--- a/src/Annotation/ReadOnly.php
+++ b/src/Annotation/ReadOnly.php
@@ -14,4 +14,9 @@ final class ReadOnly
      * @var bool
      */
     public $readOnly = true;
+
+    /**
+     * @var string
+     */
+    public $if;
 }

--- a/src/Exclusion/ExpressionLanguageExclusionStrategy.php
+++ b/src/Exclusion/ExpressionLanguageExclusionStrategy.php
@@ -72,7 +72,7 @@ final class ExpressionLanguageExclusionStrategy
         ];
         $variables['object'] = null;
 
-        if (($property->readOnly instanceof Expression) && ($this->expressionEvaluator instanceof CompilableExpressionEvaluatorInterface)) {
+        if (($property->readOnlyIf instanceof Expression) && ($this->expressionEvaluator instanceof CompilableExpressionEvaluatorInterface)) {
             return $this->expressionEvaluator->evaluateParsed($property->readOnlyIf, $variables);
         }
 

--- a/src/Exclusion/ExpressionLanguageExclusionStrategy.php
+++ b/src/Exclusion/ExpressionLanguageExclusionStrategy.php
@@ -56,4 +56,26 @@ final class ExpressionLanguageExclusionStrategy
 
         return $this->expressionEvaluator->evaluate($property->excludeIf, $variables);
     }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function shouldSkipPropertyOnDeserialize(PropertyMetadata $property, Context $navigatorContext): bool
+    {
+        if (null === $property->readOnlyIf) {
+            return false;
+        }
+
+        $variables = [
+            'context' => $navigatorContext,
+            'property_metadata' => $property,
+        ];
+        $variables['object'] = null;
+
+        if (($property->readOnly instanceof Expression) && ($this->expressionEvaluator instanceof CompilableExpressionEvaluatorInterface)) {
+            return $this->expressionEvaluator->evaluateParsed($property->readOnlyIf, $variables);
+        }
+
+        return $this->expressionEvaluator->evaluate($property->readOnlyIf, $variables);
+    }
 }

--- a/src/GraphNavigator/DeserializationGraphNavigator.php
+++ b/src/GraphNavigator/DeserializationGraphNavigator.php
@@ -205,7 +205,7 @@ final class DeserializationGraphNavigator extends GraphNavigator implements Grap
                         continue;
                     }
 
-                    if ($propertyMetadata->readOnly === true) {
+                    if ($propertyMetadata->readOnly) {
                         continue;
                     }
 

--- a/src/GraphNavigator/DeserializationGraphNavigator.php
+++ b/src/GraphNavigator/DeserializationGraphNavigator.php
@@ -201,7 +201,11 @@ final class DeserializationGraphNavigator extends GraphNavigator implements Grap
                         continue;
                     }
 
-                    if ($propertyMetadata->readOnly) {
+                    if (null !== $this->expressionExclusionStrategy && $this->expressionExclusionStrategy->shouldSkipPropertyOnDeserialize($propertyMetadata, $this->context)) {
+                        continue;
+                    }
+
+                    if ($propertyMetadata->readOnly === true) {
                         continue;
                     }
 

--- a/src/GraphNavigator/DeserializationGraphNavigator.php
+++ b/src/GraphNavigator/DeserializationGraphNavigator.php
@@ -201,10 +201,6 @@ final class DeserializationGraphNavigator extends GraphNavigator implements Grap
                         continue;
                     }
 
-                    if (null !== $this->expressionExclusionStrategy && $this->expressionExclusionStrategy->shouldSkipPropertyOnDeserialize($propertyMetadata, $this->context)) {
-                        continue;
-                    }
-
                     if ($propertyMetadata->readOnly) {
                         continue;
                     }

--- a/src/Metadata/ClassMetadata.php
+++ b/src/Metadata/ClassMetadata.php
@@ -178,7 +178,7 @@ class ClassMetadata extends MergeableClassMetadata
     {
         parent::addPropertyMetadata($metadata);
         $this->sortProperties();
-        if ($metadata instanceof PropertyMetadata && ( $metadata->excludeIf || $metadata->readOnlyIf ) ) {
+        if ($metadata instanceof PropertyMetadata && ($metadata->excludeIf || $metadata->readOnlyIf)) {
             $this->usingExpression = true;
         }
     }

--- a/src/Metadata/ClassMetadata.php
+++ b/src/Metadata/ClassMetadata.php
@@ -178,7 +178,7 @@ class ClassMetadata extends MergeableClassMetadata
     {
         parent::addPropertyMetadata($metadata);
         $this->sortProperties();
-        if ($metadata instanceof PropertyMetadata && $metadata->excludeIf) {
+        if ($metadata instanceof PropertyMetadata && ( $metadata->excludeIf || $metadata->readOnlyIf ) ) {
             $this->usingExpression = true;
         }
     }

--- a/src/Metadata/Driver/AnnotationDriver.php
+++ b/src/Metadata/Driver/AnnotationDriver.php
@@ -19,7 +19,6 @@ use JMS\Serializer\Annotation\PostDeserialize;
 use JMS\Serializer\Annotation\PostSerialize;
 use JMS\Serializer\Annotation\PreSerialize;
 use JMS\Serializer\Annotation\ReadOnly;
-use JMS\Serializer\Annotation\ReadOnlyIf;
 use JMS\Serializer\Annotation\SerializedName;
 use JMS\Serializer\Annotation\Since;
 use JMS\Serializer\Annotation\SkipWhenEmpty;

--- a/src/Metadata/Driver/XmlDriver.php
+++ b/src/Metadata/Driver/XmlDriver.php
@@ -8,7 +8,6 @@ use JMS\Serializer\Annotation\ExclusionPolicy;
 use JMS\Serializer\Exception\InvalidMetadataException;
 use JMS\Serializer\Exception\XmlErrorException;
 use JMS\Serializer\Expression\CompilableExpressionEvaluatorInterface;
-use JMS\Serializer\Expression\Expression;
 use JMS\Serializer\Metadata\ClassMetadata;
 use JMS\Serializer\Metadata\ExpressionPropertyMetadata;
 use JMS\Serializer\Metadata\PropertyMetadata;
@@ -297,18 +296,13 @@ class XmlDriver extends AbstractFileDriver
                         $pMetadata->maxDepth = (int) $pElem->attributes()->{'max-depth'};
                     }
 
-
-                    if (null !== $elem->attributes()->{'read-only'}) {
-                        $metadata->xmlRootPrefix = (string) $xmlRootPrefix;
-                    }
-
                     //we need read-only before setter and getter set, because that method depends on flag being set
                     $readOnly = null === $pElem->attributes()->{'read-only'} ? $readOnlyClass : $pElem->attributes()->{'read-only'};
-                    if(null !== $readOnly) {
-                        if ($readOnly === 'true' || $readOnly === 'false') {
-                            $pMetadata->readOnly = $pMetadata->readOnly || $readOnly === 'true' ? true : false;
+                    if (null !== $readOnly) {
+                        if ('true' === (string) $readOnly || 'false' === (string) $readOnly) {
+                            $pMetadata->readOnly = $pMetadata->readOnly || ('true' === (string) $readOnly ? true : false);
                         } else {
-                            $pMetadata->readOnlyIf = $this->parseExpression((string)$readOnly);
+                            $pMetadata->readOnlyIf = $this->parseExpression((string) $readOnly);
                         }
                     }
 

--- a/src/Metadata/Driver/YamlDriver.php
+++ b/src/Metadata/Driver/YamlDriver.php
@@ -110,8 +110,7 @@ class YamlDriver extends AbstractFileDriver
         $exclusionPolicy = isset($config['exclusion_policy']) ? strtoupper($config['exclusion_policy']) : 'NONE';
         $excludeAll = isset($config['exclude']) ? (bool) $config['exclude'] : false;
         $classAccessType = $config['access_type'] ?? PropertyMetadata::ACCESS_TYPE_PROPERTY;
-        $readOnlyClass = (isset($config['read_only']) && !isset($config['read_only_if']))  ? (bool) $config['read_only'] : false;
-        $readOnlyIfClass = isset($config['read_only_if']) ? $this->parseExpression((string) $config['read_only_if']) : null;
+        $readOnlyClass = $config['read_only'] ?? null;
         $this->addClassProperties($metadata, $config);
 
         $propertiesMetadata = [];
@@ -276,25 +275,15 @@ class YamlDriver extends AbstractFileDriver
                     }
 
                     //we need read_only before setter and getter set, because that method depends on flag being set
-                    $pMetadata->readOnly = $pMetadata->readOnly || $readOnlyClass;
-                    $pMetadata->readOnlyIf = $readOnlyIfClass;
-                    if (isset($pConfig['read_only_if'])) {
-                        $pMetadata->readOnlyIf = $this->parseExpression($pConfig['read_only_if']);
-                        $pMetadata->readOnly = false;
-                    } else {
-                        if (isset($pConfig['read_only'])) {
-                            $pMetadata->readOnly = (bool) $pConfig['read_only'];
-                            $pMetadata->readOnlyIf = null;
+                    $readOnly = $pConfig['read_only'] ?? $readOnlyClass;
+                    if (null !== $readOnly) {
+                        if (is_bool($readOnly)) {
+                            $pMetadata->readOnly = $pMetadata->readOnly || $readOnly;
+                        } else {
+                            $pMetadata->readOnlyIf = $this->parseExpression((string) $readOnly);
                         }
                     }
 
-/*
-                    if (isset($pConfig['read_only'])) {
-                        $pMetadata->readOnly = (bool) $pConfig['read_only'];
-                    } else {
-                        $pMetadata->readOnly = $pMetadata->readOnly || $readOnlyClass;
-                    }
-*/
                     $pMetadata->setAccessor(
                         $pConfig['access_type'] ?? $classAccessType,
                         $pConfig['accessor']['getter'] ?? null,

--- a/src/Metadata/Driver/YamlDriver.php
+++ b/src/Metadata/Driver/YamlDriver.php
@@ -110,7 +110,8 @@ class YamlDriver extends AbstractFileDriver
         $exclusionPolicy = isset($config['exclusion_policy']) ? strtoupper($config['exclusion_policy']) : 'NONE';
         $excludeAll = isset($config['exclude']) ? (bool) $config['exclude'] : false;
         $classAccessType = $config['access_type'] ?? PropertyMetadata::ACCESS_TYPE_PROPERTY;
-        $readOnlyClass = isset($config['read_only']) ? (bool) $config['read_only'] : false;
+        $readOnlyClass = (isset($config['read_only']) && !isset($config['read_only_if']))  ? (bool) $config['read_only'] : false;
+        $readOnlyIfClass = isset($config['read_only_if']) ? $this->parseExpression((string) $config['read_only_if']) : null;
         $this->addClassProperties($metadata, $config);
 
         $propertiesMetadata = [];
@@ -275,12 +276,25 @@ class YamlDriver extends AbstractFileDriver
                     }
 
                     //we need read_only before setter and getter set, because that method depends on flag being set
+                    $pMetadata->readOnly = $pMetadata->readOnly || $readOnlyClass;
+                    $pMetadata->readOnlyIf = $readOnlyIfClass;
+                    if (isset($pConfig['read_only_if'])) {
+                        $pMetadata->readOnlyIf = $this->parseExpression($pConfig['read_only_if']);
+                        $pMetadata->readOnly = false;
+                    } else {
+                        if (isset($pConfig['read_only'])) {
+                            $pMetadata->readOnly = (bool) $pConfig['read_only'];
+                            $pMetadata->readOnlyIf = null;
+                        }
+                    }
+
+/*
                     if (isset($pConfig['read_only'])) {
                         $pMetadata->readOnly = (bool) $pConfig['read_only'];
                     } else {
                         $pMetadata->readOnly = $pMetadata->readOnly || $readOnlyClass;
                     }
-
+*/
                     $pMetadata->setAccessor(
                         $pConfig['access_type'] ?? $classAccessType,
                         $pConfig['accessor']['getter'] ?? null,

--- a/src/Metadata/PropertyMetadata.php
+++ b/src/Metadata/PropertyMetadata.php
@@ -114,6 +114,11 @@ class PropertyMetadata extends BasePropertyMetadata
     public $readOnly = false;
 
     /**
+     * @var string
+     */
+    public $readOnlyIf = null;
+
+    /**
      * @var bool
      */
     public $xmlAttributeMap = false;
@@ -236,6 +241,7 @@ class PropertyMetadata extends BasePropertyMetadata
             'xmlEntryNamespace' => $this->xmlEntryNamespace,
             'xmlCollectionSkipWhenEmpty' => $this->xmlCollectionSkipWhenEmpty,
             'excludeIf' => $this->excludeIf,
+            'readOnlyIf' => $this->readOnlyIf,
             'skipWhenEmpty' => $this->skipWhenEmpty,
             'forceReflectionAccess' => $this->forceReflectionAccess,
         ]);
@@ -291,6 +297,9 @@ class PropertyMetadata extends BasePropertyMetadata
         }
         if (isset($unserialized['excludeIf'])) {
             $this->excludeIf = $unserialized['excludeIf'];
+        }
+        if (isset($unserialized['readOnlyIf'])) {
+            $this->readOnlyIf = $unserialized['readOnlyIf'];
         }
         if (isset($unserialized['skipWhenEmpty'])) {
             $this->skipWhenEmpty = $unserialized['skipWhenEmpty'];

--- a/src/Metadata/PropertyMetadata.php
+++ b/src/Metadata/PropertyMetadata.php
@@ -173,7 +173,7 @@ class PropertyMetadata extends BasePropertyMetadata
                 }
             }
 
-            if (empty($setter) && !$this->readOnly) {
+            if (empty($setter) && (!$this->readOnly || null !== $this->readOnlyIf)) {
                 if ($class->hasMethod('set' . $this->name) && $class->getMethod('set' . $this->name)->isPublic()) {
                     $setter = 'set' . $this->name;
                 } else {

--- a/tests/Fixtures/AuthorReadOnlyExpression.php
+++ b/tests/Fixtures/AuthorReadOnlyExpression.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace JMS\Serializer\Tests\Fixtures;
+
+use JMS\Serializer\Annotation\Accessor;
+use JMS\Serializer\Annotation\ReadOnly;
+use JMS\Serializer\Annotation\SerializedName;
+use JMS\Serializer\Annotation\Type;
+use JMS\Serializer\Annotation\XmlRoot;
+
+/** @XmlRoot("author") */
+class AuthorReadOnlyExpression
+{
+    /**
+     * @ReadOnly(if="1 == 1")
+     * @SerializedName("id")
+     */
+    private $id;
+
+    /**
+     * @ReadOnly(if="1 == 2")
+     * @Type("string")
+     * @SerializedName("full_name")
+     * @Accessor("getName")
+     */
+    private $name;
+
+    public function __construct($id, $name)
+    {
+        $this->id = $id;
+        $this->name = $name;
+    }
+
+    public function getId()
+    {
+        return $this->id;
+    }
+
+    public function getName()
+    {
+        return $this->name;
+    }
+}

--- a/tests/Fixtures/AuthorReadOnlyExpressionPerClass.php
+++ b/tests/Fixtures/AuthorReadOnlyExpressionPerClass.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace JMS\Serializer\Tests\Fixtures;
+
+use JMS\Serializer\Annotation\Accessor;
+use JMS\Serializer\Annotation\ReadOnly;
+use JMS\Serializer\Annotation\SerializedName;
+use JMS\Serializer\Annotation\Type;
+use JMS\Serializer\Annotation\XmlRoot;
+
+/**
+ * @XmlRoot("author")
+ * @ReadOnly(if="5 == 5")
+ */
+class AuthorReadOnlyExpressionPerClass
+{
+    /**
+     * @ReadOnly(if="1 == 1")
+     * @SerializedName("id")
+     */
+    private $id;
+
+    /**
+     * @Type("string")
+     * @SerializedName("full_name")
+     * @Accessor("getName")
+     * @ReadOnly(if="1 == 2")
+     */
+    private $name;
+
+    public function __construct($id, $name)
+    {
+        $this->id = $id;
+        $this->name = $name;
+    }
+
+    public function getId()
+    {
+        return $this->id;
+    }
+
+    public function getName()
+    {
+        return $this->name;
+    }
+}

--- a/tests/Fixtures/NoAdminUser.php
+++ b/tests/Fixtures/NoAdminUser.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace JMS\Serializer\Tests\Fixtures;
+
+class NoAdminUser
+{
+    public function isAdmin()
+    {
+        return false;
+    }
+}

--- a/tests/Fixtures/PersonPermission.php
+++ b/tests/Fixtures/PersonPermission.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace JMS\Serializer\Tests\Fixtures;
+
+use JMS\Serializer\Annotation as Serializer;
+
+/**
+ * @Serializer\ExclusionPolicy("NONE")
+ * @Serializer\AccessorOrder("custom",custom = {"name", "permissions" ,"userAgent"})
+ */
+class PersonPermission
+{
+    /**
+     * @Serializer\Type("string")
+     */
+    public $name;
+
+    /**
+     * @Serializer\Type("string")
+     * @Serializer\ReadOnly(if="user.isAdmin()")
+     */
+    public $permissions;
+
+    /**
+     * @Serializer\Type("string")
+     * @Serializer\ReadOnly(if="!(user.isAdmin())")
+     */
+    public $userAgent;
+}

--- a/tests/Metadata/Driver/xml/PersonPermission.xml
+++ b/tests/Metadata/Driver/xml/PersonPermission.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<serializer>
+    <class name="JMS\Serializer\Tests\Fixtures\PersonPermission">
+        <property name="name" type="string" />
+        <property name="permissions" type="string" read-only="user.isAdmin()"/>
+        <property name="userAgent" type="string" read-only="!(user.isAdmin())"/>
+    </class>
+</serializer>

--- a/tests/Metadata/Driver/yml/PersonPermission.yml
+++ b/tests/Metadata/Driver/yml/PersonPermission.yml
@@ -1,0 +1,10 @@
+JMS\Serializer\Tests\Fixtures\PersonPermission:
+    properties:
+        name:
+            type: string
+        permissions:
+            type: string
+            read_only: "user.isAdmin()"
+        userAgent:
+            type: string
+            read_only: "!(user.isAdmin())"

--- a/tests/Serializer/BaseSerializationTest.php
+++ b/tests/Serializer/BaseSerializationTest.php
@@ -37,6 +37,8 @@ use JMS\Serializer\Tests\Fixtures\AuthorExpressionAccess;
 use JMS\Serializer\Tests\Fixtures\AuthorExpressionAccessContext;
 use JMS\Serializer\Tests\Fixtures\AuthorList;
 use JMS\Serializer\Tests\Fixtures\AuthorReadOnly;
+use JMS\Serializer\Tests\Fixtures\AuthorReadOnlyExpression;
+use JMS\Serializer\Tests\Fixtures\AuthorReadOnlyExpressionPerClass;
 use JMS\Serializer\Tests\Fixtures\AuthorReadOnlyPerClass;
 use JMS\Serializer\Tests\Fixtures\AuthorsInline;
 use JMS\Serializer\Tests\Fixtures\BlogPost;
@@ -829,6 +831,42 @@ abstract class BaseSerializationTest extends TestCase
 
         if ($this->hasDeserializer()) {
             $deserialized = $this->deserialize($this->getContent('readonly'), get_class($author));
+            self::assertNull($this->getField($deserialized, 'id'));
+            self::assertEquals('Ruud Kamphuis', $this->getField($deserialized, 'name'));
+        }
+    }
+
+    public function testReadOnlyExpression()
+    {
+        $evaluator = new ExpressionEvaluator(new ExpressionLanguage());
+
+        $builder = SerializerBuilder::create();
+        $builder->setExpressionEvaluator($evaluator);
+        $serializer = $builder->build();
+
+        $author = new AuthorReadOnlyExpression(123, 'Ruud Kamphuis');
+        self::assertEquals($this->getContent('readonly'), $serializer->serialize($author, $this->getFormat()));
+
+        if ($this->hasDeserializer()) {
+            $deserialized = $serializer->deserialize($this->getContent('readonly'), get_class($author), $this->getFormat());
+            self::assertNull($this->getField($deserialized, 'id'));
+            self::assertEquals('Ruud Kamphuis', $this->getField($deserialized, 'name'));
+        }
+    }
+
+    public function testReadOnlyExpressionPerClass()
+    {
+        $evaluator = new ExpressionEvaluator(new ExpressionLanguage());
+
+        $builder = SerializerBuilder::create();
+        $builder->setExpressionEvaluator($evaluator);
+        $serializer = $builder->build();
+
+        $author = new AuthorReadOnlyExpressionPerClass(123, 'Ruud Kamphuis');
+        self::assertEquals($this->getContent('readonly'), $serializer->serialize($author, $this->getFormat()));
+
+        if ($this->hasDeserializer()) {
+            $deserialized = $serializer->deserialize($this->getContent('readonly'), get_class($author), $this->getFormat());
             self::assertNull($this->getField($deserialized, 'id'));
             self::assertEquals('Ruud Kamphuis', $this->getField($deserialized, 'name'));
         }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| Doc updated   | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | Yes
| Fixed tickets | <!-- #-prefixed issue number(s), if any -->
| License       | MIT

Hello,
for my project I needed some way to dynamically define if a property is ReadOnly or not.
So I implemented the ExpressionParser the same way as the @Exclude annotation does.

Similar features has also been asked here some years ago. It's not possible with groups though.
https://github.com/schmittjoh/JMSSerializerBundle/issues/628

