### PR TITLE
Replace "Exclude" by "Expose"

### DIFF
--- a/doc/cookbook/exclusion_strategies.rst
+++ b/doc/cookbook/exclusion_strategies.rst
@@ -324,7 +324,7 @@ By default the serializer exposes three variables (`object`, `context` and `prop
         private $name;
 
        /**
-         * @Exclude(if="someMethod(object, context, property_metadata)")
+         * @Expose(if="someMethod(object, context, property_metadata)")
          */
         private $name2;
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| Doc updated   | yes
| BC breaks?    | no 
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
| License       | MIT

Replace "Exclude" by "Expose" in the example because "Exclude" appears twice.