### PR TITLE
Fix travis tests

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -6,7 +6,7 @@ import sys, os
 
 # Add any Sphinx extension module names here, as strings. They can be extensions
 # coming with Sphinx (named 'sphinx.ext.*') or your custom ones.
-extensions = ['sensio.sphinx.refinclude', 'sensio.sphinx.configurationblock', 'sensio.sphinx.phpcode']
+extensions = ['sensio.sphinx.configurationblock', 'sensio.sphinx.phpcode']
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']

--- a/tests/Exclusion/GroupsExclusionStrategyTest.php
+++ b/tests/Exclusion/GroupsExclusionStrategyTest.php
@@ -68,7 +68,7 @@ class GroupsExclusionStrategyTest extends TestCase
         }
 
         $groupsFor = $exclusion->getGroupsFor($context);
-        $this->assertEquals($groupsFor, $resultingGroups);
+        self::assertEquals($groupsFor, $resultingGroups);
     }
 
     public function getGroupsFor()

--- a/tests/Metadata/ExpressionPropertyMetadataTest.php
+++ b/tests/Metadata/ExpressionPropertyMetadataTest.php
@@ -14,6 +14,6 @@ class ExpressionPropertyMetadataTest extends AbstractPropertyMetadataTest
         $this->setNonDefaultMetadataValues($meta);
 
         $restoredMeta = unserialize(serialize($meta));
-        $this->assertEquals($meta, $restoredMeta);
+        self::assertEquals($meta, $restoredMeta);
     }
 }

--- a/tests/Metadata/PropertyMetadataTest.php
+++ b/tests/Metadata/PropertyMetadataTest.php
@@ -18,6 +18,6 @@ class PropertyMetadataTest extends AbstractPropertyMetadataTest
         $meta->readOnly = true;
 
         $restoredMeta = unserialize(serialize($meta));
-        $this->assertEquals($meta, $restoredMeta);
+        self::assertEquals($meta, $restoredMeta);
     }
 }

--- a/tests/Metadata/StaticPropertyMetadataTest.php
+++ b/tests/Metadata/StaticPropertyMetadataTest.php
@@ -14,6 +14,6 @@ class StaticPropertyMetadataTest extends AbstractPropertyMetadataTest
         $this->setNonDefaultMetadataValues($meta);
 
         $restoredMeta = unserialize(serialize($meta));
-        $this->assertEquals($meta, $restoredMeta);
+        self::assertEquals($meta, $restoredMeta);
     }
 }

--- a/tests/Metadata/VirtualPropertyMetadataTest.php
+++ b/tests/Metadata/VirtualPropertyMetadataTest.php
@@ -15,6 +15,6 @@ class VirtualPropertyMetadataTest extends AbstractPropertyMetadataTest
         $this->setNonDefaultMetadataValues($meta);
 
         $restoredMeta = unserialize(serialize($meta));
-        $this->assertEquals($meta, $restoredMeta);
+        self::assertEquals($meta, $restoredMeta);
     }
 }

--- a/tests/Serializer/BaseSerializationTest.php
+++ b/tests/Serializer/BaseSerializationTest.php
@@ -454,10 +454,10 @@ abstract class BaseSerializationTest extends TestCase
 
         $obj = new SimpleInternalObject('foo', 'bar');
 
-        $this->assertEquals($this->getContent('simple_object'), $this->serialize($obj));
+        self::assertEquals($this->getContent('simple_object'), $this->serialize($obj));
 
         if ($this->hasDeserializer()) {
-            $this->assertEquals($obj, $this->deserialize($this->getContent('simple_object'), get_class($obj)));
+            self::assertEquals($obj, $this->deserialize($this->getContent('simple_object'), get_class($obj)));
         }
     }
 
@@ -472,10 +472,10 @@ abstract class BaseSerializationTest extends TestCase
 
     public function testSimpleObjectStaticProp()
     {
-        $this->assertEquals($this->getContent('simple_object'), $this->serialize($obj = new SimpleObjectWithStaticProp('foo', 'bar')));
+        self::assertEquals($this->getContent('simple_object'), $this->serialize($obj = new SimpleObjectWithStaticProp('foo', 'bar')));
 
         if ($this->hasDeserializer()) {
-            $this->assertEquals($obj, $this->deserialize($this->getContent('simple_object'), get_class($obj)));
+            self::assertEquals($obj, $this->deserialize($this->getContent('simple_object'), get_class($obj)));
         }
     }
 
@@ -1567,15 +1567,15 @@ abstract class BaseSerializationTest extends TestCase
             GraphNavigatorInterface::DIRECTION_SERIALIZATION,
             'Virtual',
             $this->getFormat(),
-            function ($visitor, $data) use (&$invoked) {
+            static function ($visitor, $data) use (&$invoked) {
                 $invoked = true;
-                $this->assertEquals('foo', $data);
+                self::assertEquals('foo', $data);
                 return null;
             }
         );
 
         $this->serializer->serialize('foo', $this->getFormat(), null, 'Virtual');
-        $this->assertTrue($invoked);
+        self::assertTrue($invoked);
     }
 
     public function getFirstClassListCollectionsValues()

--- a/tests/Serializer/Doctrine/ObjectConstructorTest.php
+++ b/tests/Serializer/Doctrine/ObjectConstructorTest.php
@@ -211,7 +211,7 @@ class ObjectConstructorTest extends TestCase
         /** @var Server $serverDeserialized */
         $serverDeserialized = $serializer->deserialize($jsonData, Server::class, 'json');
 
-        static::assertSame(
+        self::assertSame(
             $em->getUnitOfWork()->getEntityState($serverDeserialized),
             UnitOfWork::STATE_MANAGED
         );


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| Doc updated   | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | no
| License       | MIT

# Changed log
- To be consistency, using the `self::` approach to do assertion calls.
- Fix coding style via `php-cs-fixer` and the coding style error message is as follows:
```
FILE: tests/Serializer/BaseSerializationTest.php
--------------------------------------------------------------------------------
FOUND 1 ERROR AFFECTING 1 LINE
--------------------------------------------------------------------------------
 1570 | ERROR | [x] Closure not using "$this" should be declared static.
      |       |     (SlevomatCodingStandard.Functions.StaticClosure.ClosureNotStatic)
--------------------------------------------------------------------------------
PHPCBF CAN FIX THE 1 MARKED SNIFF VIOLATIONS AUTOMATICALLY
--------------------------------------------------------------------------------
```
- According to this [issue](https://github.com/Sylius/Sylius/pull/11168), removing the `sensio.sphinx.refinclude` setting because it's deprecated.