### PR TITLE
Fix Support conditional exclude for classes

### DIFF
--- a/src/Metadata/Driver/AnnotationDriver.php
+++ b/src/Metadata/Driver/AnnotationDriver.php
@@ -100,7 +100,7 @@ class AnnotationDriver implements DriverInterface
                 $classMetadata->registerNamespace($annot->uri, $annot->prefix);
             } elseif ($annot instanceof Exclude) {
                 if (null !== $annot->if) {
-                    $classMetadata->excludeIf = $this->parseExpression('!(' . $annot->if . ')');
+                    $classMetadata->excludeIf = $this->parseExpression($annot->if);
                 } else {
                     $excludeAll = true;
                 }

--- a/src/Metadata/Driver/XmlDriver.php
+++ b/src/Metadata/Driver/XmlDriver.php
@@ -69,7 +69,7 @@ class XmlDriver extends AbstractFileDriver
         $excludeAll = null !== $exclude ? 'true' === strtolower((string) $exclude) : false;
 
         if (null !== $excludeIf = $elem->attributes()->{'exclude-if'}) {
-            $metadata->excludeIf = $this->parseExpression('!(' . (string) $excludeIf . ')');
+            $metadata->excludeIf = $this->parseExpression((string) $excludeIf);
         }
 
         $classAccessType = (string) ($elem->attributes()->{'access-type'} ?: PropertyMetadata::ACCESS_TYPE_PROPERTY);

--- a/src/Metadata/Driver/YamlDriver.php
+++ b/src/Metadata/Driver/YamlDriver.php
@@ -111,7 +111,7 @@ class YamlDriver extends AbstractFileDriver
         $excludeAll = isset($config['exclude']) ? (bool) $config['exclude'] : false;
 
         if (isset($config['exclude_if'])) {
-            $metadata->excludeIf = $this->parseExpression('!(' . (string) $config['exclude_if'] . ')');
+            $metadata->excludeIf = $this->parseExpression((string) $config['exclude_if']);
         }
 
         $classAccessType = $config['access_type'] ?? PropertyMetadata::ACCESS_TYPE_PROPERTY;

--- a/tests/Fixtures/PersonAccount.php
+++ b/tests/Fixtures/PersonAccount.php
@@ -7,7 +7,7 @@ namespace JMS\Serializer\Tests\Fixtures;
 use JMS\Serializer\Annotation as Serializer;
 
 /**
- * @Serializer\Exclude(if="object && object.expired != true")
+ * @Serializer\Exclude(if="object.expired")
  */
 class PersonAccount
 {

--- a/tests/Metadata/Driver/BaseDriverTest.php
+++ b/tests/Metadata/Driver/BaseDriverTest.php
@@ -574,7 +574,7 @@ abstract class BaseDriverTest extends TestCase
         $m = $this->getDriver()->loadMetadataForClass(new \ReflectionClass($class));
 
         $c = new ClassMetadata($class);
-        $c->excludeIf = $this->getExpressionEvaluator()->parse('!(object && object.expired != true)', ['context', 'class_metadata', 'object']);
+        $c->excludeIf = $this->getExpressionEvaluator()->parse('object.expired', ['context', 'class_metadata', 'object']);
         self::assertEquals($c->excludeIf->serialize(), $m->excludeIf->serialize());
     }
 

--- a/tests/Metadata/Driver/xml/PersonAccount.xml
+++ b/tests/Metadata/Driver/xml/PersonAccount.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <serializer>
-    <class name="JMS\Serializer\Tests\Fixtures\PersonAccount" exclude-if="object &amp;&amp; object.expired != true">
+    <class name="JMS\Serializer\Tests\Fixtures\PersonAccount" exclude-if="object.expired">
         <property name="name" type="string" />
         <property name="expired" type="boolean"/>
     </class>

--- a/tests/Metadata/Driver/yml/PersonAccount.yaml
+++ b/tests/Metadata/Driver/yml/PersonAccount.yaml
@@ -1,5 +1,5 @@
 JMS\Serializer\Tests\Fixtures\PersonAccount:
-  exclude_if: 'object && object.expired != true'
+  exclude_if: 'object.expired'
   properties:
     title:
       name: string


### PR DESCRIPTION
In #1099 support for ExcludeIf on class level was added, unfortunately the condition was inverted.

Current behavior would actually exclude this class:
```php
/**
 * @Serializer\Exclude(if="false")
 */
class PersonAccount
```

However it should only exclude the class if the condition evaluates to true:
```php
/**
 * @Serializer\Exclude(if="true")
 */
class PersonAccount
```

This was due to a copy mistake from _Expose_, which internal also uses _Exclude_, but with the condition negated and also due to a test scenario which was not very clear to udnerstand.

 I have simplified the test to make it more clear and fixed the drivers.