### PR TITLE
GroupsExclusionStrategy code refactoring / comment for readability

### DIFF
--- a/src/Exclusion/GroupsExclusionStrategy.php
+++ b/src/Exclusion/GroupsExclusionStrategy.php
@@ -13,9 +13,9 @@ final class GroupsExclusionStrategy implements ExclusionStrategyInterface
     public const DEFAULT_GROUP = 'Default';
 
     /**
-     * @var array
+     * @var array<string,array<string,boolean>>
      */
-    private $groups = [];
+    private $parsedGroups = [];
 
     /**
      * @var bool
@@ -24,24 +24,27 @@ final class GroupsExclusionStrategy implements ExclusionStrategyInterface
 
     public function __construct(array $groups)
     {
-        if (empty($groups)) {
-            $groups = [self::DEFAULT_GROUP];
-        }
+        $this->prepare($groups, 'root');
+    }
 
-        foreach ($groups as $group) {
-            if (is_array($group)) {
+    private function prepare(array $groups, $path)
+    {
+        $currentGroups = [];
+        foreach ($groups as $key => $value) {
+            if (is_string($key) && is_array($value)) {
                 $this->nestedGroups = true;
-                break;
+                $this->prepare($value, $path . '.' . $key);
+                continue;
             }
+
+            $currentGroups[$value] = true;
         }
 
-        if ($this->nestedGroups) {
-            $this->groups = $groups;
-        } else {
-            foreach ($groups as $group) {
-                $this->groups[$group] = true;
-            }
+        if (empty($currentGroups)) {
+            $currentGroups[self::DEFAULT_GROUP] = true;
         }
+
+        $this->parsedGroups[$path] = $currentGroups;
     }
 
     /**
@@ -57,32 +60,24 @@ final class GroupsExclusionStrategy implements ExclusionStrategyInterface
      */
     public function shouldSkipProperty(PropertyMetadata $property, Context $navigatorContext): bool
     {
-        if ($this->nestedGroups) {
-            $groups = $this->getGroupsFor($navigatorContext);
+        $groups = $property->groups ?: [self::DEFAULT_GROUP];
 
-            if (!$property->groups) {
-                return !in_array(self::DEFAULT_GROUP, $groups);
-            }
-
-            return $this->shouldSkipUsingGroups($property, $groups);
+        if (!$this->nestedGroups) {
+            // Group are not nested so we
+            $path = 'root';
         } else {
-            if (!$property->groups) {
-                return !isset($this->groups[self::DEFAULT_GROUP]);
-            }
-
-            foreach ($property->groups as $group) {
-                if (isset($this->groups[$group])) {
-                    return false;
-                }
-            }
-            return true;
+            $path = $this->buildPathFromContext($navigatorContext);
         }
-    }
 
-    private function shouldSkipUsingGroups(PropertyMetadata $property, array $groups): bool
-    {
-        foreach ($property->groups as $group) {
-            if (in_array($group, $groups)) {
+        if(!isset($this->parsedGroups[$path])) {
+            // If we reach that path it's because we were allowed so we fallback on default group
+            $this->parsedGroups[$path] = [self::DEFAULT_GROUP => true];
+        }
+
+        $againstGroups = $this->parsedGroups[$path];
+
+        foreach ($groups as $group) {
+            if (isset($againstGroups[$group])) {
                 return false;
             }
         }
@@ -90,26 +85,25 @@ final class GroupsExclusionStrategy implements ExclusionStrategyInterface
         return true;
     }
 
+    private function buildPathFromContext(Context $navigatorContext): string
+    {
+        $path = $navigatorContext->getCurrentPath();
+        array_unshift($path, 'root');
+        return implode('.', $path);
+    }
+
     public function getGroupsFor(Context $navigatorContext): array
     {
         if (!$this->nestedGroups) {
-            return array_keys($this->groups);
+            return array_keys($this->parsedGroups['root']);
         }
 
-        $paths = $navigatorContext->getCurrentPath();
-        $groups = $this->groups;
-        foreach ($paths as $index => $path) {
-            if (!array_key_exists($path, $groups)) {
-                if ($index > 0) {
-                    $groups = [self::DEFAULT_GROUP];
-                }
-                break;
-            }
-            $groups = $groups[$path];
-            if (!array_filter($groups, 'is_string')) {
-                $groups += [self::DEFAULT_GROUP];
-            }
+        $path = $this->buildPathFromContext($navigatorContext);
+
+        if (!isset($this->parsedGroups[$path])) {
+            return [self::DEFAULT_GROUP];
         }
-        return $groups;
+
+        return array_keys($this->parsedGroups[$path]);
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| Doc updated   | no
| BC breaks?    | yes/no <!-- don't forget updating UPGRADING.md file -->
| Deprecations? | no <!-- don't forget updating UPGRADING.md file -->
| Tests pass?   | yes/no
| Fixed tickets | #... <!-- #-prefixed issue number(s), if any -->
| License       | MIT

This code optimize event more the groups exclusion strategy by relaying on isset in any case.

The path => groups get prepared in constructor and then we just need to build the path from the context and use isset from there on each group of the property.

The issue I have is that the GroupsExclusionStrategy::getGroupsFor is public but not part of the interface. The method is not use in the package itself other than in the test itself. 
The test failed since I the method getGroups for doesn' return the same structure (in fact it's not needed anymore).

All the integration test that rely on the GroupsExclusionStrategy does pass.

Since the getGroupsFor and the class GroupsExclusionStrategy we should pass by a deprecations flow and reimplement the getGroupsFor. Since it's not suppose to be use directly I could just combine both code and use the old way in the code.

The last section is not part of the PR yet.

