### PR TITLE
[HandlerRegistry] case sensitive default methods

### DIFF
--- a/src/Handler/HandlerRegistry.php
+++ b/src/Handler/HandlerRegistry.php
@@ -23,10 +23,10 @@ class HandlerRegistry implements HandlerRegistryInterface
 
         switch ($direction) {
             case GraphNavigatorInterface::DIRECTION_DESERIALIZATION:
-                return 'deserialize' . $type . 'From' . $format;
+                return 'deserialize' . $type . 'From' . ucfirst($format);
 
             case GraphNavigatorInterface::DIRECTION_SERIALIZATION:
-                return 'serialize' . $type . 'To' . $format;
+                return 'serialize' . $type . 'To' . ucfirst($format);
 
             default:
                 throw new LogicException(sprintf('The direction %s does not exist; see GraphNavigatorInterface::DIRECTION_??? constants.', json_encode($direction)));

--- a/tests/Handler/HandlerRegistryTest.php
+++ b/tests/Handler/HandlerRegistryTest.php
@@ -37,6 +37,24 @@ class HandlerRegistryTest extends TestCase
         self::assertSame($xmlDeserializationHandler, $this->handlerRegistry->getHandler(GraphNavigatorInterface::DIRECTION_DESERIALIZATION, '\stdClass', 'xml'));
     }
 
+    /**
+     * @dataProvider methodProvider
+     */
+    public function testCaseSensitiveDefaultMedhod(int $direction, string $type, string $format, string $result)
+    {
+        self::assertSame($result, HandlerRegistry::getDefaultMethod($direction, $type, $format));
+    }
+
+    public function methodProvider()
+    {
+        return [
+            [GraphNavigatorInterface::DIRECTION_SERIALIZATION, 'DateTime', 'xml', 'serializeDateTimeToXml'],
+            [GraphNavigatorInterface::DIRECTION_DESERIALIZATION, 'DateTime', 'xml', 'deserializeDateTimeFromXml'],
+            [GraphNavigatorInterface::DIRECTION_SERIALIZATION, 'Foo\Bar', 'json', 'serializeBarToJson'],
+            [GraphNavigatorInterface::DIRECTION_DESERIALIZATION, 'Foo\Bar', 'json', 'deserializeBarFromJson'],
+        ];
+    }
+
     protected function createHandlerRegistry()
     {
         return new HandlerRegistry();


### PR DESCRIPTION
ucfirst for the serialization format while constructing default methods in the handler registry

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  |no
| Doc updated   | no
| BC breaks?    | yes?
| Deprecations? | no 
| Tests pass?   | yes
| License       | MIT

this fixes an issue where the default DateHandler deserialization methods were improperly defined in a case sensitive environment as well as those of the FormErrorHandler.

not entirely sure whether this is considered a bc break as people might have worked aroud this issue by modifying their method names?
