### PR TITLE
Remove conflicts to hoa packages

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -46,11 +46,6 @@
         "doctrine/coding-standard": "^5.0",
         "doctrine/persistence": "^1.3.3|^2.0|^3.0"
     },
-    "conflict": {
-        "hoa/core": "*",
-        "hoa/consistency": "<1.17.05.02",
-        "hoa/iterator": "<2.16.03.15"
-    },
     "autoload": {
         "psr-4": {
             "JMS\\Serializer\\": "src/"


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| Doc updated   | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | no
| Fixed tickets | #... 
| License       | MIT

Not sure but think this conflicts can no be removed as the hoa requirement was also removed in #1212