### PR TITLE
ValueAttribute for key-value arrays

### DIFF
--- a/src/Annotation/XmlMap.php
+++ b/src/Annotation/XmlMap.php
@@ -14,4 +14,11 @@ final class XmlMap extends XmlCollection
      * @var string
      */
     public $keyAttribute = '_key';
+
+
+    /**
+     * @var string
+     */
+    public $valueAttribute;
+
 }

--- a/src/Annotation/XmlMap.php
+++ b/src/Annotation/XmlMap.php
@@ -15,10 +15,8 @@ final class XmlMap extends XmlCollection
      */
     public $keyAttribute = '_key';
 
-
     /**
      * @var string
      */
     public $valueAttribute;
-
 }

--- a/src/Metadata/Driver/AnnotationDriver.php
+++ b/src/Metadata/Driver/AnnotationDriver.php
@@ -214,6 +214,7 @@ class AnnotationDriver implements DriverInterface
                         $propertyMetadata->xmlEntryName = $annot->entry;
                         $propertyMetadata->xmlEntryNamespace = $annot->namespace;
                         $propertyMetadata->xmlKeyAttribute = $annot->keyAttribute;
+                        $propertyMetadata->xmlValueAttribute = $annot->valueAttribute;
                     } elseif ($annot instanceof XmlKeyValuePairs) {
                         $propertyMetadata->xmlKeyValuePairs = true;
                     } elseif ($annot instanceof XmlAttribute) {

--- a/src/Metadata/Driver/XmlDriver.php
+++ b/src/Metadata/Driver/XmlDriver.php
@@ -269,6 +269,9 @@ class XmlDriver extends AbstractFileDriver
                         if (isset($colConfig->attributes()->{'key-attribute-name'})) {
                             $pMetadata->xmlKeyAttribute = (string) $colConfig->attributes()->{'key-attribute-name'};
                         }
+                        if (isset($colConfig->attributes()->{'value-attribute-name'})) {
+                            $pMetadata->xmlValueAttribute = (string) $colConfig->attributes()->{'value-attribute-name'};
+                        }
                     }
 
                     if (isset($pElem->{'xml-element'})) {

--- a/src/Metadata/Driver/YamlDriver.php
+++ b/src/Metadata/Driver/YamlDriver.php
@@ -250,6 +250,10 @@ class YamlDriver extends AbstractFileDriver
                         if (isset($colConfig['key_attribute_name'])) {
                             $pMetadata->xmlKeyAttribute = $colConfig['key_attribute_name'];
                         }
+
+                        if (isset($colConfig['value_attribute_name'])) {
+                            $pMetadata->xmlValueAttribute = $colConfig['value_attribute_name'];
+                        }
                     }
 
                     if (isset($pConfig['xml_element'])) {

--- a/src/Metadata/PropertyMetadata.php
+++ b/src/Metadata/PropertyMetadata.php
@@ -65,6 +65,11 @@ class PropertyMetadata extends BasePropertyMetadata
     public $xmlKeyAttribute;
 
     /**
+     * @var string
+     */
+    public $xmlValueAttribute;
+
+    /**
      * @var bool
      */
     public $xmlAttribute = false;
@@ -222,6 +227,7 @@ class PropertyMetadata extends BasePropertyMetadata
             $this->xmlCollectionInline,
             $this->xmlEntryName,
             $this->xmlKeyAttribute,
+            $this->xmlValueAttribute,
             $this->xmlAttribute,
             $this->xmlValue,
             $this->xmlNamespace,
@@ -270,6 +276,7 @@ class PropertyMetadata extends BasePropertyMetadata
             $this->xmlCollectionInline,
             $this->xmlEntryName,
             $this->xmlKeyAttribute,
+            $this->xmlValueAttribute,
             $this->xmlAttribute,
             $this->xmlValue,
             $this->xmlNamespace,

--- a/src/XmlDeserializationVisitor.php
+++ b/src/XmlDeserializationVisitor.php
@@ -230,7 +230,11 @@ final class XmlDeserializationVisitor extends AbstractVisitor implements NullAwa
                     }
 
                     $k = $this->navigator->accept($attrs[$this->currentMetadata->xmlKeyAttribute], $keyType);
-                    $result[$k] = $this->navigator->accept($v, $entryType);
+                    if (null !== $this->currentMetadata->xmlValueAttribute) {
+                        $result[$k] = $this->navigator->accept($attrs[$this->currentMetadata->xmlValueAttribute], $entryType);
+                    } else {
+                        $result[$k] = $this->navigator->accept($v, $entryType);
+                    }
                 }
 
                 return $result;

--- a/src/XmlSerializationVisitor.php
+++ b/src/XmlSerializationVisitor.php
@@ -190,6 +190,7 @@ final class XmlSerializationVisitor extends AbstractVisitor implements Serializa
 
         $entryName = null !== $this->currentMetadata && null !== $this->currentMetadata->xmlEntryName ? $this->currentMetadata->xmlEntryName : 'entry';
         $keyAttributeName = null !== $this->currentMetadata && null !== $this->currentMetadata->xmlKeyAttribute ? $this->currentMetadata->xmlKeyAttribute : null;
+        $valueAttributeName = null !== $this->currentMetadata && null !== $this->currentMetadata->xmlValueAttribute ? $this->currentMetadata->xmlValueAttribute : null;
         $namespace = null !== $this->currentMetadata && null !== $this->currentMetadata->xmlEntryNamespace ? $this->currentMetadata->xmlEntryNamespace : null;
 
         $elType = $this->getElementType($type);
@@ -204,12 +205,16 @@ final class XmlSerializationVisitor extends AbstractVisitor implements Serializa
                 $entryNode->setAttribute($keyAttributeName, (string) $k);
             }
 
-            try {
-                if (null !== $node = $this->navigator->accept($v, $elType)) {
-                    $this->currentNode->appendChild($node);
+            if (null !== $valueAttributeName) {
+                $entryNode->setAttribute($valueAttributeName, (string) $v);
+            } else {
+                try {
+                    if (null !== $node = $this->navigator->accept($v, $elType)) {
+                        $this->currentNode->appendChild($node);
+                    }
+                } catch (NotAcceptableException $e) {
+                    $this->currentNode->parentNode->removeChild($this->currentNode);
                 }
-            } catch (NotAcceptableException $e) {
-                $this->currentNode->parentNode->removeChild($this->currentNode);
             }
 
             $this->revertCurrentNode();

--- a/tests/Fixtures/ObjectWithStringKeyMap.php
+++ b/tests/Fixtures/ObjectWithStringKeyMap.php
@@ -18,4 +18,14 @@ class ObjectWithStringKeyMap
     {
         $this->map = $map;
     }
+
+    public static function create1()
+    {
+        return new self(
+            [
+                'key-one' => 'value-1',
+                'key-two' => 'value-2',
+            ]
+        );
+    }
 }

--- a/tests/Fixtures/ObjectWithStringKeyMap.php
+++ b/tests/Fixtures/ObjectWithStringKeyMap.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace JMS\Serializer\Tests\Fixtures;
+
+use JMS\Serializer\Annotation as Serializer;
+
+class ObjectWithStringKeyMap
+{
+    /**
+     * @Serializer\Type("array<string,string>")
+     * @Serializer\XmlMap(keyAttribute="key", valueAttribute="value")
+     */
+    private $map;
+
+    public function __construct(array $map)
+    {
+        $this->map = $map;
+    }
+}

--- a/tests/Metadata/AbstractPropertyMetadataTest.php
+++ b/tests/Metadata/AbstractPropertyMetadataTest.php
@@ -21,6 +21,7 @@ abstract class AbstractPropertyMetadataTest extends TestCase
         $metadata->xmlEntryName = 'test_xml_entry_name';
         $metadata->xmlEntryNamespace = 'test_xml_entry_namespace';
         $metadata->xmlKeyAttribute = 'test_xml_key_attribute';
+        $metadata->xmlValueAttribute = 'test_xml_value_attribute';
         $metadata->xmlAttribute = true;
         $metadata->xmlValue = true;
         $metadata->xmlNamespace = 'test_xml_namespace';

--- a/tests/Serializer/XmlSerializationTest.php
+++ b/tests/Serializer/XmlSerializationTest.php
@@ -28,6 +28,7 @@ use JMS\Serializer\Tests\Fixtures\Input;
 use JMS\Serializer\Tests\Fixtures\InvalidUsageOfXmlValue;
 use JMS\Serializer\Tests\Fixtures\ObjectWithNamespacesAndList;
 use JMS\Serializer\Tests\Fixtures\ObjectWithNamespacesAndNestedList;
+use JMS\Serializer\Tests\Fixtures\ObjectWithStringKeyMap;
 use JMS\Serializer\Tests\Fixtures\ObjectWithVirtualXmlProperties;
 use JMS\Serializer\Tests\Fixtures\ObjectWithXmlKeyValuePairs;
 use JMS\Serializer\Tests\Fixtures\ObjectWithXmlKeyValuePairsWithObjectType;
@@ -271,6 +272,15 @@ class XmlSerializationTest extends BaseSerializationTest
     public function testArrayKeyValues()
     {
         self::assertEquals($this->getContent('array_key_values'), $this->serializer->serialize(new ObjectWithXmlKeyValuePairs(), 'xml'));
+    }
+
+    public function testArrayKeyMap()
+    {
+        $map = [
+            'key-one' => 'value-1',
+            'key-two' => 'value-2',
+        ];
+        self::assertEquals($this->getContent('array_key_map'), $this->serializer->serialize(new ObjectWithStringKeyMap($map), 'xml'));
     }
 
     public function testDeserializeArrayKeyValues()

--- a/tests/Serializer/XmlSerializationTest.php
+++ b/tests/Serializer/XmlSerializationTest.php
@@ -274,13 +274,18 @@ class XmlSerializationTest extends BaseSerializationTest
         self::assertEquals($this->getContent('array_key_values'), $this->serializer->serialize(new ObjectWithXmlKeyValuePairs(), 'xml'));
     }
 
-    public function testArrayKeyMap()
+    public function testSerializationStringKeyMap()
     {
-        $map = [
-            'key-one' => 'value-1',
-            'key-two' => 'value-2',
-        ];
-        self::assertEquals($this->getContent('array_key_map'), $this->serializer->serialize(new ObjectWithStringKeyMap($map), 'xml'));
+        self::assertEquals($this->getContent('array_key_map'), $this->serializer->serialize(ObjectWithStringKeyMap::create1(), 'xml'));
+    }
+
+    public function testDeserializationStringKeyMap()
+    {
+        $xml = $this->getContent('array_key_map');
+        $result = $this->serializer->deserialize($xml, ObjectWithStringKeyMap::class, 'xml');
+
+        self::assertInstanceOf(ObjectWithStringKeyMap::class, $result);
+        self::assertEquals(ObjectWithStringKeyMap::create1(), $result);
     }
 
     public function testDeserializeArrayKeyValues()

--- a/tests/Serializer/xml/array_key_map.xml
+++ b/tests/Serializer/xml/array_key_map.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <result>
-  <array>
-    <entry key="key-one" value="value-1" />
-    <entry key="key-two" value="value-2" />
-  </array>
+  <map>
+    <entry key="key-one" value="value-1"/>
+    <entry key="key-two" value="value-2"/>
+  </map>
 </result>

--- a/tests/Serializer/xml/array_key_map.xml
+++ b/tests/Serializer/xml/array_key_map.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<result>
+  <array>
+    <entry key="key-one" value="value-1" />
+    <entry key="key-two" value="value-2" />
+  </array>
+</result>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| Doc updated   | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #1218 
| License       | MIT

Closes #1218 

This PR allows to map simple string associative arrays to XML.

```php
    /**
     * @Serializer\XmlMap(entry = "variable", keyAttribute="name", valueAttribute="value")
     * @Serializer\Type("array<string,string>")
     * @var string[]
     */
    protected $variables = [
        'key1' => 'value1',
        'key2' => 'value2',
    ];
```

## Result

```xml
  <variables>
    <variable name="key1" value="value1" />
    <variable name="key2" value="value2" />
  </variables>
```