### PR TITLE
fixed exception for strict_types

### DIFF
--- a/src/Handler/DateHandler.php
+++ b/src/Handler/DateHandler.php
@@ -258,7 +258,7 @@ final class DateHandler implements SubscribingHandlerInterface
         try {
             $dateInterval = new \DateInterval($data);
         } catch (\Throwable $e) {
-            throw new RuntimeException(sprintf('Invalid dateinterval "%s", expected ISO 8601 format', $data), null, $e);
+            throw new RuntimeException(sprintf('Invalid dateinterval "%s", expected ISO 8601 format', $data), 0, $e);
         }
 
         return $dateInterval;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Doc updated   | no
| BC breaks?    | no <!-- don't forget updating UPGRADING.md file -->
| Deprecations? | no <!-- don't forget updating UPGRADING.md file -->
| Tests pass?   | yes
| Fixed tickets | #... <!-- #-prefixed issue number(s), if any -->
| License       | MIT

When using declare(strict_types=1); null will not work in RuntimeException constructor and will result in this error:

`Wrong parameters for JMS\Serializer\Exception\RuntimeException([string $message [, long $code [, Throwable $previous = NULL]]])`

