### PR TITLE
fix xml embeddable data getReference for DoctrineObjectConstructor

### DIFF
--- a/src/Construction/DoctrineObjectConstructor.php
+++ b/src/Construction/DoctrineObjectConstructor.php
@@ -67,7 +67,7 @@ final class DoctrineObjectConstructor implements ObjectConstructorInterface
         }
 
         // Managed entity, check for proxy load
-        if (!\is_array($data)) {
+        if (!\is_array($data) && !(is_object($data) && 'SimpleXMLElement' === get_class($data))) {
             // Single identifier, load proxy
             return $objectManager->getReference($metadata->name, $data);
         }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Doc updated   | no
| BC breaks?    | no <!-- don't forget updating UPGRADING.md file -->
| Deprecations? | no <!-- don't forget updating UPGRADING.md file -->
| Tests pass?   | yes
| Fixed tickets | #... <!-- #-prefixed issue number(s), if any -->
| License       | MIT

Completes #1031 for xml data.