### PR TITLE
added support for milliseconds in DateInterval deserialization

### DIFF
--- a/src/Handler/DateHandler.php
+++ b/src/Handler/DateHandler.php
@@ -256,7 +256,13 @@ final class DateHandler implements SubscribingHandlerInterface
     {
         $dateInterval = null;
         try {
+            $f = 0.0;
+            if (preg_match('~\.\d+~', $data, $match)) {
+                $data = str_replace($match[0], '', $data);
+                $f = (float) $match[0];
+            }
             $dateInterval = new \DateInterval($data);
+            $dateInterval->f= $f;
         } catch (\Throwable $e) {
             throw new RuntimeException(sprintf('Invalid dateinterval "%s", expected ISO 8601 format', $data), 0, $e);
         }

--- a/tests/Handler/DateHandlerTest.php
+++ b/tests/Handler/DateHandlerTest.php
@@ -7,6 +7,7 @@ namespace JMS\Serializer\Tests\Handler;
 use JMS\Serializer\Handler\DateHandler;
 use JMS\Serializer\JsonDeserializationVisitor;
 use JMS\Serializer\SerializationContext;
+use JMS\Serializer\Visitor\DeserializationVisitorInterface;
 use JMS\Serializer\Visitor\SerializationVisitorInterface;
 use PHPUnit\Framework\TestCase;
 
@@ -53,6 +54,34 @@ class DateHandlerTest extends TestCase
         $datetime = new \DateTime('2017-06-18 14:30:59', $this->timezone);
         $type = ['name' => 'DateTime', 'params' => $params];
         $this->handler->serializeDateTime($visitor, $datetime, $type, $context);
+    }
+
+    /**
+     * @param string    $dateInterval
+     * @param \DateTime $expected
+     *
+     * @dataProvider getDeserializeDateInterval
+     */
+    public function testDeserializeDateInterval($dateInterval, $expected)
+    {
+        $context = $this->getMockBuilder(SerializationContext::class)->getMock();
+
+        $visitor = $this->getMockBuilder(DeserializationVisitorInterface::class)->getMock();
+        $visitor->method('visitString')->with('2017-06-18');
+
+        $deserialized = $this->handler->deserializeDateIntervalFromJson($visitor, $dateInterval, [], $context);
+        if (isset($deserialized->f)) {
+            $this->assertEquals($expected['f'], $deserialized->f);
+        }
+        $this->assertEquals($expected['s'], $deserialized->s);
+    }
+
+    public function getDeserializeDateInterval()
+    {
+        return [
+            ['P0Y0M0DT3H5M7.520S', ['s' => 7, 'f' => 0.52]],
+            ['P0Y0M0DT3H5M7S', ['s' => 7, 'f' => 0]],
+        ];
     }
 
     public function testTimePartGetsRemoved()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Doc updated   | no
| BC breaks?    | no <!-- don't forget updating UPGRADING.md file -->
| Deprecations? | no <!-- don't forget updating UPGRADING.md file -->
| Tests pass?   | yes
| Fixed tickets | #... <!-- #-prefixed issue number(s), if any -->
| License       | MIT

This PR is basically the same as this: https://github.com/goetas-webservices/xsd2php-runtime/pull/14

> There is a bug in PHP for DateInterval construction and microseconds: https://bugs.php.net/bug.php?id=53831
> 
> This fixes the creation of DateInterval with microseconds like: P0Y0M0DT3H5M7.520S
> Context: https://stackoverflow.com/questions/60435670/dateinterval-doesnt-accept-iso-8601-timeperiod-with-milliseconds

