### PR TITLE
Add support for filterable (de)serialization handlers

### DIFF
--- a/doc/handlers.rst
+++ b/doc/handlers.rst
@@ -78,3 +78,25 @@ Also, this type of handler is registered via the builder object::
         })
     ;
 
+Filterable Subscribing Handlers
+-------------------------------
+
+In case you need to be able to fall back to the default deserialization behavior instead of using your custom
+handler, you can implement the `FilterableSubscribingHandlerInterface` instead of the default
+`SubscribingHandlerInterface`. This interface add a single `shouldBeSkipped` method, which will be called
+before the handler will be used. If it returns `true`, the custom handler will be skipped and the default
+implementation of the serializer will be used instead::
+
+    use JMS\Serializer\Handler\SubscribingHandlerInterface;
+    use JMS\Serializer\GraphNavigator;
+    use JMS\Serializer\JsonSerializationVisitor;
+    use JMS\Serializer\JsonDeserializationVisitor;
+    use JMS\Serializer\Context;
+
+    class MyFilteredHandler implements FilterableSubscribingHandlerInterface
+    {
+        public function shouldBeSkipped($data, array $type, Context $context): bool
+        {
+            // Determine whether the handler should be skipped based on the passed arguments
+        }
+    }

--- a/src/GraphNavigator/DeserializationGraphNavigator.php
+++ b/src/GraphNavigator/DeserializationGraphNavigator.php
@@ -19,6 +19,7 @@ use JMS\Serializer\Exclusion\ExpressionLanguageExclusionStrategy;
 use JMS\Serializer\Expression\ExpressionEvaluatorInterface;
 use JMS\Serializer\GraphNavigator;
 use JMS\Serializer\GraphNavigatorInterface;
+use JMS\Serializer\Handler\FilterableSubscribingHandlerInterface;
 use JMS\Serializer\Handler\HandlerRegistryInterface;
 use JMS\Serializer\Metadata\ClassMetadata;
 use JMS\Serializer\NullAwareVisitorInterface;
@@ -156,10 +157,14 @@ final class DeserializationGraphNavigator extends GraphNavigator implements Grap
                 // before loading metadata because the type name might not be a class, but
                 // could also simply be an artifical type.
                 if (null !== $handler = $this->handlerRegistry->getHandler(GraphNavigatorInterface::DIRECTION_DESERIALIZATION, $type['name'], $this->format)) {
-                    $rs = \call_user_func($handler, $this->visitor, $data, $type, $this->context);
-                    $this->context->decreaseDepth();
+                    // Test whether this handler must be skipped based on the context
+                    $handlerClass = is_array($handler) ? $handler[0] : $handler;
+                    if (!($handlerClass instanceof FilterableSubscribingHandlerInterface) || !$handlerClass->shouldBeSkipped($data, $type, $this->context)) {
+                        $rs = \call_user_func($handler, $this->visitor, $data, $type, $this->context);
+                        $this->context->decreaseDepth();
 
-                    return $rs;
+                        return $rs;
+                    }
                 }
 
                 /** @var ClassMetadata $metadata */

--- a/src/Handler/FilterableSubscribingHandlerInterface.php
+++ b/src/Handler/FilterableSubscribingHandlerInterface.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace JMS\Serializer\Handler;
+
+use JMS\Serializer\Context;
+
+/**
+ * Implement this interface if you need to be able to filter your custom
+ * handler based on the current (de)serialization context.
+ *
+ * @see SubscribingHandlerInterface
+ */
+interface FilterableSubscribingHandlerInterface extends SubscribingHandlerInterface
+{
+    /**
+     * @param mixed $data      The data which needs to be (de)serialized
+     * @param array $type      The type that needs to be (de)serialized
+     * @param Context $context The (de)serialization context
+     *
+     * @return bool If true, skip this handler and use the default implementation
+     */
+    public function shouldBeSkipped($data, array $type, Context $context): bool;
+}

--- a/src/Handler/FilterableSubscribingHandlerInterface.php
+++ b/src/Handler/FilterableSubscribingHandlerInterface.php
@@ -15,8 +15,8 @@ use JMS\Serializer\Context;
 interface FilterableSubscribingHandlerInterface extends SubscribingHandlerInterface
 {
     /**
-     * @param mixed $data      The data which needs to be (de)serialized
-     * @param array $type      The type that needs to be (de)serialized
+     * @param mixed $data    The data which needs to be (de)serialized
+     * @param array $type    The type that needs to be (de)serialized
      * @param Context $context The (de)serialization context
      *
      * @return bool If true, skip this handler and use the default implementation

--- a/tests/Serializer/GraphNavigatorTest.php
+++ b/tests/Serializer/GraphNavigatorTest.php
@@ -8,13 +8,16 @@ use Doctrine\Common\Annotations\AnnotationReader;
 use JMS\Serializer\Accessor\DefaultAccessorStrategy;
 use JMS\Serializer\Construction\ObjectConstructorInterface;
 use JMS\Serializer\Construction\UnserializeObjectConstructor;
+use JMS\Serializer\Context;
 use JMS\Serializer\DeserializationContext;
 use JMS\Serializer\EventDispatcher\EventDispatcher;
+use JMS\Serializer\Exception\NotAcceptableException;
 use JMS\Serializer\Exception\RuntimeException;
 use JMS\Serializer\Exclusion\ExclusionStrategyInterface;
 use JMS\Serializer\GraphNavigator\DeserializationGraphNavigator;
 use JMS\Serializer\GraphNavigator\SerializationGraphNavigator;
 use JMS\Serializer\GraphNavigatorInterface;
+use JMS\Serializer\Handler\FilterableSubscribingHandlerInterface;
 use JMS\Serializer\Handler\HandlerRegistry;
 use JMS\Serializer\Handler\SubscribingHandlerInterface;
 use JMS\Serializer\Metadata\Driver\AnnotationDriver;
@@ -22,6 +25,7 @@ use JMS\Serializer\Naming\IdenticalPropertyNamingStrategy;
 use JMS\Serializer\SerializationContext;
 use JMS\Serializer\Visitor\DeserializationVisitorInterface;
 use JMS\Serializer\Visitor\SerializationVisitorInterface;
+use JMS\Serializer\VisitorInterface;
 use Metadata\MetadataFactory;
 use PHPUnit\Framework\TestCase;
 
@@ -157,6 +161,54 @@ class GraphNavigatorTest extends TestCase
         $navigator->accept($object, ['name' => $typeName, 'params' => []]);
     }
 
+    public function testHandlerIsExecutedOnSerialization()
+    {
+        $object = new SerializableClass();
+        $this->handlerRegistry->registerSubscribingHandler(new TestSubscribingHandler());
+
+        $this->context->method('getFormat')->willReturn(TestSubscribingHandler::FORMAT);
+
+        $navigator = new SerializationGraphNavigator($this->metadataFactory, $this->handlerRegistry, $this->accessor, $this->dispatcher);
+        $navigator->initialize($this->serializationVisitor, $this->context);
+        $this->context->initialize(TestSubscribingHandler::FORMAT, $this->serializationVisitor, $navigator, $this->metadataFactory);
+
+        $rt = $navigator->accept($object, null);
+        $this->assertEquals('foobar', $rt);
+    }
+
+    /**
+     * @doesNotPerformAssertions
+     */
+    public function testFilterableHandlerIsSkippedOnSerialization()
+    {
+        $object = new SerializableClass();
+        $this->handlerRegistry->registerSubscribingHandler(new TestFilterableSubscribingHandler());
+
+        $this->context->method('getFormat')->willReturn(TestFilterableSubscribingHandler::FORMAT);
+
+        $navigator = new SerializationGraphNavigator($this->metadataFactory, $this->handlerRegistry, $this->accessor, $this->dispatcher);
+        $navigator->initialize($this->serializationVisitor, $this->context);
+        $this->context->initialize(TestFilterableSubscribingHandler::FORMAT, $this->serializationVisitor, $navigator, $this->metadataFactory);
+
+        $navigator->accept($object, null);
+    }
+
+    public function testFilterableHandlerIsNotSkippedOnSerialization()
+    {
+        $object = new SerializableClass();
+        $this->handlerRegistry->registerSubscribingHandler(new TestFilterableSubscribingHandler(false));
+
+        $this->context->method('getFormat')->willReturn(TestFilterableSubscribingHandler::FORMAT);
+
+        $navigator = new SerializationGraphNavigator($this->metadataFactory, $this->handlerRegistry, $this->accessor, $this->dispatcher);
+        $navigator->initialize($this->serializationVisitor, $this->context);
+        $this->context->initialize(TestFilterableSubscribingHandler::FORMAT, $this->serializationVisitor, $navigator, $this->metadataFactory);
+
+        $this->expectException(NotAcceptableException::class);
+        $this->expectExceptionMessage(TestFilterableSubscribingHandler::EX_MSG);
+        $navigator->accept($object, null);
+    }
+
     /**
      * @doesNotPerformAssertions
      */
@@ -213,11 +265,51 @@ class TestSubscribingHandler implements SubscribingHandlerInterface
     {
         return [
             [
-                'type' => 'JsonSerializable',
+                'type' => SerializableClass::class,
                 'format' => self::FORMAT,
                 'direction' => GraphNavigatorInterface::DIRECTION_SERIALIZATION,
                 'method' => 'serialize',
             ],
         ];
+    }
+
+    public function serialize(VisitorInterface $visitor, $userData, array $type, Context $context)
+    {
+        return 'foobar';
+    }
+}
+
+class TestFilterableSubscribingHandler implements FilterableSubscribingHandlerInterface
+{
+    public const FORMAT = 'foo';
+    public const EX_MSG = 'This method should be skipped!';
+
+    private $shouldSkip;
+
+    public function __construct(bool $shouldSkip = true)
+    {
+        $this->shouldSkip = $shouldSkip;
+    }
+
+    public static function getSubscribingMethods()
+    {
+        return [
+            [
+                'type' => SerializableClass::class,
+                'format' => self::FORMAT,
+                'direction' => GraphNavigatorInterface::DIRECTION_SERIALIZATION,
+                'method' => 'serialize',
+            ],
+        ];
+    }
+
+    public function shouldBeSkipped($data, array $type, Context $context): bool
+    {
+        return $this->shouldSkip;
+    }
+
+    public function serialize(VisitorInterface $visitor, $userData, array $type, Context $context)
+    {
+        throw new NotAcceptableException(self::EX_MSG);
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| Doc updated   | yes
| BC breaks?    | no <!-- don't forget updating UPGRADING.md file -->
| Deprecations? | no <!-- don't forget updating UPGRADING.md file -->
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT

I need to be able to choose between my handler and the default serializer implementation depending on the current deserialization depth, but I couldn't find any way to do so. Therefor, I added support for filterable handlers, which contain a `shouldBeSkipped` method which is called when the handler implements the `FilterableSubscribingHandlerInterface` interface. This way, you can fallback to the default implementation if you choose to do so from you own handler.