### PR TITLE
Change return type of SerializerBuilder::build() to Serializer

### DIFF
--- a/src/SerializerBuilder.php
+++ b/src/SerializerBuilder.php
@@ -499,10 +499,7 @@ final class SerializerBuilder
         return $this;
     }
 
-    /**
-     * @return SerializerInterface&ArrayTransformerInterface
-     */
-    public function build()
+    public function build(): Serializer
     {
         $annotationReader = $this->annotationReader;
         if (null === $annotationReader) {

--- a/src/SerializerBuilder.php
+++ b/src/SerializerBuilder.php
@@ -499,7 +499,10 @@ final class SerializerBuilder
         return $this;
     }
 
-    public function build(): SerializerInterface
+    /**
+     * @return SerializerInterface&ArrayTransformerInterface
+     */
+    public function build()
     {
         $annotationReader = $this->annotationReader;
         if (null === $annotationReader) {


### PR DESCRIPTION
Using the `SerializerBuilder` build will return an instance of `Serializer` which implements `SerializerInterface` and `ArrayTransformerInterface`.
So the return type of `SerializerInterface` is wrong in this case.

| Q             | A
| ------------- | ---
| Bug fix?      | sort of
| New feature?  |no
| Doc updated   |no
| BC breaks?    |no
| Deprecations? | no
| Tests pass?   | yes
| License       | MIT

