### PR TITLE
remove missing deprecated removal on hasData

### DIFF
--- a/src/JsonSerializationVisitor.php
+++ b/src/JsonSerializationVisitor.php
@@ -156,8 +156,6 @@ final class JsonSerializationVisitor extends AbstractVisitor implements Serializ
     }
 
     /**
-     * @deprecated Will be removed in 3.0
-     *
      * Checks if some data key exists.
      */
     public function hasData(string $key): bool


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Doc updated   | no
| BC breaks?    | no
| Deprecations? | yes
| Tests pass?   | yes
| Fixed tickets | #... <!-- #-prefixed issue number(s), if any -->
| License       | MIT

This deprecated code was not removed as planned. If it still deprecated it has to be updated to release 4.0.
Curently there is no alternative for hasData, so I choose to remove the deprecated annotation.
