### PR TITLE
DoctrineObjectConstructor Using array_key_exists() on objects is deprecated in php7.4

### DIFF
--- a/src/Construction/DoctrineObjectConstructor.php
+++ b/src/Construction/DoctrineObjectConstructor.php
@@ -101,7 +101,9 @@ final class DoctrineObjectConstructor implements ObjectConstructorInterface
                 return $this->fallbackConstructor->construct($visitor, $metadata, $data, $type, $context);
             }
 
-            if (!array_key_exists($propertyMetadata->serializedName, $data)) {
+            if (is_array($data) && !array_key_exists($propertyMetadata->serializedName, $data)) {
+                return $this->fallbackConstructor->construct($visitor, $metadata, $data, $type, $context);
+            } elseif (is_object($data) && !property_exists($data, $propertyMetadata->serializedName)) {
                 return $this->fallbackConstructor->construct($visitor, $metadata, $data, $type, $context);
             }
 


### PR DESCRIPTION
Occurs with xml data.

Deprecated: array_key_exists(): Using array_key_exists() on objects is deprecated. Use isset() or property_exists() instead in /builds/inexpost/www-api/vendor/jms/serializer/src/Construction/DoctrineObjectConstructor.php on line 103

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Doc updated   | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #... <!-- #-prefixed issue number(s), if any -->
| License       | MIT

