### PR TITLE
Allow interfaces for typed properties

### DIFF
--- a/src/Metadata/Driver/TypedPropertiesDriver.php
+++ b/src/Metadata/Driver/TypedPropertiesDriver.php
@@ -98,7 +98,8 @@ class TypedPropertiesDriver implements DriverInterface
             return true;
         }
 
-        return class_exists($propertyReflection->getType()->getName());
+        return class_exists($propertyReflection->getType()->getName())
+            || interface_exists($propertyReflection->getType()->getName());
     }
 
     private function getReflection(PropertyMetadata $propertyMetadata): ReflectionProperty

--- a/tests/Fixtures/TypedProperties/Car.php
+++ b/tests/Fixtures/TypedProperties/Car.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace JMS\Serializer\Tests\Fixtures\TypedProperties;
+
+class Car implements Vehicle
+{
+}

--- a/tests/Fixtures/TypedProperties/User.php
+++ b/tests/Fixtures/TypedProperties/User.php
@@ -10,6 +10,7 @@ class User
 {
     public int $id;
     public Role $role;
+    public Vehicle $vehicle;
     public \DateTime $created;
 
     /**

--- a/tests/Fixtures/TypedProperties/Vehicle.php
+++ b/tests/Fixtures/TypedProperties/Vehicle.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace JMS\Serializer\Tests\Fixtures\TypedProperties;
+
+use JMS\Serializer\Annotation as Serializer;
+
+/**
+ * @Serializer\Discriminator(field = "type", map = {
+ *    "car": "JMS\Serializer\Tests\Fixtures\TypedProperties\Car",
+ * })
+ */
+interface Vehicle
+{
+}

--- a/tests/Metadata/Driver/TypedPropertiesDriverTest.php
+++ b/tests/Metadata/Driver/TypedPropertiesDriverTest.php
@@ -32,6 +32,7 @@ class TypedPropertiesDriverTest extends TestCase
         $expectedPropertyTypes = [
             'id' => 'int',
             'role' => 'JMS\Serializer\Tests\Fixtures\TypedProperties\Role',
+            'vehicle' => 'JMS\Serializer\Tests\Fixtures\TypedProperties\Vehicle',
             'created' => 'DateTime',
             'tags' => 'iterable',
         ];

--- a/tests/Serializer/BaseSerializationTest.php
+++ b/tests/Serializer/BaseSerializationTest.php
@@ -1356,6 +1356,10 @@ abstract class BaseSerializationTest extends TestCase
             $this->markTestSkipped(sprintf('%s requires PHP 7.4', __METHOD__));
         }
 
+        $builder = SerializerBuilder::create($this->handlerRegistry, $this->dispatcher);
+        $builder->includeInterfaceMetadata(true);
+        $this->serializer = $builder->build();
+
         $user = new TypedProperties\User();
         $user->id = 1;
         $user->created = new \DateTime('2010-10-01 00:00:00');
@@ -1364,6 +1368,7 @@ abstract class BaseSerializationTest extends TestCase
         $role = new TypedProperties\Role();
         $role->id = 5;
         $user->role = $role;
+        $user->vehicle = new TypedProperties\Car();
 
         $result = $this->serialize($user);
 

--- a/tests/Serializer/JsonSerializationTest.php
+++ b/tests/Serializer/JsonSerializationTest.php
@@ -129,7 +129,7 @@ class JsonSerializationTest extends BaseSerializationTest
             $outputs['user_discriminator_array'] = '[{"entityName":"User"},{"entityName":"ExtendedUser"}]';
             $outputs['user_discriminator'] = '{"entityName":"User"}';
             $outputs['user_discriminator_extended'] = '{"entityName":"ExtendedUser"}';
-            $outputs['typed_props'] = '{"id":1,"role":{"id":5},"created":"2010-10-01T00:00:00+00:00","updated":"2011-10-01T00:00:00+00:00","tags":["a","b"]}';
+            $outputs['typed_props'] = '{"id":1,"role":{"id":5},"vehicle":{"type":"car"},"created":"2010-10-01T00:00:00+00:00","updated":"2011-10-01T00:00:00+00:00","tags":["a","b"]}';
         }
 
         if (!isset($outputs[$key])) {

--- a/tests/Serializer/xml/typed_props.xml
+++ b/tests/Serializer/xml/typed_props.xml
@@ -4,6 +4,9 @@
   <role>
     <id>5</id>
   </role>
+  <vehicle>
+    <type><![CDATA[car]]></type>
+  </vehicle>
   <created><![CDATA[2010-10-01T00:00:00+00:00]]></created>
   <updated><![CDATA[2011-10-01T00:00:00+00:00]]></updated>
   <tags>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| Doc updated   | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #...
| License       | MIT

Currently the `TypedPropertiesDriver` only reads classes (abstract included) and some php defined types. For interfaces, additional metadata in the form of annotations or files must be specified. This pull request makes this obsolete.