### PR TITLE
Allow interfaces for DocBlock

### DIFF
--- a/src/Metadata/Driver/DocBlockTypeResolver.php
+++ b/src/Metadata/Driver/DocBlockTypeResolver.php
@@ -63,12 +63,12 @@ class DocBlockTypeResolver
 
     private function expandClassNameUsingUseStatements(string $typeHint, \ReflectionClass $declaringClass, \ReflectionProperty $reflectionProperty): string
     {
-        if (class_exists($typeHint)) {
+        if ($this->isClassOrInterface($typeHint)) {
             return $typeHint;
         }
 
         $expandedClassName = $declaringClass->getNamespaceName() . '\\' . $typeHint;
-        if (class_exists($expandedClassName)) {
+        if ($this->isClassOrInterface($expandedClassName)) {
             return $expandedClassName;
         }
 
@@ -157,5 +157,10 @@ class DocBlockTypeResolver
     private function isArrayWithoutAnyType(string $typeHint): bool
     {
         return 'array' === $typeHint;
+    }
+
+    private function isClassOrInterface(string $typeHint): bool
+    {
+        return class_exists($typeHint) || interface_exists($typeHint);
     }
 }

--- a/tests/Fixtures/DocBlockType/Collection/CollectionOfInterfacesFromDifferentNamespace.php
+++ b/tests/Fixtures/DocBlockType/Collection/CollectionOfInterfacesFromDifferentNamespace.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace JMS\Serializer\Tests\Fixtures\DocBlockType\Collection;
+
+use JMS\Serializer\Tests\Fixtures\DocBlockType\Collection\Details\ProductColor;
+
+class CollectionOfInterfacesFromDifferentNamespace
+{
+    /**
+     * @var ProductColor[]
+     */
+    public array $productColors;
+}

--- a/tests/Fixtures/DocBlockType/Collection/CollectionOfInterfacesFromGlobalNamespace.php
+++ b/tests/Fixtures/DocBlockType/Collection/CollectionOfInterfacesFromGlobalNamespace.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace JMS\Serializer\Tests\Fixtures\DocBlockType\Collection;
+
+class CollectionOfInterfacesFromGlobalNamespace
+{
+    /**
+     * phpcs:ignore SlevomatCodingStandard.Namespaces.ReferenceUsedNamesOnly.ReferenceViaFullyQualifiedName
+     * @var \JMS\Serializer\Tests\Fixtures\DocBlockType\Collection\Details\ProductColor[]
+     */
+    public array $productColors;
+}

--- a/tests/Fixtures/DocBlockType/Collection/CollectionOfInterfacesFromSameNamespace.php
+++ b/tests/Fixtures/DocBlockType/Collection/CollectionOfInterfacesFromSameNamespace.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace JMS\Serializer\Tests\Fixtures\DocBlockType\Collection;
+
+class CollectionOfInterfacesFromSameNamespace
+{
+    /**
+     * @var Vehicle[]
+     */
+    public array $vehicles;
+}

--- a/tests/Fixtures/DocBlockType/Collection/CollectionOfInterfacesWithFullNamespacePath.php
+++ b/tests/Fixtures/DocBlockType/Collection/CollectionOfInterfacesWithFullNamespacePath.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace JMS\Serializer\Tests\Fixtures\DocBlockType\Collection;
+
+class CollectionOfInterfacesWithFullNamespacePath
+{
+    /**
+     * @var JMS\Serializer\Tests\Fixtures\DocBlockType\Collection\Details\ProductColor[]
+     */
+    public array $productColors;
+}

--- a/tests/Fixtures/DocBlockType/Collection/Details/ProductColor.php
+++ b/tests/Fixtures/DocBlockType/Collection/Details/ProductColor.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace JMS\Serializer\Tests\Fixtures\DocBlockType\Collection\Details;
+
+interface ProductColor
+{
+}

--- a/tests/Fixtures/DocBlockType/Collection/Vehicle.php
+++ b/tests/Fixtures/DocBlockType/Collection/Vehicle.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace JMS\Serializer\Tests\Fixtures\DocBlockType\Collection;
+
+interface Vehicle
+{
+}

--- a/tests/Metadata/Driver/DocBlockDriverTest.php
+++ b/tests/Metadata/Driver/DocBlockDriverTest.php
@@ -18,14 +18,20 @@ use JMS\Serializer\Tests\Fixtures\DocBlockType\Collection\CollectionOfClassesFro
 use JMS\Serializer\Tests\Fixtures\DocBlockType\Collection\CollectionOfClassesFromTraitInsideTrait;
 use JMS\Serializer\Tests\Fixtures\DocBlockType\Collection\CollectionOfClassesWithFullNamespacePath;
 use JMS\Serializer\Tests\Fixtures\DocBlockType\Collection\CollectionOfClassesWithNull;
+use JMS\Serializer\Tests\Fixtures\DocBlockType\Collection\CollectionOfInterfacesFromDifferentNamespace;
+use JMS\Serializer\Tests\Fixtures\DocBlockType\Collection\CollectionOfInterfacesFromGlobalNamespace;
+use JMS\Serializer\Tests\Fixtures\DocBlockType\Collection\CollectionOfInterfacesFromSameNamespace;
+use JMS\Serializer\Tests\Fixtures\DocBlockType\Collection\CollectionOfInterfacesWithFullNamespacePath;
 use JMS\Serializer\Tests\Fixtures\DocBlockType\Collection\CollectionOfNotExistingClasses;
 use JMS\Serializer\Tests\Fixtures\DocBlockType\Collection\CollectionOfScalars;
 use JMS\Serializer\Tests\Fixtures\DocBlockType\Collection\CollectionOfUnionClasses;
 use JMS\Serializer\Tests\Fixtures\DocBlockType\Collection\CollectionTypedAsGenericClass;
+use JMS\Serializer\Tests\Fixtures\DocBlockType\Collection\Details\ProductColor;
 use JMS\Serializer\Tests\Fixtures\DocBlockType\Collection\Details\ProductDescription;
 use JMS\Serializer\Tests\Fixtures\DocBlockType\Collection\Details\ProductName;
 use JMS\Serializer\Tests\Fixtures\DocBlockType\Collection\MapTypedAsGenericClass;
 use JMS\Serializer\Tests\Fixtures\DocBlockType\Collection\Product;
+use JMS\Serializer\Tests\Fixtures\DocBlockType\Collection\Vehicle;
 use JMS\Serializer\Tests\Fixtures\DocBlockType\SingleClassFromDifferentNamespaceTypeHint;
 use JMS\Serializer\Tests\Fixtures\DocBlockType\SingleClassFromGlobalNamespaceTypeHint;
 use Metadata\ClassMetadata;
@@ -244,6 +250,62 @@ class DocBlockDriverTest extends TestCase
         self::assertEquals(
             ['name' => 'array', 'params' => [['name' => ProductDescription::class, 'params' => []]]],
             $m->propertyMetadata['productDescriptions']->type
+        );
+    }
+
+    public function testInferDocBlockCollectionOfInterfacesFromDifferentNamespace()
+    {
+        if (PHP_VERSION_ID < 70400) {
+            $this->markTestSkipped(sprintf('%s requires PHP 7.4', TypedPropertiesDriver::class));
+        }
+
+        $m = $this->resolve(CollectionOfInterfacesFromDifferentNamespace::class);
+
+        self::assertEquals(
+            ['name' => 'array', 'params' => [['name' => ProductColor::class, 'params' => []]]],
+            $m->propertyMetadata['productColors']->type
+        );
+    }
+
+    public function testInferDocBlockCollectionOfInterfacesFromGlobalNamespace()
+    {
+        if (PHP_VERSION_ID < 70400) {
+            $this->markTestSkipped(sprintf('%s requires PHP 7.4', TypedPropertiesDriver::class));
+        }
+
+        $m = $this->resolve(CollectionOfInterfacesFromGlobalNamespace::class);
+
+        self::assertEquals(
+            ['name' => 'array', 'params' => [['name' => ProductColor::class, 'params' => []]]],
+            $m->propertyMetadata['productColors']->type
+        );
+    }
+
+    public function testInferDocBlockCollectionOfInterfacesFromSameNamespace()
+    {
+        if (PHP_VERSION_ID < 70400) {
+            $this->markTestSkipped(sprintf('%s requires PHP 7.4', TypedPropertiesDriver::class));
+        }
+
+        $m = $this->resolve(CollectionOfInterfacesFromSameNamespace::class);
+
+        self::assertEquals(
+            ['name' => 'array', 'params' => [['name' => Vehicle::class, 'params' => []]]],
+            $m->propertyMetadata['vehicles']->type
+        );
+    }
+
+    public function testInferDocBlockCollectionOfInterfacesWithFullNamespacePath()
+    {
+        if (PHP_VERSION_ID < 70400) {
+            $this->markTestSkipped(sprintf('%s requires PHP 7.4', TypedPropertiesDriver::class));
+        }
+
+        $m = $this->resolve(CollectionOfInterfacesWithFullNamespacePath::class);
+
+        self::assertEquals(
+            ['name' => 'array', 'params' => [['name' => ProductColor::class, 'params' => []]]],
+            $m->propertyMetadata['productColors']->type
         );
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| Doc updated   | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #...
| License       | MIT

Currently the `DocBlockDriver` only reads classes (abstract included) and some php defined types. For interfaces, additional metadata in the form of annotations or files must be specified. This pull request makes this obsolete.