### PR TITLE
Use phpstan/phpdoc-parser to retrieve additional type information from PhpDoc

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -35,6 +35,7 @@
         "doctrine/phpcr-odm": "^1.3|^2.0",
         "jackalope/jackalope-doctrine-dbal": "^1.1.5",
         "ocramius/proxy-manager": "^1.0|^2.0",
+        "phpstan/phpdoc-parser": "^0.4",
         "phpunit/phpunit": "^8.0||^9.0",
         "psr/container": "^1.0",
         "symfony/dependency-injection": "^3.0|^4.0|^5.0",

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,8 @@
         "doctrine/annotations": "^1.0",
         "doctrine/instantiator": "^1.0.3",
         "doctrine/lexer": "^1.1",
-        "jms/metadata": "^2.0"
+        "jms/metadata": "^2.0",
+        "phpstan/phpdoc-parser": "^0.4"
     },
     "suggest": {
         "doctrine/cache": "Required if you like to use cache functionality.",
@@ -35,7 +36,6 @@
         "doctrine/phpcr-odm": "^1.3|^2.0",
         "jackalope/jackalope-doctrine-dbal": "^1.1.5",
         "ocramius/proxy-manager": "^1.0|^2.0",
-        "phpstan/phpdoc-parser": "^0.4",
         "phpunit/phpunit": "^8.0||^9.0",
         "psr/container": "^1.0",
         "symfony/dependency-injection": "^3.0|^4.0|^5.0",

--- a/src/Metadata/Driver/DocBlockTypeResolver.php
+++ b/src/Metadata/Driver/DocBlockTypeResolver.php
@@ -48,6 +48,7 @@ class DocBlockTypeResolver
      * information and will return null if no helpful type information could be retrieved.
      *
      * @param \ReflectionProperty $reflectionProperty
+     *
      * @return string|null
      */
     public function getPropertyDocblockTypeHint(\ReflectionProperty $reflectionProperty): ?string
@@ -66,20 +67,20 @@ class DocBlockTypeResolver
         $typesWithoutNull = $this->filterNullFromTypes($types);
 
         // The PhpDoc does not contain additional type information.
-        if (count($typesWithoutNull) === 0) {
+        if (0 === count($typesWithoutNull)) {
             return null;
         }
 
         // The PhpDoc contains multiple non-null types which produces ambiguity when deserializing.
         if (count($typesWithoutNull) > 1) {
-            $typeHint = implode('|', array_map(function (TypeNode $type) {
+            $typeHint = implode('|', array_map(static function (TypeNode $type) {
                 return (string) $type;
             }, $types));
+
             throw new \InvalidArgumentException(sprintf("Can't use union type %s for collection in %s:%s", $typeHint, $reflectionProperty->getDeclaringClass()->getName(), $reflectionProperty->getName()));
         }
 
         // Only one type is left, so we only need to differentiate between arrays, generics and other types.
-        /** @var TypeNode $type */
         $type = $typesWithoutNull[0];
 
         // Simple array without concrete type: array
@@ -115,11 +116,12 @@ class DocBlockTypeResolver
      * Returns a flat list of types of the given var tags. Union types are flattened as well.
      *
      * @param VarTagValueNode[] $varTagValues
+     *
      * @return TypeNode[]
      */
     private function flattenVarTagValueTypes(array $varTagValues): array
     {
-        return array_merge(...array_map(function (VarTagValueNode $node) {
+        return array_merge(...array_map(static function (VarTagValueNode $node) {
             if ($node->type instanceof UnionTypeNode) {
                 return $node->type->types;
             }
@@ -132,6 +134,7 @@ class DocBlockTypeResolver
      * Filters the null type from the given types array. If no null type is found, the array is returned unchanged.
      *
      * @param TypeNode[] $types
+     *
      * @return TypeNode[]
      */
     private function filterNullFromTypes(array $types): array
@@ -145,7 +148,8 @@ class DocBlockTypeResolver
      * Determines if the given type is a null type.
      *
      * @param TypeNode $typeNode
-     * @return boolean
+     *
+     * @return bool
      */
     private function isNullType(TypeNode $typeNode): bool
     {
@@ -157,7 +161,8 @@ class DocBlockTypeResolver
      *
      * @param TypeNode $typeNode
      * @param string $simpleType
-     * @return boolean
+     *
+     * @return bool
      */
     private function isSimpleType(TypeNode $typeNode, string $simpleType): bool
     {
@@ -170,7 +175,9 @@ class DocBlockTypeResolver
      *
      * @param TypeNode $typeNode
      * @param \ReflectionProperty $reflectionProperty
+     *
      * @return string
+     *
      * @throws \InvalidArgumentException
      */
     private function resolveTypeFromTypeNode(TypeNode $typeNode, \ReflectionProperty $reflectionProperty): string

--- a/src/Metadata/Driver/DocBlockTypeResolver.php
+++ b/src/Metadata/Driver/DocBlockTypeResolver.php
@@ -4,61 +4,182 @@ declare(strict_types=1);
 
 namespace JMS\Serializer\Metadata\Driver;
 
+use PHPStan\PhpDocParser\Ast\PhpDoc\VarTagValueNode;
+use PHPStan\PhpDocParser\Ast\Type\ArrayTypeNode;
+use PHPStan\PhpDocParser\Ast\Type\GenericTypeNode;
+use PHPStan\PhpDocParser\Ast\Type\IdentifierTypeNode;
+use PHPStan\PhpDocParser\Ast\Type\TypeNode;
+use PHPStan\PhpDocParser\Ast\Type\UnionTypeNode;
+use PHPStan\PhpDocParser\Lexer\Lexer;
+use PHPStan\PhpDocParser\Parser\ConstExprParser;
+use PHPStan\PhpDocParser\Parser\PhpDocParser;
+use PHPStan\PhpDocParser\Parser\TokenIterator;
+use PHPStan\PhpDocParser\Parser\TypeParser;
+
 class DocBlockTypeResolver
 {
-    /** resolve type hints from property */
-    private const CLASS_PROPERTY_TYPE_HINT_REGEX = '#@var[\s]*([^\n\$]*)#';
     /** resolve single use statements */
     private const SINGLE_USE_STATEMENTS_REGEX = '/^[^\S\r\n]*use[\s]*([^;\n]*)[\s]*;$/m';
     /** resolve group use statements */
     private const GROUP_USE_STATEMENTS_REGEX = '/^[^\S\r\n]*use[[\s]*([^;\n]*)[\s]*{([a-zA-Z0-9\s\n\r,]*)};$/m';
     private const GLOBAL_NAMESPACE_PREFIX = '\\';
 
+    /**
+     * @var PhpDocParser
+     */
+    protected $phpDocParser;
+
+    /**
+     * @var Lexer
+     */
+    protected $lexer;
+
+    public function __construct()
+    {
+        $constExprParser = new ConstExprParser();
+        $typeParser = new TypeParser($constExprParser);
+
+        $this->phpDocParser = new PhpDocParser($typeParser, $constExprParser);
+        $this->lexer = new Lexer();
+    }
+
+    /**
+     * Attempts to retrieve additional type information from a PhpDoc block. Throws in case of ambiguous type
+     * information and will return null if no helpful type information could be retrieved.
+     *
+     * @param \ReflectionProperty $reflectionProperty
+     * @return string|null
+     */
     public function getPropertyDocblockTypeHint(\ReflectionProperty $reflectionProperty): ?string
     {
         if (!$reflectionProperty->getDocComment()) {
             return null;
         }
 
-        preg_match_all(self::CLASS_PROPERTY_TYPE_HINT_REGEX, $reflectionProperty->getDocComment(), $matchedDocBlockParameterTypes);
-        if (!isset($matchedDocBlockParameterTypes[1][0])) {
+        // First we tokenize the PhpDoc comment and parse the tokens into a PhpDocNode.
+        $tokens = $this->lexer->tokenize($reflectionProperty->getDocComment());
+        $phpDocNode = $this->phpDocParser->parse(new TokenIterator($tokens));
+
+        // Then we retrieve a flattened list of annotated types excluding null.
+        $varTagValues = $phpDocNode->getVarTagValues();
+        $types = $this->flattenVarTagValueTypes($varTagValues);
+        $typesWithoutNull = $this->filterNullFromTypes($types);
+
+        // The PhpDoc does not contain additional type information.
+        if (count($typesWithoutNull) === 0) {
             return null;
         }
 
-        $typeHint = trim($matchedDocBlockParameterTypes[1][0]);
-        if ($this->isArrayWithoutAnyType($typeHint)) {
-            return null;
-        }
-
-        $unionTypeHint = [];
-        foreach (explode('|', $typeHint) as $singleTypeHint) {
-            if ('null' !== $singleTypeHint) {
-                $unionTypeHint[] = $singleTypeHint;
-            }
-        }
-
-        $typeHint = implode('|', $unionTypeHint);
-        if (count($unionTypeHint) > 1) {
+        // The PhpDoc contains multiple non-null types which produces ambiguity when deserializing.
+        if (count($typesWithoutNull) > 1) {
+            $typeHint = implode('|', array_map(function (TypeNode $type) {
+                return (string) $type;
+            }, $types));
             throw new \InvalidArgumentException(sprintf("Can't use union type %s for collection in %s:%s", $typeHint, $reflectionProperty->getDeclaringClass()->getName(), $reflectionProperty->getName()));
         }
 
-        if (false !== strpos($typeHint, 'array<')) {
-            $resolvedTypes = [];
-            preg_match_all('#array<(.*)>#', $typeHint, $genericTypesToResolve);
-            $genericTypesToResolve = $genericTypesToResolve[1][0];
-            foreach (explode(',', $genericTypesToResolve) as $genericTypeToResolve) {
-                $resolvedTypes[] = $this->resolveType(trim($genericTypeToResolve), $reflectionProperty);
-            }
+        // Only one type is left, so we only need to differentiate between arrays, generics and other types.
+        /** @var TypeNode $type */
+        $type = $typesWithoutNull[0];
 
-            return 'array<' . implode(',', $resolvedTypes) . '>';
-        } elseif (false !== strpos($typeHint, '[]')) {
-            $typeHint = rtrim($typeHint, '[]');
-            $typeHint = $this->resolveType($typeHint, $reflectionProperty);
-
-            return 'array<' . $typeHint . '>';
+        // Simple array without concrete type: array
+        if ($this->isSimpleType($type, 'array')) {
+            return null;
         }
 
-        return $this->resolveType($typeHint, $reflectionProperty);
+        // Normal array syntax: Product[] | \Foo\Bar\Product[]
+        if ($type instanceof ArrayTypeNode) {
+            $resolvedType = $this->resolveTypeFromTypeNode($type->type, $reflectionProperty);
+
+            return 'array<' . $resolvedType . '>';
+        }
+
+        // Generic array syntax: array<Product> | array<\Foo\Bar\Product> | array<int,Product>
+        if ($type instanceof GenericTypeNode) {
+            if (!$this->isSimpleType($type->type, 'array')) {
+                throw new \InvalidArgumentException(sprintf("Can't use non-array generic type %s for collection in %s:%s", (string) $type->type, $reflectionProperty->getDeclaringClass()->getName(), $reflectionProperty->getName()));
+            }
+
+            $resolvedTypes = array_map(function (TypeNode $node) use ($reflectionProperty) {
+                return $this->resolveTypeFromTypeNode($node, $reflectionProperty);
+            }, $type->genericTypes);
+
+            return 'array<' . implode(',', $resolvedTypes) . '>';
+        }
+
+        // Primitives and class names: Collection | \Foo\Bar\Product | string
+        return $this->resolveTypeFromTypeNode($type, $reflectionProperty);
+    }
+
+    /**
+     * Returns a flat list of types of the given var tags. Union types are flattened as well.
+     *
+     * @param VarTagValueNode[] $varTagValues
+     * @return TypeNode[]
+     */
+    private function flattenVarTagValueTypes(array $varTagValues): array
+    {
+        return array_merge(...array_map(function (VarTagValueNode $node) {
+            if ($node->type instanceof UnionTypeNode) {
+                return $node->type->types;
+            }
+
+            return [$node->type];
+        }, $varTagValues));
+    }
+
+    /**
+     * Filters the null type from the given types array. If no null type is found, the array is returned unchanged.
+     *
+     * @param TypeNode[] $types
+     * @return TypeNode[]
+     */
+    private function filterNullFromTypes(array $types): array
+    {
+        return array_filter(array_map(function (TypeNode $node) {
+            return $this->isNullType($node) ? null : $node;
+        }, $types));
+    }
+
+    /**
+     * Determines if the given type is a null type.
+     *
+     * @param TypeNode $typeNode
+     * @return boolean
+     */
+    private function isNullType(TypeNode $typeNode): bool
+    {
+        return $this->isSimpleType($typeNode, 'null');
+    }
+
+    /**
+     * Determines if the given node represents a simple type.
+     *
+     * @param TypeNode $typeNode
+     * @param string $simpleType
+     * @return boolean
+     */
+    private function isSimpleType(TypeNode $typeNode, string $simpleType): bool
+    {
+        return $typeNode instanceof IdentifierTypeNode && $typeNode->name === $simpleType;
+    }
+
+    /**
+     * Attempts to resolve the fully qualified type from the given node. If the node is not suitable for type
+     * retrieval, an exception is thrown.
+     *
+     * @param TypeNode $typeNode
+     * @param \ReflectionProperty $reflectionProperty
+     * @return string
+     * @throws \InvalidArgumentException
+     */
+    private function resolveTypeFromTypeNode(TypeNode $typeNode, \ReflectionProperty $reflectionProperty): string
+    {
+        if (!($typeNode instanceof IdentifierTypeNode)) {
+            throw new \InvalidArgumentException(sprintf("Can't use unsupported type %s for collection in %s:%s", (string) $typeNode, $reflectionProperty->getDeclaringClass()->getName(), $reflectionProperty->getName()));
+        }
+
+        return $this->resolveType($typeNode->name, $reflectionProperty);
     }
 
     private function expandClassNameUsingUseStatements(string $typeHint, \ReflectionClass $declaringClass, \ReflectionProperty $reflectionProperty): string
@@ -152,11 +273,6 @@ class DocBlockTypeResolver
         }
 
         return ltrim($typeHint, '\\');
-    }
-
-    private function isArrayWithoutAnyType(string $typeHint): bool
-    {
-        return 'array' === $typeHint;
     }
 
     private function isClassOrInterface(string $typeHint): bool

--- a/tests/Fixtures/DocBlockType/Collection/CollectionOfClassesWithNullSingleLinePhpDoc.php
+++ b/tests/Fixtures/DocBlockType/Collection/CollectionOfClassesWithNullSingleLinePhpDoc.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace JMS\Serializer\Tests\Fixtures\DocBlockType\Collection;
+
+class CollectionOfClassesWithNullSingleLinePhpDoc
+{
+    /** @var Product[]|null */
+    public ?array $productIds;
+}

--- a/tests/Metadata/Driver/DocBlockDriverTest.php
+++ b/tests/Metadata/Driver/DocBlockDriverTest.php
@@ -22,6 +22,7 @@ use JMS\Serializer\Tests\Fixtures\DocBlockType\Collection\CollectionOfInterfaces
 use JMS\Serializer\Tests\Fixtures\DocBlockType\Collection\CollectionOfInterfacesFromGlobalNamespace;
 use JMS\Serializer\Tests\Fixtures\DocBlockType\Collection\CollectionOfInterfacesFromSameNamespace;
 use JMS\Serializer\Tests\Fixtures\DocBlockType\Collection\CollectionOfInterfacesWithFullNamespacePath;
+use JMS\Serializer\Tests\Fixtures\DocBlockType\Collection\CollectionOfClassesWithNullSingleLinePhpDoc;
 use JMS\Serializer\Tests\Fixtures\DocBlockType\Collection\CollectionOfNotExistingClasses;
 use JMS\Serializer\Tests\Fixtures\DocBlockType\Collection\CollectionOfScalars;
 use JMS\Serializer\Tests\Fixtures\DocBlockType\Collection\CollectionOfUnionClasses;
@@ -132,6 +133,20 @@ class DocBlockDriverTest extends TestCase
         }
 
         $m = $this->resolve(CollectionOfClassesWithNull::class);
+
+        self::assertEquals(
+            ['name' => 'array', 'params' => [['name' => Product::class, 'params' => []]]],
+            $m->propertyMetadata['productIds']->type
+        );
+    }
+
+    public function testInferDocBlockCollectionOfClassesIgnoringNullTypeHintWithSingleLinePhpDoc()
+    {
+        if (PHP_VERSION_ID < 70400) {
+            $this->markTestSkipped(sprintf('%s requires PHP 7.4', TypedPropertiesDriver::class));
+        }
+
+        $m = $this->resolve(CollectionOfClassesWithNullSingleLinePhpDoc::class);
 
         self::assertEquals(
             ['name' => 'array', 'params' => [['name' => Product::class, 'params' => []]]],

--- a/tests/Metadata/Driver/DocBlockDriverTest.php
+++ b/tests/Metadata/Driver/DocBlockDriverTest.php
@@ -18,11 +18,11 @@ use JMS\Serializer\Tests\Fixtures\DocBlockType\Collection\CollectionOfClassesFro
 use JMS\Serializer\Tests\Fixtures\DocBlockType\Collection\CollectionOfClassesFromTraitInsideTrait;
 use JMS\Serializer\Tests\Fixtures\DocBlockType\Collection\CollectionOfClassesWithFullNamespacePath;
 use JMS\Serializer\Tests\Fixtures\DocBlockType\Collection\CollectionOfClassesWithNull;
+use JMS\Serializer\Tests\Fixtures\DocBlockType\Collection\CollectionOfClassesWithNullSingleLinePhpDoc;
 use JMS\Serializer\Tests\Fixtures\DocBlockType\Collection\CollectionOfInterfacesFromDifferentNamespace;
 use JMS\Serializer\Tests\Fixtures\DocBlockType\Collection\CollectionOfInterfacesFromGlobalNamespace;
 use JMS\Serializer\Tests\Fixtures\DocBlockType\Collection\CollectionOfInterfacesFromSameNamespace;
 use JMS\Serializer\Tests\Fixtures\DocBlockType\Collection\CollectionOfInterfacesWithFullNamespacePath;
-use JMS\Serializer\Tests\Fixtures\DocBlockType\Collection\CollectionOfClassesWithNullSingleLinePhpDoc;
 use JMS\Serializer\Tests\Fixtures\DocBlockType\Collection\CollectionOfNotExistingClasses;
 use JMS\Serializer\Tests\Fixtures\DocBlockType\Collection\CollectionOfScalars;
 use JMS\Serializer\Tests\Fixtures\DocBlockType\Collection\CollectionOfUnionClasses;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Doc updated   | no
| BC breaks?    | yes
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #1259
| License       | MIT

As suggested by @goetas in #1259, this PR fixes the mentioned issue by implementing `phpstan/phpdoc-parser` support to read `@var` tags from PhpDoc. Only one test case for single-line PhpDoc parsing has been added, which works fine now.

In my opinion, a BC break is introduced by adding a constructor to `DocBlockTypeResolver`, since none existed before (which means possible extensions probably do not contain and call to the parent constructor so far).

This needs to be reviewed carefully, as I'm not sure if I considered all possible cases. The tests seem to work fine though.