### PR TITLE
Add Composer cache for v2 on Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,12 @@
 language: php
 
-sudo: false
-
 git:
     depth: 1
 
 cache:
   directories:
     - $HOME/.composer/cache
+    - $HOME/.cache/composer
 
 env:
   global:


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Doc updated   | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | n/a
| License       | MIT

Composer v1 and v2 store caches in different places:

    $HOME/.composer/cache
    $HOME/.cache/composer

Can be verified with:

    composer --global config cache-dir