### PR TITLE
Allow to defined custom property ordering strategy

### DIFF
--- a/src/Metadata/Driver/AnnotationDriver.php
+++ b/src/Metadata/Driver/AnnotationDriver.php
@@ -42,6 +42,7 @@ use JMS\Serializer\Metadata\ExpressionPropertyMetadata;
 use JMS\Serializer\Metadata\PropertyMetadata;
 use JMS\Serializer\Metadata\VirtualPropertyMetadata;
 use JMS\Serializer\Naming\PropertyNamingStrategyInterface;
+use JMS\Serializer\Ordering\PropertyOrderingRegistryInterface;
 use JMS\Serializer\Type\Parser;
 use JMS\Serializer\Type\ParserInterface;
 use Metadata\ClassMetadata as BaseClassMetadata;
@@ -65,18 +66,28 @@ class AnnotationDriver implements DriverInterface
      * @var PropertyNamingStrategyInterface
      */
     private $namingStrategy;
+    /**
+     * @var PropertyOrderingRegistryInterface|null
+     */
+    private $propertyOrderingRegistry;
 
-    public function __construct(Reader $reader, PropertyNamingStrategyInterface $namingStrategy, ?ParserInterface $typeParser = null, ?CompilableExpressionEvaluatorInterface $expressionEvaluator = null)
-    {
+    public function __construct(
+        Reader $reader,
+        PropertyNamingStrategyInterface $namingStrategy,
+        ?ParserInterface $typeParser = null,
+        ?CompilableExpressionEvaluatorInterface $expressionEvaluator = null,
+        ?PropertyOrderingRegistryInterface $propertyOrderingRegistry = null
+    ) {
         $this->reader = $reader;
         $this->typeParser = $typeParser ?: new Parser();
         $this->namingStrategy = $namingStrategy;
         $this->expressionEvaluator = $expressionEvaluator;
+        $this->propertyOrderingRegistry = $propertyOrderingRegistry;
     }
 
     public function loadMetadataForClass(\ReflectionClass $class): ?BaseClassMetadata
     {
-        $classMetadata = new ClassMetadata($name = $class->name);
+        $classMetadata = new ClassMetadata($name = $class->name, $this->propertyOrderingRegistry);
         $fileResource =  $class->getFilename();
         if (false !== $fileResource) {
             $classMetadata->fileResources[] = $fileResource;

--- a/src/Metadata/Driver/YamlDriver.php
+++ b/src/Metadata/Driver/YamlDriver.php
@@ -12,6 +12,7 @@ use JMS\Serializer\Metadata\ExpressionPropertyMetadata;
 use JMS\Serializer\Metadata\PropertyMetadata;
 use JMS\Serializer\Metadata\VirtualPropertyMetadata;
 use JMS\Serializer\Naming\PropertyNamingStrategyInterface;
+use JMS\Serializer\Ordering\PropertyOrderingRegistryInterface;
 use JMS\Serializer\Type\Parser;
 use JMS\Serializer\Type\ParserInterface;
 use Metadata\ClassMetadata as BaseClassMetadata;
@@ -39,13 +40,23 @@ class YamlDriver extends AbstractFileDriver
      * @var FileLocatorInterface
      */
     private $locator;
+    /**
+     * @var PropertyOrderingRegistryInterface|null
+     */
+    private $propertyOrderingRegistry;
 
-    public function __construct(FileLocatorInterface $locator, PropertyNamingStrategyInterface $namingStrategy, ?ParserInterface $typeParser = null, ?CompilableExpressionEvaluatorInterface $expressionEvaluator = null)
-    {
+    public function __construct(
+        FileLocatorInterface $locator,
+        PropertyNamingStrategyInterface $namingStrategy,
+        ?ParserInterface $typeParser = null,
+        ?CompilableExpressionEvaluatorInterface $expressionEvaluator = null,
+        ?PropertyOrderingRegistryInterface $propertyOrderingRegistry = null
+    ) {
         $this->locator = $locator;
         $this->typeParser = $typeParser ?? new Parser();
         $this->namingStrategy = $namingStrategy;
         $this->expressionEvaluator = $expressionEvaluator;
+        $this->propertyOrderingRegistry = $propertyOrderingRegistry;
     }
 
     public function loadMetadataForClass(ReflectionClass $class): ?BaseClassMetadata
@@ -100,7 +111,7 @@ class YamlDriver extends AbstractFileDriver
         }
 
         $config = $config[$name];
-        $metadata = new ClassMetadata($name);
+        $metadata = new ClassMetadata($name, $this->propertyOrderingRegistry);
         $metadata->fileResources[] = $file;
         $fileResource = $class->getFilename();
         if (false !== $fileResource) {

--- a/src/Ordering/AlphabeticalPropertyOrderingStrategy.php
+++ b/src/Ordering/AlphabeticalPropertyOrderingStrategy.php
@@ -11,7 +11,7 @@ final class AlphabeticalPropertyOrderingStrategy implements PropertyOrderingInte
     /**
      * {@inheritdoc}
      */
-    public function order(array $properties): array
+    public function order(array $properties, array $options): array
     {
         uasort(
             $properties,

--- a/src/Ordering/CustomPropertyOrderingStrategy.php
+++ b/src/Ordering/CustomPropertyOrderingStrategy.php
@@ -6,27 +6,19 @@ namespace JMS\Serializer\Ordering;
 
 final class CustomPropertyOrderingStrategy implements PropertyOrderingInterface
 {
-    /** @var int[] property => weight */
-    private $ordering;
-
-    /**
-     * @param int[] $ordering property => weight
-     */
-    public function __construct(array $ordering)
-    {
-        $this->ordering = $ordering;
-    }
-
     /**
      * {@inheritdoc}
      */
-    public function order(array $properties): array
+    public function order(array $properties, array $options): array
     {
+        /** @var int[] $ordering property => weight */
+        $ordering = $options['ordering'] ?? [];
+
         $currentSorting = $properties ? array_combine(array_keys($properties), range(1, \count($properties))) : [];
 
-        uksort($properties, function ($a, $b) use ($currentSorting) {
-            $existsA = isset($this->ordering[$a]);
-            $existsB = isset($this->ordering[$b]);
+        uksort($properties, static function ($a, $b) use ($currentSorting, $ordering) {
+            $existsA = isset($ordering[$a]);
+            $existsB = isset($ordering[$b]);
 
             if (!$existsA && !$existsB) {
                 return $currentSorting[$a] - $currentSorting[$b];
@@ -40,7 +32,7 @@ final class CustomPropertyOrderingStrategy implements PropertyOrderingInterface
                 return -1;
             }
 
-            return $this->ordering[$a] < $this->ordering[$b] ? -1 : 1;
+            return $ordering[$a] < $ordering[$b] ? -1 : 1;
         });
 
         return $properties;

--- a/src/Ordering/IdenticalPropertyOrderingStrategy.php
+++ b/src/Ordering/IdenticalPropertyOrderingStrategy.php
@@ -9,7 +9,7 @@ final class IdenticalPropertyOrderingStrategy implements PropertyOrderingInterfa
     /**
      * {@inheritdoc}
      */
-    public function order(array $properties): array
+    public function order(array $properties, array $options): array
     {
         return $properties;
     }

--- a/src/Ordering/PropertyOrderingInterface.php
+++ b/src/Ordering/PropertyOrderingInterface.php
@@ -10,8 +10,9 @@ interface PropertyOrderingInterface
 {
     /**
      * @param PropertyMetadata[] $properties name => property
+     * @param array $options    name => options
      *
      * @return PropertyMetadata[] name => property
      */
-    public function order(array $properties): array;
+    public function order(array $properties, array $options): array;
 }

--- a/src/Ordering/PropertyOrderingRegistry.php
+++ b/src/Ordering/PropertyOrderingRegistry.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace JMS\Serializer\Ordering;
+
+class PropertyOrderingRegistry implements PropertyOrderingRegistryInterface
+{
+    /**
+     * @var PropertyOrderingInterface[]
+     */
+    private $orders = [];
+
+    public function add(string $strategyName, PropertyOrderingInterface $propertyOrdering): void
+    {
+        if (!\array_key_exists($strategyName, $this->orders)) {
+            $this->orders[$strategyName] = $propertyOrdering;
+        }
+    }
+
+    public function get(string $strategyName): ?PropertyOrderingInterface
+    {
+        return $this->orders[$strategyName] ?? null;
+    }
+
+    /**
+     * @return PropertyOrderingInterface[]
+     */
+    public function all(): array
+    {
+        return $this->orders;
+    }
+
+    public function supports(string $strategyName): bool
+    {
+        return \array_key_exists($strategyName, $this->orders);
+    }
+}

--- a/src/Ordering/PropertyOrderingRegistryInterface.php
+++ b/src/Ordering/PropertyOrderingRegistryInterface.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace JMS\Serializer\Ordering;
+
+/**
+ * Interface for register PropertyOrdering strategy
+ */
+interface PropertyOrderingRegistryInterface
+{
+    public function add(string $strategyName, PropertyOrderingInterface $propertyOrdering);
+
+    public function get(string $strategyName): ?PropertyOrderingInterface;
+
+    public function supports(string $strategyName): bool;
+}

--- a/tests/Ordering/PropertyOrderingRegistryTest.php
+++ b/tests/Ordering/PropertyOrderingRegistryTest.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+namespace JMS\Serializer\Tests\Ordering;
+
+use JMS\Serializer\Ordering\AlphabeticalPropertyOrderingStrategy;
+use JMS\Serializer\Ordering\PropertyOrderingRegistry;
+use PHPUnit\Framework\TestCase;
+
+class PropertyOrderingRegistryTest extends TestCase
+{
+    /**
+     * @var PropertyOrderingRegistry
+     */
+    private $registry;
+
+    protected function setUp(): void
+    {
+        $this->registry = new PropertyOrderingRegistry();
+    }
+
+    public function testAdd(): void
+    {
+        $this->assertEquals([], $this->registry->all());
+
+        $strategy = new AlphabeticalPropertyOrderingStrategy();
+
+        $this->registry->add('MY_ALPHABETICAL', $strategy);
+        $this->assertEquals(['MY_ALPHABETICAL' => $strategy], $this->registry->all());
+
+        //Add twice with same name
+        $this->registry->add('MY_ALPHABETICAL', $strategy);
+        $this->assertEquals(['MY_ALPHABETICAL' => $strategy], $this->registry->all());
+
+        $this->registry->add('MY_OTHER_ALPHABETICAL', $strategy);
+        $this->assertEquals([
+            'MY_ALPHABETICAL' => $strategy,
+            'MY_OTHER_ALPHABETICAL' => $strategy,
+        ], $this->registry->all());
+    }
+
+    public function testSupports(): void
+    {
+        $strategy = new AlphabeticalPropertyOrderingStrategy();
+        $this->registry->add('MY_ALPHABETICAL', $strategy);
+
+        $this->assertTrue($this->registry->supports('MY_ALPHABETICAL'));
+        $this->assertFalse($this->registry->supports('NOT_DEFINED_NAME'));
+    }
+
+    public function testGet(): void
+    {
+        $strategy = new AlphabeticalPropertyOrderingStrategy();
+        $this->registry->add('MY_ALPHABETICAL', $strategy);
+
+        $this->assertEquals($strategy, $this->registry->get('MY_ALPHABETICAL'));
+        $this->assertNull($this->registry->get('NOT_DEFINED_NAME'));
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | yes
| Doc updated   | no
| BC breaks?    | yes
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
| License       | MIT

This PR allow to register new properties order strategy in addition of `undefined`, `alphabetical`, `custom`.
Useful examples can be Reverse Alphabetical Order or set virtual properties after properties in serialization.

There is a BC breaks on signature of `PropertyOrderingInterface` but this interface was used only in `ClassMetadata`. Not sure if I must add this in UPGRADING.md. If I must updating this file, what will be section name ?

If this PR is accepted and merged, I will make changes in JMSSerializerBundle in order to register new strategies when implementing interface (like EventDisptacher)

(Resolve closed issue https://github.com/schmittjoh/serializer/issues/379)