### PR TITLE
Fix DocBlockTypeResolver crash on PHP 7.3 and less

### DIFF
--- a/src/Metadata/Driver/DocBlockTypeResolver.php
+++ b/src/Metadata/Driver/DocBlockTypeResolver.php
@@ -121,6 +121,10 @@ class DocBlockTypeResolver
      */
     private function flattenVarTagValueTypes(array $varTagValues): array
     {
+        if ([] === $varTagValues) {
+            return [];
+        }
+
         return array_merge(...array_map(static function (VarTagValueNode $node) {
             if ($node->type instanceof UnionTypeNode) {
                 return $node->type->types;

--- a/tests/Fixtures/ObjectWithPhpDocProperty.php
+++ b/tests/Fixtures/ObjectWithPhpDocProperty.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace JMS\Serializer\Tests\Fixtures;
+
+// phpcs:disable
+final class ObjectWithPhpDocProperty
+{
+    /**
+     */
+    private $emptyBlock;
+
+}

--- a/tests/Metadata/Driver/DocBlockTypeResolverTest.php
+++ b/tests/Metadata/Driver/DocBlockTypeResolverTest.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace JMS\Serializer\Tests\Metadata\Driver;
+
+use JMS\Serializer\Metadata\Driver\DocBlockTypeResolver;
+use JMS\Serializer\Tests\Fixtures\ObjectWithPhpDocProperty;
+use PHPUnit\Framework\TestCase;
+use ReflectionProperty;
+
+final class DocBlockTypeResolverTest extends TestCase
+{
+    public function testGetPropertyDocblockTypeHintDoesNotCrash(): void
+    {
+        // It crashed on PHP 7.3 and less because of array_merge(...[])
+
+        $resolver = new DocBlockTypeResolver();
+        self::assertNull(
+            $resolver->getPropertyDocblockTypeHint(
+                new ReflectionProperty(ObjectWithPhpDocProperty::class, 'emptyBlock')
+            )
+        );
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Doc updated   |no
| BC breaks?    | no <!-- don't forget updating UPGRADING.md file -->
| Deprecations? | no <!-- don't forget updating UPGRADING.md file -->
| Tests pass?   | yes
| Fixed tickets | https://github.com/schmittjoh/JMSSerializerBundle/pull/824/checks?check_run_id=1956236845
| License       | MIT

