### PR TITLE
Show all toctree on index page

### DIFF
--- a/doc/index.rst
+++ b/doc/index.rst
@@ -40,7 +40,7 @@ Documentation
 -------------
 
 .. toctree ::
-    :hidden:
+    :maxdepth: 2
 
     configuration
     usage
@@ -48,19 +48,6 @@ Documentation
     handlers
     reference
     cookbook
-
-- :doc:`Configuration <configuration>`
-- :doc:`Usage <usage>`
-- :doc:`Events <event_system>`
-- :doc:`Handlers <handlers>`
-
-- Recipes
-    * :doc:`/cookbook/exclusion_strategies`
-
-- Reference
-    * :doc:`Annotations </reference/annotations>`
-    * :doc:`XML Reference </reference/xml_reference>`
-    * :doc:`YML Reference </reference/yml_reference>`
 
 License
 -------


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Doc updated   | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes/no
| Fixed tickets | #891
| License       | MIT

I have noticed what some sections of the documentation difficult to access. Showing all documentation pages on the index page will be much better for users.
