### PR TITLE
Doctrine `json` field type can contain not only an array

### DIFF
--- a/src/Metadata/Driver/AbstractDoctrineTypeDriver.php
+++ b/src/Metadata/Driver/AbstractDoctrineTypeDriver.php
@@ -56,7 +56,6 @@ abstract class AbstractDoctrineTypeDriver implements DriverInterface
         'boolean' => 'boolean',
 
         'array' => 'array',
-        'json' => 'array',
         'json_array' => 'array',
         'simple_array' => 'array<string>',
     ];


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Doc updated   | no
| BC breaks?    | no <!-- don't forget updating UPGRADING.md file -->
| Deprecations? | no <!-- don't forget updating UPGRADING.md file -->
| Tests pass?   | yes
| Fixed tickets | #... <!-- #-prefixed issue number(s), if any -->
| License       | MIT

In my project I have database table with `json` field which can contain not only `array`, but `string`, `int`, `bool` etc.
Using release 3.12.0 is not possible for me