### PR TITLE
`Undefined offset: 0` when using `@var null|string` instead of `@var string|null`

### DIFF
--- a/src/Metadata/Driver/DocBlockTypeResolver.php
+++ b/src/Metadata/Driver/DocBlockTypeResolver.php
@@ -143,9 +143,9 @@ class DocBlockTypeResolver
      */
     private function filterNullFromTypes(array $types): array
     {
-        return array_filter(array_map(function (TypeNode $node) {
+        return array_values(array_filter(array_map(function (TypeNode $node) {
             return $this->isNullType($node) ? null : $node;
-        }, $types));
+        }, $types)));
     }
 
     /**

--- a/tests/Fixtures/ObjectWithPhpDocProperty.php
+++ b/tests/Fixtures/ObjectWithPhpDocProperty.php
@@ -11,4 +11,14 @@ final class ObjectWithPhpDocProperty
      */
     private $emptyBlock;
 
+    /**
+     * @var string|null
+     */
+    private $firstname;
+
+    /**
+     * @var null|string
+     */
+    private $lastname;
+
 }

--- a/tests/Metadata/Driver/DocBlockTypeResolverTest.php
+++ b/tests/Metadata/Driver/DocBlockTypeResolverTest.php
@@ -22,4 +22,21 @@ final class DocBlockTypeResolverTest extends TestCase
             )
         );
     }
+
+    public function testGetPropertyDocblockTypeHintDoesNotCrashWhenUnionType(): void
+    {
+        $resolver = new DocBlockTypeResolver();
+        self::assertSame(
+            'string',
+            $resolver->getPropertyDocblockTypeHint(
+                new ReflectionProperty(ObjectWithPhpDocProperty::class, 'firstname')
+            )
+        );
+        self::assertSame(
+            'string',
+            $resolver->getPropertyDocblockTypeHint(
+                new ReflectionProperty(ObjectWithPhpDocProperty::class, 'lastname')
+            )
+        );
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  |no
| Doc updated   |no
| BC breaks?    |no
| Deprecations? | no 
| Tests pass?   | see CI
| License       | MIT

After upgrading from 3.12.0 to 3.12.1 I received `Undefined offset: 0` errors. After some debugging I found the problem.

In the commits I explain what the problem is and how I fixed it. 