### PR TITLE
Allow phpstan/phpdoc-parser v0.5

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
         "doctrine/instantiator": "^1.0.3",
         "doctrine/lexer": "^1.1",
         "jms/metadata": "^2.0",
-        "phpstan/phpdoc-parser": "^0.4"
+        "phpstan/phpdoc-parser": "^0.4 || ^0.5"
     },
     "suggest": {
         "doctrine/cache": "Required if you like to use cache functionality.",


### PR DESCRIPTION
It is often needed by other libraries in PHP world that support PHP 8

| Q             | A
| ------------- | ---
| Bug fix?      |no
| New feature?  |no
| Doc updated   |no
| BC breaks?    |no <!-- don't forget updating UPGRADING.md file -->
| Deprecations? |no <!-- don't forget updating UPGRADING.md file -->
| Tests pass?   | yes
| License       | MIT

