### PR TITLE
useful error when data is not an object

### DIFF
--- a/src/GraphNavigator/SerializationGraphNavigator.php
+++ b/src/GraphNavigator/SerializationGraphNavigator.php
@@ -236,7 +236,7 @@ final class SerializationGraphNavigator extends GraphNavigator
                 }
 
                 if (!is_object($data)) {
-                    throw new InvalidArgumentException('Value at '.$this->context->getPath().' is expected to be an object of class '.$type['name'].' but is of type '.gettype($data));
+                    throw new InvalidArgumentException('Value at ' . $this->context->getPath() . ' is expected to be an object of class ' . $type['name'] . ' but is of type ' . csgettype($data));
                 }
                 
                 $this->context->pushClassMetadata($metadata);

--- a/src/GraphNavigator/SerializationGraphNavigator.php
+++ b/src/GraphNavigator/SerializationGraphNavigator.php
@@ -234,6 +234,10 @@ final class SerializationGraphNavigator extends GraphNavigator
                     throw new ExcludedClassException();
                 }
 
+                if (!is_object($data)) {
+                    throw new InvalidArgumentException('Value at '.$this->context->getPath().' is expected to be an object of class '.type['name'].' but is of type '.gettype($data));
+                }
+                
                 $this->context->pushClassMetadata($metadata);
 
                 foreach ($metadata->preSerializeMethods as $method) {

--- a/src/GraphNavigator/SerializationGraphNavigator.php
+++ b/src/GraphNavigator/SerializationGraphNavigator.php
@@ -236,9 +236,9 @@ final class SerializationGraphNavigator extends GraphNavigator
                 }
 
                 if (!is_object($data)) {
-                    throw new InvalidArgumentException('Value at ' . $this->context->getPath() . ' is expected to be an object of class ' . $type['name'] . ' but is of type ' . csgettype($data));
+                    throw new InvalidArgumentException('Value at ' . $this->context->getPath() . ' is expected to be an object of class ' . $type['name'] . ' but is of type ' . gettype($data));
                 }
-                
+
                 $this->context->pushClassMetadata($metadata);
 
                 foreach ($metadata->preSerializeMethods as $method) {

--- a/src/GraphNavigator/SerializationGraphNavigator.php
+++ b/src/GraphNavigator/SerializationGraphNavigator.php
@@ -13,6 +13,7 @@ use JMS\Serializer\EventDispatcher\PreSerializeEvent;
 use JMS\Serializer\Exception\CircularReferenceDetectedException;
 use JMS\Serializer\Exception\ExcludedClassException;
 use JMS\Serializer\Exception\ExpressionLanguageRequiredException;
+use JMS\Serializer\Exception\InvalidArgumentException;
 use JMS\Serializer\Exception\NotAcceptableException;
 use JMS\Serializer\Exception\RuntimeException;
 use JMS\Serializer\Exception\SkipHandlerException;
@@ -235,7 +236,7 @@ final class SerializationGraphNavigator extends GraphNavigator
                 }
 
                 if (!is_object($data)) {
-                    throw new InvalidArgumentException('Value at '.$this->context->getPath().' is expected to be an object of class '.type['name'].' but is of type '.gettype($data));
+                    throw new InvalidArgumentException('Value at '.$this->context->getPath().' is expected to be an object of class '.$type['name'].' but is of type '.gettype($data));
                 }
                 
                 $this->context->pushClassMetadata($metadata);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | (yes)
| New feature?  | no
| Doc updated   | -
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | see ci
| Fixed tickets | -
| License       | MIT

I was spending some time trying to figure out why i get:

    TypeError: "Argument 2 passed to JMS\Serializer\JsonSerializationVisitor::startVisitingObject() must be an object, array given

Turns out i misconfigured a property that was supposed to be an array of objects as an object with the JMS annotations. From the error it is impossible to know what is wrong. With this exception, the path to the offending property is printed and we say what is actually expected.
