### PR TITLE
fix iterable::class that does not exist

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1,6 +1,0 @@
-parameters:
-	ignoreErrors:
-		-
-			message: "#^Class JMS\\\\Serializer\\\\Handler\\\\iterable not found\\.$#"
-			count: 2
-			path: src/Handler/IteratorHandler.php

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -9,6 +9,3 @@ parameters:
     paths:
         - %currentWorkingDirectory%/src
         - %currentWorkingDirectory%/tests
-
-includes:
-    - phpstan-baseline.neon

--- a/src/Handler/ArrayCollectionHandler.php
+++ b/src/Handler/ArrayCollectionHandler.php
@@ -6,6 +6,9 @@ namespace JMS\Serializer\Handler;
 
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
+use Doctrine\ODM\MongoDB\PersistentCollection as MongoPersistentCollection;
+use Doctrine\ODM\PHPCR\PersistentCollection as PhpcrPersistentCollection;
+use Doctrine\ORM\PersistentCollection as OrmPersistentCollection;
 use JMS\Serializer\DeserializationContext;
 use JMS\Serializer\GraphNavigatorInterface;
 use JMS\Serializer\SerializationContext;
@@ -33,10 +36,10 @@ final class ArrayCollectionHandler implements SubscribingHandlerInterface
         $formats = ['json', 'xml', 'yml'];
         $collectionTypes = [
             'ArrayCollection',
-            'Doctrine\Common\Collections\ArrayCollection',
-            'Doctrine\ORM\PersistentCollection',
-            'Doctrine\ODM\MongoDB\PersistentCollection',
-            'Doctrine\ODM\PHPCR\PersistentCollection',
+            ArrayCollection::class,
+            OrmPersistentCollection::class,
+            MongoPersistentCollection::class,
+            PhpcrPersistentCollection::class,
         ];
 
         foreach ($collectionTypes as $type) {

--- a/src/Handler/ConstraintViolationHandler.php
+++ b/src/Handler/ConstraintViolationHandler.php
@@ -20,7 +20,7 @@ final class ConstraintViolationHandler implements SubscribingHandlerInterface
     {
         $methods = [];
         $formats = ['xml', 'json'];
-        $types = ['Symfony\Component\Validator\ConstraintViolationList' => 'serializeList', 'Symfony\Component\Validator\ConstraintViolation' => 'serializeViolation'];
+        $types = [ConstraintViolationList::class => 'serializeList', ConstraintViolation::class => 'serializeViolation'];
 
         foreach ($types as $type => $method) {
             foreach ($formats as $format) {

--- a/src/Handler/DateHandler.php
+++ b/src/Handler/DateHandler.php
@@ -34,7 +34,7 @@ final class DateHandler implements SubscribingHandlerInterface
     public static function getSubscribingMethods()
     {
         $methods = [];
-        $types = ['DateTime', 'DateTimeImmutable', 'DateInterval'];
+        $types = [\DateTime::class, \DateTimeImmutable::class, \DateInterval::class];
 
         foreach (['json', 'xml'] as $format) {
             foreach ($types as $type) {

--- a/src/Handler/FormErrorHandler.php
+++ b/src/Handler/FormErrorHandler.php
@@ -35,12 +35,12 @@ final class FormErrorHandler implements SubscribingHandlerInterface
         foreach (['xml', 'json'] as $format) {
             $methods[] = [
                 'direction' => GraphNavigatorInterface::DIRECTION_SERIALIZATION,
-                'type' => 'Symfony\Component\Form\Form',
+                'type' => Form::class,
                 'format' => $format,
             ];
             $methods[] = [
                 'direction' => GraphNavigatorInterface::DIRECTION_SERIALIZATION,
-                'type' => 'Symfony\Component\Form\FormError',
+                'type' => FormError::class,
                 'format' => $format,
             ];
         }

--- a/src/Handler/IteratorHandler.php
+++ b/src/Handler/IteratorHandler.php
@@ -77,14 +77,14 @@ final class IteratorHandler implements SubscribingHandlerInterface
     }
 
     /**
-     * @return array|\ArrayObject
+     * @return array|\ArrayObject|null
      */
     public function serializeIterable(
         SerializationVisitorInterface $visitor,
         iterable $iterable,
         array $type,
         SerializationContext $context
-    ): iterable {
+    ): ?iterable {
         $type['name'] = 'array';
 
         $context->stopVisiting($iterable);

--- a/src/Handler/IteratorHandler.php
+++ b/src/Handler/IteratorHandler.php
@@ -28,22 +28,6 @@ final class IteratorHandler implements SubscribingHandlerInterface
         foreach (self::SUPPORTED_FORMATS as $format) {
             $methods[] = [
                 'direction' => GraphNavigatorInterface::DIRECTION_SERIALIZATION,
-                'type' => iterable::class,
-                'format' => $format,
-                'method' => 'serializeIterable',
-            ];
-
-            $methods[] = [
-                'direction' => GraphNavigatorInterface::DIRECTION_DESERIALIZATION,
-                'type' => iterable::class,
-                'format' => $format,
-                'method' => 'deserializeIterable',
-            ];
-        }
-
-        foreach (self::SUPPORTED_FORMATS as $format) {
-            $methods[] = [
-                'direction' => GraphNavigatorInterface::DIRECTION_SERIALIZATION,
                 'type' => Iterator::class,
                 'format' => $format,
                 'method' => 'serializeIterable',
@@ -93,14 +77,14 @@ final class IteratorHandler implements SubscribingHandlerInterface
     }
 
     /**
-     * @return mixed
+     * @return array|\ArrayObject
      */
     public function serializeIterable(
         SerializationVisitorInterface $visitor,
         iterable $iterable,
         array $type,
         SerializationContext $context
-    ) {
+    ): iterable {
         $type['name'] = 'array';
 
         $context->stopVisiting($iterable);
@@ -122,25 +106,6 @@ final class IteratorHandler implements SubscribingHandlerInterface
         $type['name'] = 'array';
 
         return new ArrayIterator($visitor->visitArray($data, $type));
-    }
-
-    /**
-     * @param mixed $data
-     */
-    public function deserializeIterable(
-        DeserializationVisitorInterface $visitor,
-        $data,
-        array $type,
-        DeserializationContext $context
-    ): array {
-        $type['name'] = 'array';
-
-        $return = [];
-        foreach ($visitor->visitArray($data, $type) as $key => $item) {
-            $return[$key] = $item;
-        }
-
-        return $return;
     }
 
     /**

--- a/src/Handler/StdClassHandler.php
+++ b/src/Handler/StdClassHandler.php
@@ -25,7 +25,7 @@ final class StdClassHandler implements SubscribingHandlerInterface
         foreach ($formats as $format) {
             $methods[] = [
                 'direction' => GraphNavigatorInterface::DIRECTION_SERIALIZATION,
-                'type' => 'stdClass',
+                'type' => \stdClass::class,
                 'format' => $format,
                 'method' => 'serializeStdClass',
             ];


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Doc updated   | no
| BC breaks?    | no <!-- don't forget updating UPGRADING.md file -->
| Deprecations? | no <!-- don't forget updating UPGRADING.md file -->
| Tests pass?   | yes
| Fixed tickets | 
| License       | MIT

