### PR TITLE
Check data can be casted before actual casting

### DIFF
--- a/src/AbstractVisitor.php
+++ b/src/AbstractVisitor.php
@@ -4,6 +4,10 @@ declare(strict_types=1);
 
 namespace JMS\Serializer;
 
+use JMS\Serializer\Exception\NonFloatCastableTypeException;
+use JMS\Serializer\Exception\NonIntCastableTypeException;
+use JMS\Serializer\Exception\NonStringCastableTypeException;
+
 /**
  * @internal
  */
@@ -37,6 +41,49 @@ abstract class AbstractVisitor implements VisitorInterface
             return $typeArray['params'][1];
         } else {
             return $typeArray['params'][0];
+        }
+    }
+
+    /**
+     * logic according to strval https://www.php.net/manual/en/function.strval.php
+     * "You cannot use strval() on arrays or on objects that do not implement the __toString() method."
+     *
+     * @param mixed $value
+     */
+    protected function assertValueCanBeCastToString($value): void
+    {
+        if (is_array($value)) {
+            throw new NonStringCastableTypeException($value);
+        }
+
+        if (is_object($value) && !method_exists($value, '__toString')) {
+            throw new NonStringCastableTypeException($value);
+        }
+    }
+
+    /**
+     * logic according to intval https://www.php.net/manual/en/function.intval.php
+     * "intval() should not be used on objects, as doing so will emit an E_NOTICE level error and return 1."
+     *
+     * @param mixed $value
+     */
+    protected function assertValueCanBeCastToInt($value): void
+    {
+        if (is_object($value) && !$value instanceof \SimpleXMLElement) {
+            throw new NonIntCastableTypeException($value);
+        }
+    }
+
+    /**
+     *  logic according to floatval https://www.php.net/manual/en/function.floatval.php
+     * "floatval() should not be used on objects, as doing so will emit an E_NOTICE level error and return 1."
+     *
+     * @param mixed $value
+     */
+    protected function assertValueCanCastToFloat($value): void
+    {
+        if (is_object($value) && !$value instanceof \SimpleXMLElement) {
+            throw new NonFloatCastableTypeException($value);
         }
     }
 }

--- a/src/Exception/NonCastableTypeException.php
+++ b/src/Exception/NonCastableTypeException.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace JMS\Serializer\Exception;
+
+class NonCastableTypeException extends RuntimeException
+{
+    /**
+     * @var mixed
+     */
+    private $value;
+
+    /**
+     * @param mixed $value
+     */
+    public function __construct(string $expectedType, $value)
+    {
+        $this->value = $value;
+
+        parent::__construct(
+            sprintf(
+                'Cannot convert value of type "%s" to %s',
+                gettype($value),
+                $expectedType
+            )
+        );
+    }
+
+    /**
+     * @return mixed
+     */
+    public function getValue()
+    {
+        return $this->value;
+    }
+}

--- a/src/Exception/NonCastableTypeException.php
+++ b/src/Exception/NonCastableTypeException.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace JMS\Serializer\Exception;
 
-class NonCastableTypeException extends RuntimeException
+abstract class NonCastableTypeException extends RuntimeException
 {
     /**
      * @var mixed

--- a/src/Exception/NonFloatCastableTypeException.php
+++ b/src/Exception/NonFloatCastableTypeException.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace JMS\Serializer\Exception;
+
+class NonFloatCastableTypeException extends NonCastableTypeException
+{
+    /**
+     * @param mixed $value
+     */
+    public function __construct($value)
+    {
+        parent::__construct('float', $value);
+    }
+}

--- a/src/Exception/NonFloatCastableTypeException.php
+++ b/src/Exception/NonFloatCastableTypeException.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace JMS\Serializer\Exception;
 
-class NonFloatCastableTypeException extends NonCastableTypeException
+final class NonFloatCastableTypeException extends NonCastableTypeException
 {
     /**
      * @param mixed $value

--- a/src/Exception/NonIntCastableTypeException.php
+++ b/src/Exception/NonIntCastableTypeException.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace JMS\Serializer\Exception;
 
-class NonIntCastableTypeException extends NonCastableTypeException
+final class NonIntCastableTypeException extends NonCastableTypeException
 {
     /**
      * @param mixed $value

--- a/src/Exception/NonIntCastableTypeException.php
+++ b/src/Exception/NonIntCastableTypeException.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace JMS\Serializer\Exception;
+
+class NonIntCastableTypeException extends NonCastableTypeException
+{
+    /**
+     * @param mixed $value
+     */
+    public function __construct($value)
+    {
+        parent::__construct('int', $value);
+    }
+}

--- a/src/Exception/NonStringCastableTypeException.php
+++ b/src/Exception/NonStringCastableTypeException.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace JMS\Serializer\Exception;
+
+class NonStringCastableTypeException extends NonCastableTypeException
+{
+    /**
+     * @param mixed $value
+     */
+    public function __construct($value)
+    {
+        parent::__construct('string', $value);
+    }
+}

--- a/src/Exception/NonStringCastableTypeException.php
+++ b/src/Exception/NonStringCastableTypeException.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace JMS\Serializer\Exception;
 
-class NonStringCastableTypeException extends NonCastableTypeException
+final class NonStringCastableTypeException extends NonCastableTypeException
 {
     /**
      * @param mixed $value

--- a/src/JsonDeserializationVisitor.php
+++ b/src/JsonDeserializationVisitor.php
@@ -55,6 +55,8 @@ final class JsonDeserializationVisitor extends AbstractVisitor implements Deseri
      */
     public function visitString($data, array $type): string
     {
+        $this->assertValueCanBeCastToString($data);
+
         return (string) $data;
     }
 
@@ -71,6 +73,8 @@ final class JsonDeserializationVisitor extends AbstractVisitor implements Deseri
      */
     public function visitInteger($data, array $type): int
     {
+        $this->assertValueCanBeCastToInt($data);
+
         return (int) $data;
     }
 
@@ -79,6 +83,8 @@ final class JsonDeserializationVisitor extends AbstractVisitor implements Deseri
      */
     public function visitDouble($data, array $type): float
     {
+        $this->assertValueCanCastToFloat($data);
+
         return (float) $data;
     }
 

--- a/src/XmlDeserializationVisitor.php
+++ b/src/XmlDeserializationVisitor.php
@@ -128,6 +128,8 @@ final class XmlDeserializationVisitor extends AbstractVisitor implements NullAwa
      */
     public function visitString($data, array $type): string
     {
+        $this->assertValueCanBeCastToString($data);
+
         return (string) $data;
     }
 
@@ -136,6 +138,8 @@ final class XmlDeserializationVisitor extends AbstractVisitor implements NullAwa
      */
     public function visitBoolean($data, array $type): bool
     {
+        $this->assertValueCanBeCastToString($data);
+
         $data = (string) $data;
 
         if ('true' === $data || '1' === $data) {
@@ -152,6 +156,8 @@ final class XmlDeserializationVisitor extends AbstractVisitor implements NullAwa
      */
     public function visitInteger($data, array $type): int
     {
+        $this->assertValueCanBeCastToInt($data);
+
         return (int) $data;
     }
 
@@ -160,6 +166,8 @@ final class XmlDeserializationVisitor extends AbstractVisitor implements NullAwa
      */
     public function visitDouble($data, array $type): float
     {
+        $this->assertValueCanCastToFloat($data);
+
         return (float) $data;
     }
 

--- a/tests/Deserializer/BaseDeserializationTest.php
+++ b/tests/Deserializer/BaseDeserializationTest.php
@@ -5,12 +5,46 @@ declare(strict_types=1);
 namespace JMS\Serializer\Tests\Deserializer;
 
 use JMS\Serializer\DeserializationContext;
+use JMS\Serializer\Exception\NonCastableTypeException;
 use JMS\Serializer\SerializerBuilder;
+use JMS\Serializer\Tests\Fixtures\Discriminator\Car;
 use JMS\Serializer\Tests\Fixtures\GroupsObject;
+use JMS\Serializer\Tests\Fixtures\Price;
+use JMS\Serializer\Tests\Fixtures\Publisher;
 use PHPUnit\Framework\TestCase;
 
 class BaseDeserializationTest extends TestCase
 {
+    /**
+     * @dataProvider dataTypeCannotBeCasted
+     */
+    public function testDeserializationInvalidDataCausesException($data, string $type): void
+    {
+        $serializer = SerializerBuilder::create()->build();
+
+        $this->expectException(NonCastableTypeException::class);
+
+        $serializer->fromArray($data, $type);
+    }
+
+    public function dataTypeCannotBeCasted(): iterable
+    {
+        yield 'array to string' => [
+            ['pub_name' => ['bla', 'bla']],
+            Publisher::class,
+        ];
+
+        yield 'object to float' => [
+            ['price' => (object) ['bla' => 'bla']],
+            Price::class,
+        ];
+
+        yield 'object to int' => [
+            ['km' => (object) ['bla' => 'bla']],
+            Car::class,
+        ];
+    }
+
     /**
      * @dataProvider dataDeserializerGroupExclusion
      */
@@ -25,17 +59,17 @@ class BaseDeserializationTest extends TestCase
     public function dataDeserializerGroupExclusion(): iterable
     {
         $data = [
-            'foo'    => 'foo',
+            'foo' => 'foo',
             'foobar' => 'foobar',
-            'bar'    => 'bar',
-            'none'   => 'none',
+            'bar' => 'bar',
+            'none' => 'none',
         ];
 
         yield [
             $data,
             ['Default'],
             [
-                'bar'  => 'bar',
+                'bar' => 'bar',
                 'none' => 'none',
             ],
         ];
@@ -44,7 +78,7 @@ class BaseDeserializationTest extends TestCase
             $data,
             ['foo'],
             [
-                'foo'    => 'foo',
+                'foo' => 'foo',
                 'foobar' => 'foobar',
             ],
         ];
@@ -54,7 +88,7 @@ class BaseDeserializationTest extends TestCase
             ['bar'],
             [
                 'foobar' => 'foobar',
-                'bar'    => 'bar',
+                'bar' => 'bar',
             ],
         ];
 
@@ -62,9 +96,9 @@ class BaseDeserializationTest extends TestCase
             $data,
             ['foo', 'bar'],
             [
-                'foo'    => 'foo',
+                'foo' => 'foo',
                 'foobar' => 'foobar',
-                'bar'    => 'bar',
+                'bar' => 'bar',
             ],
         ];
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Doc updated   | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #880 
| License       | MIT

This is retake of #1167 I've cleaned it up and added some tests

I'd rather consider this a bug fix than a new feature since I came here because my tests are failing because of warnings `Array to string conversion` are being caught by phpunit, not by my library exception system.