### PR TITLE
Context::getCurrentPath() returns indexes of list items

### DIFF
--- a/src/Context.php
+++ b/src/Context.php
@@ -253,6 +253,9 @@ abstract class Context
 
         $paths = [];
         foreach ($this->metadataStack as $metadata) {
+            if ($metadata instanceof ClassMetadata && $metadata->positionInList !== null) {
+                array_unshift($paths, $metadata->positionInList);
+            }
             if ($metadata instanceof PropertyMetadata) {
                 array_unshift($paths, $metadata->name);
             }

--- a/src/GraphNavigator/SerializationGraphNavigator.php
+++ b/src/GraphNavigator/SerializationGraphNavigator.php
@@ -116,6 +116,14 @@ final class SerializationGraphNavigator extends GraphNavigator
      */
     public function accept($data, ?array $type = null)
     {
+        // Element could be one of the element list
+        $positionInList = null;
+        if (isset($type['position_in_list'])) {
+            $positionInList = $type['position_in_list'];
+            unset($type['position_in_list']);
+            $type = $type ?: null;
+        }
+
         // If the type was not given, we infer the most specific type from the
         // input data in serialization mode.
         if (null === $type) {
@@ -218,6 +226,11 @@ final class SerializationGraphNavigator extends GraphNavigator
 
                 $metadata = $this->metadataFactory->getMetadataForClass($type['name']);
                 \assert($metadata instanceof ClassMetadata);
+
+                if ($positionInList !== null) {
+                    $metadata = clone $metadata;
+                    $metadata->positionInList = $positionInList;
+                }
 
                 if ($metadata->usingExpression && null === $this->expressionExclusionStrategy) {
                     throw new ExpressionLanguageRequiredException(sprintf('To use conditional exclude/expose in %s you must configure the expression language.', $metadata->name));

--- a/src/JsonSerializationVisitor.php
+++ b/src/JsonSerializationVisitor.php
@@ -89,6 +89,7 @@ final class JsonSerializationVisitor extends AbstractVisitor implements Serializ
 
         $elType = $this->getElementType($type);
         foreach ($data as $k => $v) {
+            $elType['position_in_list'] = $k;
             try {
                 $v = $this->navigator->accept($v, $elType);
             } catch (NotAcceptableException $e) {

--- a/src/Metadata/ClassMetadata.php
+++ b/src/Metadata/ClassMetadata.php
@@ -85,6 +85,13 @@ class ClassMetadata extends MergeableClassMetadata
     public $isMap = false;
 
     /**
+     * @internal
+     *
+     * @var int|null
+     */
+    public $positionInList = null;
+
+    /**
      * @var bool
      */
     public $discriminatorDisabled = false;

--- a/tests/Serializer/ContextTest.php
+++ b/tests/Serializer/ContextTest.php
@@ -62,24 +62,29 @@ class ContextTest extends TestCase
         $exclusionStrategy->expects($this->any())
             ->method('shouldSkipProperty')
             ->with($this->anything(), $this->callback(static function (SerializationContext $context) use ($self, $objects) {
-                $expectedDepth = $expectedPath = null;
+                $expectedCurrentPath = $expectedDepth = $expectedPath = null;
 
                 if ($context->getObject() === $objects[0]) {
                     $expectedDepth = 1;
                     $expectedPath = 'JMS\Serializer\Tests\Fixtures\Node';
+                    $expectedCurrentPath = [];
                 } elseif ($context->getObject() === $objects[1]) {
                     $expectedDepth = 2;
                     $expectedPath = 'JMS\Serializer\Tests\Fixtures\Node -> JMS\Serializer\Tests\Fixtures\Node';
+                    $expectedCurrentPath = ['children', 0];
                 } elseif ($context->getObject() === $objects[2]) {
                     $expectedDepth = 2;
                     $expectedPath = 'JMS\Serializer\Tests\Fixtures\Node -> JMS\Serializer\Tests\Fixtures\Node';
+                    $expectedCurrentPath = ['children', 1];
                 } elseif ($context->getObject() === $objects[3]) {
                     $expectedDepth = 3;
                     $expectedPath = 'JMS\Serializer\Tests\Fixtures\Node -> JMS\Serializer\Tests\Fixtures\Node -> JMS\Serializer\Tests\Fixtures\Node';
+                    $expectedCurrentPath = ['children', 1, 'children', 0];
                 }
 
                 $self->assertEquals($expectedDepth, $context->getDepth(), 'shouldSkipProperty depth');
                 $self->assertEquals($expectedPath, $context->getPath(), 'shouldSkipProperty path');
+                $self->assertEquals($expectedCurrentPath, $context->getCurrentPath(), 'Unexpected context current path');
 
                 return true;
             }))


### PR DESCRIPTION
Implementing `ExclusionStrategyInterface` i realized that there is no way to detect if current element is part on the list with specific index. 

For example, we have a class
```
class Node {
  public string $name;
  /** @var Node[] */
  public array $children;
}
```
When one of `$children` element has been passed to `shouldSkipProperty(PropertyMetadata $property, Context $context)`, i don't know which one. `Context` does not know the index of such element. But i have external rules like so which  define whether property of element should be serialized or not: 
```
$rules = [
  'children' => [
    0 => ['name'],
    2 => ['name', 'children']
  ]
]
```

I suggest `$context->getCurrentPath()` should return array like so: `[children][0]['name']` instead of `[children]['name']` (current behavior)

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Doc updated   | no
| BC breaks?    | likely so
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
| License       | MIT

