### PR TITLE
Proposed fix for serializing custom DateTimeInterface implementations

### DIFF
--- a/src/GraphNavigator/SerializationGraphNavigator.php
+++ b/src/GraphNavigator/SerializationGraphNavigator.php
@@ -186,7 +186,7 @@ final class SerializationGraphNavigator extends GraphNavigator
                 // If we're serializing a polymorphic type, then we'll be interested in the
                 // metadata for the actual type of the object, not the base class.
                 if (class_exists($type['name'], false) || interface_exists($type['name'], false)) {
-                    if (is_subclass_of($data, $type['name'], false)) {
+                    if (is_subclass_of($data, $type['name'], false) && null === $this->handlerRegistry->getHandler(GraphNavigatorInterface::DIRECTION_SERIALIZATION, $type['name'], $this->format)) {
                         $type = ['name' => \get_class($data), 'params' => $type['params'] ?? []];
                     }
                 }

--- a/src/Handler/DateHandler.php
+++ b/src/Handler/DateHandler.php
@@ -52,10 +52,17 @@ final class DateHandler implements SubscribingHandlerInterface
             }
 
             $methods[] = [
-                'type' => 'DateTimeInterface',
+                'type' => \DateTimeInterface::class,
                 'direction' => GraphNavigatorInterface::DIRECTION_DESERIALIZATION,
                 'format' => $format,
                 'method' => 'deserializeDateTimeFrom' . ucfirst($format),
+            ];
+
+            $methods[] = [
+                'type' => \DateTimeInterface::class,
+                'direction' => GraphNavigatorInterface::DIRECTION_SERIALIZATION,
+                'format' => $format,
+                'method' => 'serializeDateTimeInterface',
             ];
         }
 
@@ -72,7 +79,7 @@ final class DateHandler implements SubscribingHandlerInterface
     /**
      * @return \DOMCdataSection|\DOMText|mixed
      */
-    private function serializeDateTimeInterface(
+    public function serializeDateTimeInterface(
         SerializationVisitorInterface $visitor,
         \DateTimeInterface $date,
         array $type,

--- a/tests/Fixtures/DateTimeContainer.php
+++ b/tests/Fixtures/DateTimeContainer.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace JMS\Serializer\Tests\Fixtures;
+
+use DateTimeInterface;
+use JMS\Serializer\Annotation as JMS;
+
+class DateTimeContainer
+{
+    /**
+     * @var DateTimeInterface
+     * @JMS\Type("DateTimeInterface<'Y-m-d'>")
+     * @JMS\SerializedName("custom")
+     */
+    public $customDateTime;
+
+    public function __construct(DateTimeInterface $custom)
+    {
+        $this->customDateTime = $custom;
+    }
+}

--- a/tests/Fixtures/DateTimeCustomObject.php
+++ b/tests/Fixtures/DateTimeCustomObject.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace JMS\Serializer\Tests\Fixtures;
+
+use DateTimeImmutable;
+
+class DateTimeCustomObject extends DateTimeImmutable
+{
+
+}

--- a/tests/Serializer/BaseSerializationTest.php
+++ b/tests/Serializer/BaseSerializationTest.php
@@ -647,9 +647,7 @@ abstract class BaseSerializationTest extends TestCase
 
     public function testCustomDateObject()
     {
-        $customDate = new DateTimeCustomObject('2021-09-07');
-        $customDate->extraField = 'test';
-        $data = new DateTimeContainer($customDate);
+        $data = new DateTimeContainer(new DateTimeCustomObject('2021-09-07'));
 
         self::assertEquals($this->getContent('custom_datetimeinterface'), $this->serialize($data));
     }

--- a/tests/Serializer/BaseSerializationTest.php
+++ b/tests/Serializer/BaseSerializationTest.php
@@ -47,6 +47,8 @@ use JMS\Serializer\Tests\Fixtures\CurrencyAwareOrder;
 use JMS\Serializer\Tests\Fixtures\CurrencyAwarePrice;
 use JMS\Serializer\Tests\Fixtures\CustomDeserializationObject;
 use JMS\Serializer\Tests\Fixtures\DateTimeArraysObject;
+use JMS\Serializer\Tests\Fixtures\DateTimeContainer;
+use JMS\Serializer\Tests\Fixtures\DateTimeCustomObject;
 use JMS\Serializer\Tests\Fixtures\Discriminator\Car;
 use JMS\Serializer\Tests\Fixtures\Discriminator\ImagePost;
 use JMS\Serializer\Tests\Fixtures\Discriminator\Moped;
@@ -642,6 +644,16 @@ abstract class BaseSerializationTest extends TestCase
 
         self::assertEquals($this->getContent('array_list_and_map_difference'), $this->serialize($data));
     }
+
+    public function testCustomDateObject()
+    {
+        $customDate = new DateTimeCustomObject('2021-09-07');
+        $customDate->extraField = 'test';
+        $data = new DateTimeContainer($customDate);
+
+        self::assertEquals($this->getContent('custom_datetimeinterface'), $this->serialize($data));
+    }
+
 
     public function testDateTimeArrays()
     {

--- a/tests/Serializer/JsonSerializationTest.php
+++ b/tests/Serializer/JsonSerializationTest.php
@@ -130,6 +130,7 @@ class JsonSerializationTest extends BaseSerializationTest
             $outputs['user_discriminator'] = '{"entityName":"User"}';
             $outputs['user_discriminator_extended'] = '{"entityName":"ExtendedUser"}';
             $outputs['typed_props'] = '{"id":1,"role":{"id":5},"vehicle":{"type":"car"},"created":"2010-10-01T00:00:00+00:00","updated":"2011-10-01T00:00:00+00:00","tags":["a","b"]}';
+            $outputs['custom_datetimeinterface'] = '{"custom":"2021-09-07"}';
         }
 
         if (!isset($outputs[$key])) {

--- a/tests/Serializer/xml/custom_datetimeinterface.xml
+++ b/tests/Serializer/xml/custom_datetimeinterface.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<result>
+  <custom><![CDATA[2021-09-07]]></custom>
+</result>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Doc updated   | yes/no
| BC breaks?    | no <!-- don't forget updating UPGRADING.md file -->
| Deprecations? | no <!-- don't forget updating UPGRADING.md file -->
| Tests pass?   | yes
| Fixed tickets | #1342 
| License       | MIT

Proposed fix for  #1342 

Consideration: there's nothing stopping a custom DateTimeInterface implementation from, say, adding extra fields. This MR does not address that, instead treats the implementation as having the same restricted responsibility as the default implementations (eg: DateTime / DateTimeImmutable) since the ticket was aimed at issues with the two main custom date time libraries (Carbon and Chronos)

