### PR TITLE
Allow stable PHPStan PHPDoc Parser

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
         "doctrine/instantiator": "^1.0.3",
         "doctrine/lexer": "^1.1",
         "jms/metadata": "^2.0",
-        "phpstan/phpdoc-parser": "^0.4 || ^0.5"
+        "phpstan/phpdoc-parser": "^0.4 || ^0.5 || ^1.0"
     },
     "suggest": {
         "doctrine/collections": "Required if you like to use doctrine collection types as ArrayCollection.",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| Doc updated   | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | N/A
| License       | MIT

`phpstan/phpdoc-parser` now has a stable 1.0 release (where 1.0 is essentially the same as 0.5.7).  This PR will allow using the new 1.x versions.