### PR TITLE
Psalm annotations for "deserialize" method

### DIFF
--- a/src/SerializerInterface.php
+++ b/src/SerializerInterface.php
@@ -28,6 +28,10 @@ interface SerializerInterface
      * @return mixed
      *
      * @throws RuntimeException
+     *
+     * @psalm-template T
+     * @psalm-param class-string<T>|mixed $type // mixed, because "array<Foo>" doesn't match class-string<T>
+     * @psalm-return T
      */
     public function deserialize(string $data, string $type, string $format, ?DeserializationContext $context = null);
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| Doc updated   | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #1211
| License       | MIT

With this PR psalm will be able to infer returning type for `SerializerInterface::deserialize()` method, when deserializing one instance of a class, e.g. `$s->deserialize($json, A::class);`.

Other variants unfortunately still be `mixed`, so it should cause no BC breaks, but make life a bit easier

Example snippet: https://psalm.dev/r/5e0bce36c4