### PR TITLE
PHP 8.1 deprecations

### DIFF
--- a/src/Expression/Expression.php
+++ b/src/Expression/Expression.php
@@ -63,4 +63,15 @@ class Expression implements \Serializable
     {
         $this->expression = new SerializedParsedExpression(...unserialize($str));
     }
+
+    public function __serialize(): array
+    {
+        return [(string) $this->expression, $this->expression->getNodes()];
+    }
+
+    public function __unserialize(array $data): void
+    {
+        [$expression, $nodes] = $data;
+        $this->expression = new BaseExpression($expression, $nodes);
+    }
 }

--- a/tests/Fixtures/AuthorList.php
+++ b/tests/Fixtures/AuthorList.php
@@ -27,7 +27,7 @@ class AuthorList implements \IteratorAggregate, \Countable, \ArrayAccess
     /**
      * @see IteratorAggregate
      */
-    public function getIterator()
+    public function getIterator(): \Traversable
     {
         return new \ArrayIterator($this->authors);
     }
@@ -35,7 +35,7 @@ class AuthorList implements \IteratorAggregate, \Countable, \ArrayAccess
     /**
      * @see Countable
      */
-    public function count()
+    public function count(): int
     {
         return count($this->authors);
     }
@@ -43,6 +43,7 @@ class AuthorList implements \IteratorAggregate, \Countable, \ArrayAccess
     /**
      * @see ArrayAccess
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->authors[$offset]);
@@ -51,6 +52,7 @@ class AuthorList implements \IteratorAggregate, \Countable, \ArrayAccess
     /**
      * @see ArrayAccess
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->authors[$offset] ?? null;
@@ -59,6 +61,7 @@ class AuthorList implements \IteratorAggregate, \Countable, \ArrayAccess
     /**
      * @see ArrayAccess
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (null === $offset) {
@@ -71,6 +74,7 @@ class AuthorList implements \IteratorAggregate, \Countable, \ArrayAccess
     /**
      * @see ArrayAccess
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->authors[$offset]);

--- a/tests/Fixtures/Comment.php
+++ b/tests/Fixtures/Comment.php
@@ -20,7 +20,7 @@ class Comment
     #[Type(name: 'string')]
     private $text;
 
-    public function __construct(?Author $author = null, $text)
+    public function __construct(?Author $author, $text)
     {
         $this->author = $author;
         $this->text = $text;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| Doc updated   | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
| License       | MIT

* Fix deprecation warning because of deprecated `Serializeable` interface (https://wiki.php.net/rfc/phase_out_serializable)
* Fix deprecation warnings in test fixtures