### PR TITLE
Update phpstan to 1.0.2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -36,7 +36,7 @@
         "doctrine/phpcr-odm": "^1.3|^2.0",
         "jackalope/jackalope-doctrine-dbal": "^1.1.5",
         "ocramius/proxy-manager": "^1.0|^2.0",
-        "phpstan/phpstan": "^0.12.65",
+        "phpstan/phpstan": "^1.0.2",
         "phpunit/phpunit": "^8.0||^9.0",
         "psr/container": "^1.0",
         "symfony/dependency-injection": "^3.0|^4.0|^5.0|^6.0",

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -6,6 +6,7 @@ parameters:
         - '~Class Doctrine\\ODM\\MongoDB\\PersistentCollection not found~'
         - '~Class Symfony\\Component\\Translation\\TranslatorInterface not found~'
         - '#Constructor of class JMS\\Serializer\\Annotation\\.*? has an unused parameter#'
+        - '#Class JMS\\Serializer\\Annotation\\ReadOnly extends @final class JMS\\Serializer\\Annotation\\ReadOnlyProperty.#'
 
     paths:
         - %currentWorkingDirectory%/src

--- a/src/JsonSerializationVisitor.php
+++ b/src/JsonSerializationVisitor.php
@@ -22,7 +22,7 @@ final class JsonSerializationVisitor extends AbstractVisitor implements Serializ
      */
     private $dataStack;
     /**
-     * @var \ArrayObject
+     * @var \ArrayObject|array
      */
     private $data;
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| Doc updated   | no
| BC breaks?    | no <!-- don't forget updating UPGRADING.md file -->
| Deprecations? | no <!-- don't forget updating UPGRADING.md file -->
| Tests pass?   | yes
| Fixed tickets |  <!-- #-prefixed issue number(s), if any -->
| License       | MIT

Bump phpstan to 1.x, one error ignored, second fixed by fixing PHPDoc. 

>  ------ --------------------------------------------------------- 
>   Line   src/JsonSerializationVisitor.php                         
>  ------ --------------------------------------------------------- 
>   132    Variable $rs in empty() always exists and is not falsy.  
>  ------ --------------------------------------------------------- 
> 
