### PR TITLE
Fix PHP 8.1 pipeline

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
     ],
     "require": {
         "php": "^7.2||^8.0",
-        "doctrine/annotations": "^1.10.4",
+        "doctrine/annotations": "^1.13",
         "doctrine/instantiator": "^1.0.3",
         "doctrine/lexer": "^1.1",
         "jms/metadata": "^2.0",
@@ -40,7 +40,7 @@
         "phpunit/phpunit": "^8.0||^9.0",
         "psr/container": "^1.0",
         "symfony/dependency-injection": "^3.0|^4.0|^5.0|^6.0",
-        "symfony/expression-language": "^3.0|^4.0|^5.0|^6.0",
+        "symfony/expression-language": "^3.2|^4.0|^5.0|^6.0",
         "symfony/filesystem": "^3.0|^4.0|^5.0|^6.0",
         "symfony/form": "^3.0|^4.0|^5.0|^6.0",
         "symfony/translation": "^3.0|^4.0|^5.0|^6.0",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Doc updated   | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
| License       | MIT

I just wanted to check if this package is deprecation free for PHP 8.1 after https://github.com/schmittjoh/metadata/releases/tag/2.5.2

This PR fixes the remaining deprecation warnings in the PHP 8.1 pipeline by bumping some minor versions of dependencies.