### PR TITLE
Improve performance of max depth exclusions

### DIFF
--- a/src/Exclusion/DepthExclusionStrategy.php
+++ b/src/Exclusion/DepthExclusionStrategy.php
@@ -25,20 +25,17 @@ final class DepthExclusionStrategy implements ExclusionStrategyInterface
 
     private function isTooDeep(Context $context): bool
     {
-        $depth = $context->getDepth();
-        $metadataStack = $context->getMetadataStack();
+        $relativeDepth = 0;
 
-        $nthProperty = 0;
-        // iterate from the first added items to the lasts
-        for ($i = $metadataStack->count() - 1; $i > 0; $i--) {
-            $metadata = $metadataStack[$i];
-            if ($metadata instanceof PropertyMetadata) {
-                $nthProperty++;
-                $relativeDepth = $depth - $nthProperty;
+        foreach ($context->getMetadataStack() as $metadata) {
+            if (!$metadata instanceof PropertyMetadata) {
+                continue;
+            }
 
-                if (null !== $metadata->maxDepth && $relativeDepth > $metadata->maxDepth) {
-                    return true;
-                }
+            $relativeDepth++;
+
+            if (null !== $metadata->maxDepth && $relativeDepth > $metadata->maxDepth) {
+                return true;
             }
         }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| Doc updated   | no
| BC breaks?    | no <!-- don't forget updating UPGRADING.md file -->
| Deprecations? | no <!-- don't forget updating UPGRADING.md file -->
| Tests pass?   | yes
| Fixed tickets | #1347
| License       | MIT

According to the benchmarks from master serialisation with enabled max depth exclusions are around 30% slower than without it. 
Looking at the code - for each metadata we are iterating over the SplStack (which under the hood uses SplDoublyLinkedList) and accessing element based on the index. Second operation has O(n) complexity, but if we are making it for each element in list we are getting complexity like O(n!). We can easily replace it with simple traversal over the stack (complexity O(n)). 

According to performance benchmarks on my local env - it should improve performance by around 20%. Still it do it multiple times during serialisation so the performance for deep objects might be degraded - but fixing it might require deeper changes in the library. 

@aelfannir - it would be awesome if you could check it with your examples and confirm that it helps. 