### PR TITLE
Run full tests for php8.1 and static analytics

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -18,11 +18,10 @@ jobs:
           - "7.3"
           - "7.4"
           - "8.0"
+          - "8.1"
         dependencies:
           - "lowest"
           - "highest"
-        include:
-          - { php-version: '8.1', dependencies: 'highest', composer-options: '--ignore-platform-req=php' }
 
     env:
       JMS_TESTS_SHOW_DEPRECATIONS: 1

--- a/.github/workflows/static-analysis.yaml
+++ b/.github/workflows/static-analysis.yaml
@@ -16,6 +16,7 @@ jobs:
         php-version:
           - "7.4"
           - "8.0"
+          - "8.1"
 
     steps:
       - name: "Checkout code"

--- a/composer.json
+++ b/composer.json
@@ -38,7 +38,7 @@
         "ocramius/proxy-manager": "^1.0|^2.0",
         "phpbench/phpbench": "^1.0",
         "phpstan/phpstan": "^1.0.2",
-        "phpunit/phpunit": "^8.0||^9.0",
+        "phpunit/phpunit": "^8.5.21||^9.0",
         "psr/container": "^1.0",
         "symfony/dependency-injection": "^3.0|^4.0|^5.0|^6.0",
         "symfony/expression-language": "^3.2|^4.0|^5.0|^6.0",

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -4,10 +4,12 @@ parameters:
     ignoreErrors:
         - '~Class Doctrine\\Common\\Persistence\\Proxy not found~'
         - '~Class Doctrine\\ODM\\MongoDB\\PersistentCollection not found~'
-        - '~Class Symfony\\Component\\Translation\\TranslatorInterface not found~'
+        - '~Class Symfony\\(Contracts|Component)\\Translation\\TranslatorInterface not found~'
         - '#Constructor of class JMS\\Serializer\\Annotation\\.*? has an unused parameter#'
-        - '#Class JMS\\Serializer\\Annotation\\ReadOnly extends @final class JMS\\Serializer\\Annotation\\ReadOnlyProperty.#'
 
     paths:
         - %currentWorkingDirectory%/src
         - %currentWorkingDirectory%/tests
+    excludePaths:
+        - %currentWorkingDirectory%/src/Annotation/ReadOnly.php
+     


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| Doc updated   | no
| BC breaks?    | no <!-- don't forget updating UPGRADING.md file -->
| Deprecations? | no <!-- don't forget updating UPGRADING.md file -->
| Tests pass?   | yes
| Fixed tickets | 
| License       | MIT

### PHPunit 
Bumped minimal phpunit version from 8.0 to 8.21 to make it work in PHP 8.1. 

### PHPstan
Excluding ReadOnly class from analysis as it cannot be parsed in PHP8.1 (reserved keyword). 