### PR TITLE
added return native types for AttributeReader

### DIFF
--- a/src/Metadata/Driver/AttributeDriver/AttributeReader.php
+++ b/src/Metadata/Driver/AttributeDriver/AttributeReader.php
@@ -21,42 +21,42 @@ class AttributeReader implements Reader
         $this->reader = $reader;
     }
 
-    public function getClassAnnotations(ReflectionClass $class)
+    public function getClassAnnotations(ReflectionClass $class): array
     {
         $attributes = $class->getAttributes();
 
         return array_merge($this->reader->getClassAnnotations($class), $this->buildAnnotations($attributes));
     }
 
-    public function getClassAnnotation(ReflectionClass $class, $annotationName)
+    public function getClassAnnotation(ReflectionClass $class, $annotationName): ?object
     {
         $attributes = $class->getAttributes($annotationName);
 
         return $this->reader->getClassAnnotation($class, $annotationName) ?? $this->buildAnnotation($attributes);
     }
 
-    public function getMethodAnnotations(ReflectionMethod $method)
+    public function getMethodAnnotations(ReflectionMethod $method): array
     {
         $attributes = $method->getAttributes();
 
         return array_merge($this->reader->getMethodAnnotations($method), $this->buildAnnotations($attributes));
     }
 
-    public function getMethodAnnotation(ReflectionMethod $method, $annotationName)
+    public function getMethodAnnotation(ReflectionMethod $method, $annotationName): ?object
     {
         $attributes = $method->getAttributes($annotationName);
 
         return $this->reader->getClassAnnotation($method, $annotationName) ?? $this->buildAnnotation($attributes);
     }
 
-    public function getPropertyAnnotations(ReflectionProperty $property)
+    public function getPropertyAnnotations(ReflectionProperty $property): array
     {
         $attributes = $property->getAttributes();
 
         return array_merge($this->reader->getPropertyAnnotations($property), $this->buildAnnotations($attributes));
     }
 
-    public function getPropertyAnnotation(ReflectionProperty $property, $annotationName)
+    public function getPropertyAnnotation(ReflectionProperty $property, $annotationName): ?object
     {
         $attributes = $property->getAttributes($annotationName);
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| Doc updated   | no
| BC breaks?    | no
| Deprecations? | bi
| Tests pass?   | yes
| License       | MIT

added native return types for JMS\Serializer\Metadata\Driver\AttributeDriver\AttributeReader
