### PR TITLE
Composer > Define allowed plugins

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -60,7 +60,11 @@
         }
     },
     "config": {
-        "sort-packages": true
+        "sort-packages": true,
+        "allow-plugins": {
+            "composer/package-versions-deprecated": true,
+            "dealerdirect/phpcodesniffer-composer-installer": true
+        }
     },
     "extra": {
         "branch-alias": {


### PR DESCRIPTION
Needed for Composer 2.2.0 (found with 2.2.0-RC1)
```
composer self-update --preview
```
