### PR TITLE
Deprecate usage of doctrine/cache

### DIFF
--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -3,6 +3,7 @@ Unreleased
 
 - Use symfony/cache for FileSystem cache implementation instead of doctrine/cache
 - Deprecated the `@ReadOnly` annotation due to `readonly` becoming a keyword in PHP 8.1, use the `@ReadOnlyProperty` annotation instead
+- Deprecated caching annotations with `doctrine/cache` in favor of `symfony/cache` as `doctrine/cache:2.x` do not provide cache drivers anymore.  
 
 From 2.x to 3.0.0
 =================

--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -43,6 +43,12 @@ filesystem checks to see whether the data that it has cached is still valid. The
 so that you do not need to manually clear cache folders, however in production they are just unnecessary overhead. The
 debug setting allows you to make the behavior environment specific.
 
+To use file cache you need to install ``symfony/cache`` library. You can do it with the following command:
+.. code-block :: bash
+
+    composer require symfony/cache
+
+
 Adding Custom Handlers
 ----------------------
 If you have created custom handlers, you can add them to the serializer easily::

--- a/src/SerializerBuilder.php
+++ b/src/SerializerBuilder.php
@@ -631,9 +631,15 @@ final class SerializerBuilder
             if (class_exists(FilesystemAdapter::class)) {
                 $annotationsCache = new FilesystemAdapter('', 0, $this->cacheDir . '/annotations');
                 $annotationReader = new PsrCachedReader($annotationReader, $annotationsCache, $this->debug);
-            } else {
+            } elseif (class_exists(FilesystemCache::class)) {
+                \trigger_error(
+                    'Package doctrine/cache is deprecated. Please install symfony/cache instead.',
+                    E_USER_DEPRECATED
+                );
                 $annotationsCache = new FilesystemCache($this->cacheDir . '/annotations');
                 $annotationReader = new CachedReader($annotationReader, $annotationsCache, $this->debug);
+            } else {
+                throw new RuntimeException('To use cached annotation readers please install symfony/cache.');
             }
         }
 

--- a/tests/Util/DeprecationLogger.php
+++ b/tests/Util/DeprecationLogger.php
@@ -44,6 +44,6 @@ class DeprecationLogger
 
         set_error_handler(static function ($errno, $errstr, $errfile, $errline) {
             self::$instance->errors[] = [$errno, $errstr, $errfile, $errline];
-        }, E_DEPRECATED);
+        }, E_DEPRECATED | E_USER_DEPRECATED);
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| Doc updated   | yes
| BC breaks?    | no <!-- don't forget updating UPGRADING.md file -->
| Deprecations? | yes <!-- don't forget updating UPGRADING.md file -->
| Tests pass?   | yes
| Fixed tickets | #... <!-- #-prefixed issue number(s), if any -->
| License       | MIT

We have replaced `doctrine/cache` with `symfony/cache` with fallback to doctrine implementation. But `doctrine/cache:2.0` removed the drivers implementation, so in case of missing `symfony/cache` and installed `doctrine/cache:2.x` it will fail with fatal error. 
We should inform users that using doctrine cache is deprecate and we should remove this support with the next major release. 