### PR TITLE
Fix exclusions for max depth 0

### DIFF
--- a/src/Exclusion/DepthExclusionStrategy.php
+++ b/src/Exclusion/DepthExclusionStrategy.php
@@ -34,6 +34,10 @@ final class DepthExclusionStrategy implements ExclusionStrategyInterface
 
             $relativeDepth++;
 
+            if (0 === $metadata->maxDepth && $context->getMetadataStack()->top() === $metadata) {
+                continue;
+            }
+
             if (null !== $metadata->maxDepth && $relativeDepth > $metadata->maxDepth) {
                 return true;
             }

--- a/tests/Fixtures/MaxDepth/Gh1382Bar.php
+++ b/tests/Fixtures/MaxDepth/Gh1382Bar.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace JMS\Serializer\Tests\Fixtures\MaxDepth;
+
+class Gh1382Bar
+{
+    public $b = 12345;
+
+    public $c;
+}

--- a/tests/Fixtures/MaxDepth/Gh1382Baz.php
+++ b/tests/Fixtures/MaxDepth/Gh1382Baz.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace JMS\Serializer\Tests\Fixtures\MaxDepth;
+
+use JMS\Serializer\Annotation as Serializer;
+
+class Gh1382Baz
+{
+    /**
+     * @Serializer\MaxDepth(1)
+     */
+    #[Serializer\MaxDepth(depth: 1)]
+    public $a;
+
+    public function __construct()
+    {
+        $this->a = new Gh1382Bar();
+        $this->a->c = new Gh1382Bar();
+    }
+}

--- a/tests/Fixtures/MaxDepth/Gh1382Foo.php
+++ b/tests/Fixtures/MaxDepth/Gh1382Foo.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace JMS\Serializer\Tests\Fixtures\MaxDepth;
+
+use JMS\Serializer\Annotation as Serializer;
+
+class Gh1382Foo
+{
+    /**
+     * @Serializer\MaxDepth(0)
+     */
+    #[Serializer\MaxDepth(depth: 0)]
+    public $a;
+
+    public function __construct()
+    {
+        $this->a = new Gh1382Bar();
+        $this->a->c = new Gh1382Bar();
+    }
+}

--- a/tests/Serializer/BaseSerializationTest.php
+++ b/tests/Serializer/BaseSerializationTest.php
@@ -73,6 +73,8 @@ use JMS\Serializer\Tests\Fixtures\InlineParentWithEmptyChild;
 use JMS\Serializer\Tests\Fixtures\Input;
 use JMS\Serializer\Tests\Fixtures\InvalidGroupsObject;
 use JMS\Serializer\Tests\Fixtures\Log;
+use JMS\Serializer\Tests\Fixtures\MaxDepth\Gh1382Baz;
+use JMS\Serializer\Tests\Fixtures\MaxDepth\Gh1382Foo;
 use JMS\Serializer\Tests\Fixtures\MaxDepth\Gh236Foo;
 use JMS\Serializer\Tests\Fixtures\NamedDateTimeArraysObject;
 use JMS\Serializer\Tests\Fixtures\NamedDateTimeImmutableArraysObject;
@@ -1639,6 +1641,26 @@ abstract class BaseSerializationTest extends TestCase
         $serialized = $this->serialize($data, $context);
 
         self::assertEquals($this->getContent('maxdepth_skippabe_object'), $serialized);
+    }
+
+    public function testMaxDepthWithZeroDepthObject()
+    {
+        $data = new Gh1382Foo();
+
+        $context = SerializationContext::create()->enableMaxDepthChecks();
+        $serialized = $this->serialize($data, $context);
+
+        self::assertEquals($this->getContent('maxdepth_0'), $serialized);
+    }
+
+    public function testMaxDepthWithOneDepthObject()
+    {
+        $data = new Gh1382Baz();
+
+        $context = SerializationContext::create()->enableMaxDepthChecks();
+        $serialized = $this->serialize($data, $context);
+
+        self::assertEquals($this->getContent('maxdepth_1'), $serialized);
     }
 
     public function testDeserializingIntoExistingObject()

--- a/tests/Serializer/JsonSerializationTest.php
+++ b/tests/Serializer/JsonSerializationTest.php
@@ -112,6 +112,8 @@ class JsonSerializationTest extends BaseSerializationTest
             $outputs['author_expression'] = '{"my_first_name":"Ruud","last_name":"Kamphuis","id":123}';
             $outputs['author_expression_context'] = '{"first_name":"Ruud","direction":1,"name":"name"}';
             $outputs['maxdepth_skippabe_object'] = '{"a":{"xxx":"yyy"}}';
+            $outputs['maxdepth_0'] = '{"a":{}}';
+            $outputs['maxdepth_1'] = '{"a":{"b":12345}}';
             $outputs['array_objects_nullable'] = '[]';
             $outputs['type_casting'] = '{"as_string":"8"}';
             $outputs['authors_inline'] = '[{"full_name":"foo"},{"full_name":"bar"}]';

--- a/tests/Serializer/xml/maxdepth_0.xml
+++ b/tests/Serializer/xml/maxdepth_0.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<result>
+  <a/>
+</result>

--- a/tests/Serializer/xml/maxdepth_1.xml
+++ b/tests/Serializer/xml/maxdepth_1.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<result>
+  <a>
+    <b>12345</b>
+  </a>
+</result>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Doc updated   | no
| BC breaks?    | no <!-- don't forget updating UPGRADING.md file -->
| Deprecations? | no <!-- don't forget updating UPGRADING.md file -->
| Tests pass?   | yes
| Fixed tickets | #1382  <!-- #-prefixed issue number(s), if any -->
| License       | MIT

### Background
In the previous implementation of depth exclusions of object was behaving differently if depth was 0 and differently for any other value. 
- For depth `0` -  The property with excluded object exists, serialised object is empty.
- For depth higher then `1` (and deeper object tree ) -  The property with excluded object does not exists.

The thing is that previous loop was not checking annotations of the latest metadata:
```
        for ($i = $metadataStack->count() - 1; $i > 0; $i--) {
```
So metadata with max depth 0 was checked after adding the next class metadata. 
Such case was not covered by the tests. 

### Fix

1. Added test cases for max depth `0` and `1` based on the old implementation
2. Add logic to skip metadata if maxDepth = 0 and metadata is on top of the metadata stack.


