### PR TITLE
added backed enum support

### DIFF
--- a/src/GraphNavigator/DeserializationGraphNavigator.php
+++ b/src/GraphNavigator/DeserializationGraphNavigator.php
@@ -146,6 +146,10 @@ final class DeserializationGraphNavigator extends GraphNavigator implements Grap
             default:
                 $this->context->increaseDepth();
 
+                if (function_exists('enum_exists') && enum_exists($type['name'], false)) {
+                    $type = ['name' => \BackedEnum::class, 'enum' => $type['name'], 'params' => $type['params'] ?? []];
+                }
+
                 // Trigger pre-serialization callbacks, and listeners if they exist.
                 // Dispatch pre-serialization event before handling data to have ability change type in listener
                 if ($this->dispatcher->hasListeners('serializer.pre_deserialize', $type['name'], $this->format)) {

--- a/src/GraphNavigator/SerializationGraphNavigator.php
+++ b/src/GraphNavigator/SerializationGraphNavigator.php
@@ -186,8 +186,12 @@ final class SerializationGraphNavigator extends GraphNavigator
                 // If we're serializing a polymorphic type, then we'll be interested in the
                 // metadata for the actual type of the object, not the base class.
                 if (class_exists($type['name'], false) || interface_exists($type['name'], false)) {
-                    if (is_subclass_of($data, $type['name'], false) && null === $this->handlerRegistry->getHandler(GraphNavigatorInterface::DIRECTION_SERIALIZATION, $type['name'], $this->format)) {
-                        $type = ['name' => \get_class($data), 'params' => $type['params'] ?? []];
+                    if (null === $this->handlerRegistry->getHandler(GraphNavigatorInterface::DIRECTION_SERIALIZATION, $type['name'], $this->format)) {
+                        if (function_exists('enum_exists') && enum_exists($type['name'], false)) {
+                            $type = ['name' => \BackedEnum::class, 'enum' => $type['name'], 'params' => $type['params'] ?? []];
+                        } elseif (is_subclass_of($data, $type['name'], false)) {
+                            $type = ['name' => \get_class($data), 'params' => $type['params'] ?? []];
+                        }
                     }
                 }
 

--- a/src/Handler/BackedEnumHandler.php
+++ b/src/Handler/BackedEnumHandler.php
@@ -1,0 +1,92 @@
+<?php
+
+declare(strict_types=1);
+
+namespace JMS\Serializer\Handler;
+
+use JMS\Serializer\Context;
+use JMS\Serializer\SerializationContext;
+use JMS\Serializer\GraphNavigatorInterface;
+use JMS\Serializer\Visitor\SerializationVisitorInterface;
+use JMS\Serializer\Visitor\DeserializationVisitorInterface;
+
+class BackedEnumHandler implements SubscribingHandlerInterface
+{
+    /**
+     * {@inheritDoc}
+     */
+    public static function getSubscribingMethods(): array
+    {
+        $methods = [];
+        foreach (['json', 'xml'] as $format) {
+            $methods[] = [
+                'type' => \BackedEnum::class,
+                'format' => $format,
+                'direction' => GraphNavigatorInterface::DIRECTION_SERIALIZATION,
+                'method' => 'serializeBackedEnum',
+            ];
+
+            $methods[] = [
+                'type' => \BackedEnum::class,
+                'direction' => GraphNavigatorInterface::DIRECTION_DESERIALIZATION,
+                'format' => $format,
+                'method' => 'deserializeBackedEnum',
+            ];
+        }
+
+        return $methods;
+    }
+
+    /**
+     * @param SerializationVisitorInterface $visitor
+     * @param \BackedEnum                   $object
+     * @param array                         $type
+     * @param SerializationContext          $context
+     *
+     * @return null|string|int
+     */
+    public function serializeBackedEnum(SerializationVisitorInterface $visitor, $object, array $type, Context $context)
+    {
+        $value = $object->value;
+        if ('int' === $this->getValueType($type, $context)) {
+            return $visitor->visitInteger($value, $type);
+        }
+
+        return $visitor->visitString($value, $type);
+    }
+
+    /**
+     * @param DeserializationVisitorInterface $visitor
+     * @param string|int                      $value
+     * @param array                           $type
+     * @param Context                         $context
+     *
+     * @return null|\BackedEnum
+     */
+    public function deserializeBackedEnum(DeserializationVisitorInterface $visitor, $value, array $type, Context $context)
+    {
+        if ('int' === $this->getValueType($type, $context)) {
+            $value = $visitor->visitInteger($value, $type);
+        } else {
+            $value = $visitor->visitString($value, $type);
+        }
+
+        return $this->tryFrom($type, $value);
+    }
+
+    /**
+     * @param array           $type
+     * @param null|int|string $value
+     *
+     * @return null|\BackedEnum
+     */
+    protected function tryFrom(array $type, $value)
+    {
+        return $type['enum']::tryFrom($value);
+    }
+
+    protected function getValueType(array $type, Context $context): string
+    {
+        return $context->getMetadataFactory()->getMetadataForClass($type['enum'])->propertyMetadata['value']->type['name'];
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| Doc updated   | no
| BC breaks?    | yes(?)
| Deprecations? | no
| Tests pass?   | TODO
| Fixed tickets | #1373
| License       | MIT

This is my proposal for a serialization implementation for sets. I'm ready to listen to suggestions and make changes, It may not be perfect, but it works. :)

Backward compatibility will be broken as the structure of the serialized enum will be changed from `{"enum":{"name":"NAME", "value":"VALUE"}}` to `{"enum":"VALUE"}` for json, and for xml `<enum><name><![CDATA[NAME]]></name><value><![CDATA[VALUE]]></value></enum>`.

<img width="344" alt="Screenshot 2021-12-28 at 23 11 01" src="https://user-images.githubusercontent.com/16158349/147607406-04bc4604-48a9-4ab1-8e35-25b3c47a49e4.png">