### PR TITLE
Fix deprecation

### DIFF
--- a/src/Type/Lexer.php
+++ b/src/Type/Lexer.php
@@ -53,7 +53,7 @@ final class Lexer extends AbstractLexer implements ParserInterface
     }
 
     /**
-     * {{@inheritDoc}}
+     * {@inheritDoc}
      */
     protected function getType(&$value)
     {


### PR DESCRIPTION
I think this is because the PHPDoc is invalid. 

Symfony PHPUnit Bridge reports:
```
Method "Doctrine\Common\Lexer\AbstractLexer::getType()" might add "int|string|null" as a native return type declaration in the future. Do the same in child class "JMS\Serializer\Type\Lexer" now to avoid errors or add an explicit @return annotation to suppress this message.
```
