### PR TITLE
ArrayTransformerInterface::fromArray() DocBlock typehint to allow psalm infer correct return type

### DIFF
--- a/src/ArrayTransformerInterface.php
+++ b/src/ArrayTransformerInterface.php
@@ -26,8 +26,11 @@ interface ArrayTransformerInterface
      * Restores objects from an array structure.
      *
      * @param array $data
+     * @param class-string<T> $type
      *
-     * @return mixed this returns whatever the passed type is, typically an object or an array of objects
+     * @return T this returns whatever the passed type is, typically an object or an array of objects
+     *
+     * @template T
      */
     public function fromArray(array $data, string $type, ?DeserializationContext $context = null);
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Doc updated   | no
| BC breaks?    | Under some circumstances, It may cause psalm to emit `UnnecessaryVarAnnotation` message. But psalm itself released `UnnecessaryVarAnnotation` as a [patch-level change](https://github.com/vimeo/psalm/releases/tag/3.5.2)
| Deprecations? | no <!-- don't forget updating UPGRADING.md file -->
| Tests pass?   | yes
| License       | MIT

This PR allows to simplify this type of code:
```php
/** @var Obj $r */
$r = $serializer->fromArray($arr, Obj::class);
return $r;
```
to
```php
return $serializer->fromArray($arr, Obj::class);
```
I don't know how to test it automatically, but hope it can be merged without auto-tests.


Thank you for this great library.
