### PR TITLE
Add a handler supporting `symfony/uid`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,6 +26,7 @@
     "suggest": {
         "doctrine/collections": "Required if you like to use doctrine collection types as ArrayCollection.",
         "symfony/cache": "Required if you like to use cache functionality.",
+        "symfony/uid": "Required if you'd like to serialize UID objects.",
         "symfony/yaml": "Required if you'd like to use the YAML metadata format."
     },
     "require-dev": {
@@ -45,6 +46,7 @@
         "symfony/filesystem": "^3.0|^4.0|^5.0|^6.0",
         "symfony/form": "^3.0|^4.0|^5.0|^6.0",
         "symfony/translation": "^3.0|^4.0|^5.0|^6.0",
+        "symfony/uid": "^5.1|^6.0",
         "symfony/validator": "^3.1.9|^4.0|^5.0|^6.0",
         "symfony/yaml": "^3.3|^4.0|^5.0|^6.0",
         "twig/twig": "~1.34|~2.4|^3.0"

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -27,9 +27,21 @@
             <group>performance</group>
         </exclude>
     </groups>
+
+    <!-- PHPUnit <9 coverage filters -->
     <filter>
         <whitelist>
             <directory>src</directory>
         </whitelist>
     </filter>
+
+    <!-- PHPUnit >=9 coverage filters -->
+    <coverage processUncoveredFiles="true">
+        <include>
+            <directory suffix=".php">./src</directory>
+        </include>
+        <exclude>
+            <file>./src/Annotation/ReadOnly.php</file>
+        </exclude>
+    </coverage>
 </phpunit>

--- a/src/Handler/SymfonyUidHandler.php
+++ b/src/Handler/SymfonyUidHandler.php
@@ -1,0 +1,167 @@
+<?php
+
+declare(strict_types=1);
+
+namespace JMS\Serializer\Handler;
+
+use JMS\Serializer\DeserializationContext;
+use JMS\Serializer\Exception\InvalidArgumentException;
+use JMS\Serializer\GraphNavigatorInterface;
+use JMS\Serializer\SerializationContext;
+use JMS\Serializer\Visitor\DeserializationVisitorInterface;
+use JMS\Serializer\Visitor\SerializationVisitorInterface;
+use JMS\Serializer\XmlSerializationVisitor;
+use Symfony\Component\Uid\AbstractUid;
+use Symfony\Component\Uid\Ulid;
+use Symfony\Component\Uid\UuidV1;
+use Symfony\Component\Uid\UuidV3;
+use Symfony\Component\Uid\UuidV4;
+use Symfony\Component\Uid\UuidV5;
+use Symfony\Component\Uid\UuidV6;
+
+final class SymfonyUidHandler implements SubscribingHandlerInterface
+{
+    public const FORMAT_BASE32    = 'base32';
+    public const FORMAT_BASE58    = 'base58';
+    public const FORMAT_CANONICAL = 'canonical';
+    public const FORMAT_RFC4122   = 'rfc4122';
+
+    private const UID_CLASSES = [
+        Ulid::class,
+        UuidV1::class,
+        UuidV3::class,
+        UuidV4::class,
+        UuidV5::class,
+        UuidV6::class,
+    ];
+
+    /**
+     * @var string
+     * @phpstan-var self::FORMAT_*
+     */
+    private $defaultFormat;
+
+    /**
+     * @var bool
+     */
+    private $xmlCData;
+
+    public function __construct(string $defaultFormat = self::FORMAT_CANONICAL, bool $xmlCData = true)
+    {
+        $this->defaultFormat = $defaultFormat;
+        $this->xmlCData = $xmlCData;
+    }
+
+    public static function getSubscribingMethods(): array
+    {
+        $methods = [];
+        $formats = ['json', 'xml'];
+
+        foreach ($formats as $format) {
+            foreach (self::UID_CLASSES as $class) {
+                $methods[] = [
+                    'direction' => GraphNavigatorInterface::DIRECTION_SERIALIZATION,
+                    'format'    => $format,
+                    'type'      => $class,
+                    'method'    => 'serializeUid',
+                ];
+
+                $methods[] = [
+                    'direction' => GraphNavigatorInterface::DIRECTION_DESERIALIZATION,
+                    'format'    => $format,
+                    'type'      => $class,
+                    'method'    => 'deserializeUidFrom' . ucfirst($format),
+                ];
+            }
+        }
+
+        return $methods;
+    }
+
+    /**
+     * @phpstan-param array{name: class-string<AbstractUid>, params: array} $type
+     */
+    public function deserializeUidFromJson(DeserializationVisitorInterface $visitor, ?string $data, array $type, DeserializationContext $context): ?AbstractUid
+    {
+        if (null === $data) {
+            return null;
+        }
+
+        return $this->deserializeUid($data, $type);
+    }
+
+    /**
+     * @phpstan-param array{name: class-string<AbstractUid>, params: array} $type
+     */
+    public function deserializeUidFromXml(DeserializationVisitorInterface $visitor, \SimpleXMLElement $data, array $type, DeserializationContext $context): ?AbstractUid
+    {
+        if ($this->isDataXmlNull($data)) {
+            return null;
+        }
+
+        return $this->deserializeUid((string) $data, $type);
+    }
+
+    /**
+     * @phpstan-param array{name: class-string<AbstractUid>, params: array} $type
+     */
+    private function deserializeUid(string $data, array $type): ?AbstractUid
+    {
+        /** @var class-string<AbstractUid> $uidClass */
+        $uidClass = $type['name'];
+
+        try {
+            return $uidClass::fromString($data);
+        } catch (\InvalidArgumentException | \TypeError $exception) {
+            throw new InvalidArgumentException(sprintf('"%s" is not a valid UID string.', $data), 0, $exception);
+        }
+    }
+
+    /**
+     * @return \DOMText|string
+     *
+     * @phpstan-param array{name: class-string<AbstractUid>, params: array} $type
+     */
+    public function serializeUid(SerializationVisitorInterface $visitor, AbstractUid $uid, array $type, SerializationContext $context)
+    {
+        /** @phpstan-var self::FORMAT_* $format */
+        $format = $type['params'][0]['name'] ?? $this->defaultFormat;
+
+        switch ($format) {
+            case self::FORMAT_BASE32:
+                $serialized = $uid->toBase32();
+                break;
+
+            case self::FORMAT_BASE58:
+                $serialized = $uid->toBase58();
+                break;
+
+            case self::FORMAT_CANONICAL:
+                $serialized = (string) $uid;
+                break;
+
+            case self::FORMAT_RFC4122:
+                $serialized = $uid->toRfc4122();
+                break;
+
+            default:
+                throw new InvalidArgumentException(sprintf('The "%s" format is not valid.', $format));
+        }
+
+        if ($visitor instanceof XmlSerializationVisitor && false === $this->xmlCData) {
+            return $visitor->visitSimpleString($serialized, $type);
+        }
+
+        return $visitor->visitString($serialized, $type);
+    }
+
+    /**
+     * @param mixed $data
+     */
+    private function isDataXmlNull($data): bool
+    {
+        $attributes = $data->attributes('xsi', true);
+
+        return isset($attributes['nil'][0]) && 'true' === (string) $attributes['nil'][0];
+    }
+}

--- a/tests/Handler/SymfonyUidHandlerTest.php
+++ b/tests/Handler/SymfonyUidHandlerTest.php
@@ -1,0 +1,134 @@
+<?php
+
+declare(strict_types=1);
+
+namespace JMS\Serializer\Tests\Handler;
+
+use JMS\Serializer\EventDispatcher\EventDispatcher;
+use JMS\Serializer\Exception\InvalidArgumentException;
+use JMS\Serializer\Handler\HandlerRegistry;
+use JMS\Serializer\Handler\SymfonyUidHandler;
+use JMS\Serializer\SerializerBuilder;
+use JMS\Serializer\SerializerInterface;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Uid\AbstractUid;
+use Symfony\Component\Uid\Ulid;
+use Symfony\Component\Uid\Uuid;
+use Symfony\Component\Uid\UuidV1;
+use Symfony\Component\Uid\UuidV3;
+use Symfony\Component\Uid\UuidV4;
+use Symfony\Component\Uid\UuidV5;
+use Symfony\Component\Uid\UuidV6;
+
+final class SymfonyUidHandlerTest extends TestCase
+{
+    public function dataUid(): \Generator
+    {
+        yield sprintf('%s instance', Ulid::class) => [new Ulid()];
+        yield sprintf('%s instance', UuidV1::class) => [Uuid::v1()];
+        yield sprintf('%s instance', UuidV3::class) => [Uuid::v3(Uuid::v4(), 'serializer-test')];
+        yield sprintf('%s instance', UuidV4::class) => [Uuid::v4()];
+        yield sprintf('%s instance', UuidV5::class) => [Uuid::v5(Uuid::v4(), 'serializer-test')];
+        yield sprintf('%s instance', UuidV6::class) => [Uuid::v6()];
+    }
+
+    /**
+     * @dataProvider dataUid
+     */
+    public function testSerializeUidToJson(AbstractUid $uid): void
+    {
+        self::assertJsonStringEqualsJsonString(
+            sprintf('"%s"', (string) $uid),
+            $this->createSerializer()->serialize($uid, 'json', null, AbstractUid::class)
+        );
+    }
+
+    /**
+     * @dataProvider dataUid
+     */
+    public function testSerializeUidToXmlWithCData(AbstractUid $uid): void
+    {
+        self::assertXmlStringEqualsXmlString(
+            sprintf('<?xml version="1.0" encoding="UTF-8"?><result>%s</result>', (string) $uid),
+            $this->createSerializer()->serialize($uid, 'xml', null, AbstractUid::class)
+        );
+    }
+
+    /**
+     * @dataProvider dataUid
+     */
+    public function testSerializeUidToXmlWithoutCData(AbstractUid $uid): void
+    {
+        self::assertXmlStringEqualsXmlString(
+            sprintf('<?xml version="1.0" encoding="UTF-8"?><result>%s</result>', (string) $uid),
+            $this->createSerializer(false)->serialize($uid, 'xml', null, AbstractUid::class)
+        );
+    }
+
+    public function testSerializeUidToBase32(): void
+    {
+        $uid = Uuid::v4();
+
+        self::assertJsonStringEqualsJsonString(
+            sprintf('"%s"', $uid->toBase32()),
+            $this->createSerializer()->serialize($uid, 'json', null, sprintf('%s<%s>', AbstractUid::class, SymfonyUidHandler::FORMAT_BASE32))
+        );
+    }
+
+    public function testSerializeUidToBase58(): void
+    {
+        $uid = Uuid::v4();
+
+        self::assertJsonStringEqualsJsonString(
+            sprintf('"%s"', $uid->toBase58()),
+            $this->createSerializer()->serialize($uid, 'json', null, sprintf('%s<%s>', AbstractUid::class, SymfonyUidHandler::FORMAT_BASE58))
+        );
+    }
+
+    public function testSerializeUidToRfc4122(): void
+    {
+        $uid = Uuid::v4();
+
+        self::assertJsonStringEqualsJsonString(
+            sprintf('"%s"', $uid->toRfc4122()),
+            $this->createSerializer()->serialize($uid, 'json', null, sprintf('%s<%s>', AbstractUid::class, SymfonyUidHandler::FORMAT_RFC4122))
+        );
+    }
+
+    public function testSerializeUidRejectsInvalidFormat(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('The "unknown" format is not valid.');
+
+        $this->createSerializer()->serialize(Uuid::v4(), 'json', null, sprintf('%s<unknown>', AbstractUid::class));
+    }
+
+    /**
+     * @dataProvider dataUid
+     */
+    public function testDeserializeUidFromJson(AbstractUid $uid): void
+    {
+        self::assertTrue($uid->equals($this->createSerializer()->deserialize(sprintf('"%s"', (string) $uid), \get_class($uid), 'json')));
+    }
+
+    /**
+     * @dataProvider dataUid
+     */
+    public function testDeserializeUidFromXml(AbstractUid $uid): void
+    {
+        self::assertTrue($uid->equals($this->createSerializer()->deserialize(sprintf('<?xml version="1.0" encoding="UTF-8"?><result>%s</result>', (string) $uid), \get_class($uid), 'xml')));
+    }
+
+    public function testDeserializeNullUidFromJson(): void
+    {
+        self::assertNull($this->createSerializer()->deserialize(json_encode(null), UuidV4::class, 'json'));
+    }
+
+    private function createSerializer(bool $xmlCData = true): SerializerInterface
+    {
+        $registry = new HandlerRegistry();
+        $registry->registerSubscribingHandler(new SymfonyUidHandler(SymfonyUidHandler::FORMAT_CANONICAL, $xmlCData));
+
+        return SerializerBuilder::create($registry, new EventDispatcher())->build();
+    }
+}

--- a/tests/Serializer/BaseSerializationTest.php
+++ b/tests/Serializer/BaseSerializationTest.php
@@ -27,6 +27,7 @@ use JMS\Serializer\Handler\HandlerRegistry;
 use JMS\Serializer\Handler\HandlerRegistryInterface;
 use JMS\Serializer\Handler\IteratorHandler;
 use JMS\Serializer\Handler\StdClassHandler;
+use JMS\Serializer\Handler\SymfonyUidHandler;
 use JMS\Serializer\Metadata\Driver\TypedPropertiesDriver;
 use JMS\Serializer\SerializationContext;
 use JMS\Serializer\Serializer;
@@ -132,6 +133,8 @@ use Symfony\Component\Form\FormConfigBuilder;
 use Symfony\Component\Form\FormError;
 use Symfony\Component\Form\FormFactoryBuilder;
 use Symfony\Component\Translation\IdentityTranslator;
+use Symfony\Component\Uid\Uuid;
+use Symfony\Component\Uid\UuidV4;
 use Symfony\Component\Validator\ConstraintViolation;
 use Symfony\Component\Validator\ConstraintViolationList;
 
@@ -920,6 +923,20 @@ abstract class BaseSerializationTest extends TestCase
             self::assertFalse($this->getField($deserialized, 'reviewed'));
             self::assertEquals(new ArrayCollection(), $this->getField($deserialized, 'comments'));
             self::assertEquals(null, $this->getField($deserialized, 'author'));
+        }
+    }
+
+    public function testSymfonyUid()
+    {
+        $uid = Uuid::fromString('66b3177c-e03b-4a22-9dee-ddd7d37a04d5');
+
+        self::assertEquals($this->getContent('uid'), $this->serialize($uid));
+
+        if ($this->hasDeserializer()) {
+            $deserialized = $this->deserialize($this->getContent('uid'), UuidV4::class);
+
+            self::assertInstanceOf(UuidV4::class, $deserialized);
+            self::assertTrue($uid->equals($deserialized));
         }
     }
 
@@ -1997,6 +2014,7 @@ abstract class BaseSerializationTest extends TestCase
         $this->handlerRegistry->registerSubscribingHandler(new FormErrorHandler(new IdentityTranslator()));
         $this->handlerRegistry->registerSubscribingHandler(new ArrayCollectionHandler());
         $this->handlerRegistry->registerSubscribingHandler(new IteratorHandler());
+        $this->handlerRegistry->registerSubscribingHandler(new SymfonyUidHandler());
         $this->handlerRegistry->registerHandler(
             GraphNavigatorInterface::DIRECTION_SERIALIZATION,
             'AuthorList',

--- a/tests/Serializer/JsonSerializationTest.php
+++ b/tests/Serializer/JsonSerializationTest.php
@@ -138,6 +138,7 @@ class JsonSerializationTest extends BaseSerializationTest
             $outputs['typed_props'] = '{"id":1,"role":{"id":5},"vehicle":{"type":"car"},"created":"2010-10-01T00:00:00+00:00","updated":"2011-10-01T00:00:00+00:00","tags":["a","b"]}';
             $outputs['custom_datetimeinterface'] = '{"custom":"2021-09-07"}';
             $outputs['data_integer'] = '{"data":10000}';
+            $outputs['uid'] = '"66b3177c-e03b-4a22-9dee-ddd7d37a04d5"';
         }
 
         if (!isset($outputs[$key])) {

--- a/tests/Serializer/xml/uid.xml
+++ b/tests/Serializer/xml/uid.xml
@@ -1,0 +1,2 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<result><![CDATA[66b3177c-e03b-4a22-9dee-ddd7d37a04d5]]></result>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| Doc updated   | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | N/A
| License       | MIT

I needed to be able to serialize objects from the `symfony/uid` component in one of my apps, so I figured I'd share the handler I wrote here.