### PR TITLE
Enum deserialization support

### DIFF
--- a/src/Construction/UnserializeObjectConstructor.php
+++ b/src/Construction/UnserializeObjectConstructor.php
@@ -19,6 +19,10 @@ final class UnserializeObjectConstructor implements ObjectConstructorInterface
      */
     public function construct(DeserializationVisitorInterface $visitor, ClassMetadata $metadata, $data, array $type, DeserializationContext $context): ?object
     {
+        if ($metadata->isEnum) {
+            return (new \ReflectionEnum($type['name']))->getCase($data['name'])->getValue();
+        }
+
         return $this->getInstantiator()->instantiate($metadata->name);
     }
 

--- a/src/GraphNavigator/DeserializationGraphNavigator.php
+++ b/src/GraphNavigator/DeserializationGraphNavigator.php
@@ -198,6 +198,10 @@ final class DeserializationGraphNavigator extends GraphNavigator implements Grap
 
                 $this->visitor->startVisitingObject($metadata, $object, $type);
                 foreach ($metadata->propertyMetadata as $propertyMetadata) {
+                    if ($metadata->isEnum) {
+                        continue;
+                    }
+
                     if (null !== $this->exclusionStrategy && $this->exclusionStrategy->shouldSkipProperty($propertyMetadata, $this->context)) {
                         continue;
                     }

--- a/src/Metadata/ClassMetadata.php
+++ b/src/Metadata/ClassMetadata.php
@@ -85,6 +85,13 @@ class ClassMetadata extends MergeableClassMetadata
     public $isMap = false;
 
     /**
+     * @internal
+     *
+     * @var bool
+     */
+    public $isEnum = false;
+
+    /**
      * @var bool
      */
     public $discriminatorDisabled = false;

--- a/src/Metadata/ClassMetadata.php
+++ b/src/Metadata/ClassMetadata.php
@@ -231,6 +231,7 @@ class ClassMetadata extends MergeableClassMetadata
 
         $this->isMap = $object->isMap;
         $this->isList = $object->isList;
+        $this->isEnum = $object->isEnum;
 
         $this->xmlNamespaces = array_merge($this->xmlNamespaces, $object->xmlNamespaces);
 
@@ -319,6 +320,7 @@ class ClassMetadata extends MergeableClassMetadata
             $this->xmlRootPrefix,
             $this->isList,
             $this->isMap,
+            $this->isEnum,
             parent::serializeToArray(),
         ];
     }
@@ -349,6 +351,7 @@ class ClassMetadata extends MergeableClassMetadata
             $this->xmlRootPrefix,
             $this->isList,
             $this->isMap,
+            $this->isEnum,
             $parentData,
         ] = $data;
 

--- a/src/Metadata/Driver/AnnotationDriver.php
+++ b/src/Metadata/Driver/AnnotationDriver.php
@@ -77,6 +77,7 @@ class AnnotationDriver implements DriverInterface
     public function loadMetadataForClass(\ReflectionClass $class): ?BaseClassMetadata
     {
         $classMetadata = new ClassMetadata($name = $class->name);
+        $classMetadata->isEnum = method_exists($class, 'isEnum') ? $class->isEnum() : false;
         $fileResource =  $class->getFilename();
         if (false !== $fileResource) {
             $classMetadata->fileResources[] = $fileResource;

--- a/src/Metadata/Driver/NullDriver.php
+++ b/src/Metadata/Driver/NullDriver.php
@@ -13,6 +13,7 @@ class NullDriver implements DriverInterface
     public function loadMetadataForClass(\ReflectionClass $class): ?BaseClassMetadata
     {
         $classMetadata = new ClassMetadata($name = $class->name);
+        $classMetadata->isEnum = method_exists($class, 'isEnum') ? $class->isEnum() : false;
         $fileResource =  $class->getFilename();
         if (false !== $fileResource) {
             $classMetadata->fileResources[] = $fileResource;

--- a/src/Metadata/Driver/XmlDriver.php
+++ b/src/Metadata/Driver/XmlDriver.php
@@ -54,6 +54,7 @@ class XmlDriver extends AbstractFileDriver
         }
 
         $metadata = new ClassMetadata($name = $class->name);
+        $metadata->isEnum = method_exists($class, 'isEnum') ? $class->isEnum() : false;
         if (!$elems = $elem->xpath("./class[@name = '" . $name . "']")) {
             throw new InvalidMetadataException(sprintf('Could not find class %s inside XML element.', $name));
         }

--- a/src/Metadata/Driver/YamlDriver.php
+++ b/src/Metadata/Driver/YamlDriver.php
@@ -101,6 +101,7 @@ class YamlDriver extends AbstractFileDriver
 
         $config = $config[$name];
         $metadata = new ClassMetadata($name);
+        $metadata->isEnum = method_exists($class, 'isEnum') ? $class->isEnum() : false;
         $metadata->fileResources[] = $file;
         $fileResource = $class->getFilename();
         if (false !== $fileResource) {

--- a/tests/Deserializer/BaseDeserializationTest.php
+++ b/tests/Deserializer/BaseDeserializationTest.php
@@ -9,8 +9,10 @@ use JMS\Serializer\Exception\NonCastableTypeException;
 use JMS\Serializer\SerializerBuilder;
 use JMS\Serializer\Tests\Fixtures\Discriminator\Car;
 use JMS\Serializer\Tests\Fixtures\GroupsObject;
+use JMS\Serializer\Tests\Fixtures\ObjectWithPureEnum;
 use JMS\Serializer\Tests\Fixtures\Price;
 use JMS\Serializer\Tests\Fixtures\Publisher;
+use JMS\Serializer\Tests\Fixtures\PureEnum;
 use PHPUnit\Framework\TestCase;
 
 class BaseDeserializationTest extends TestCase
@@ -107,5 +109,13 @@ class BaseDeserializationTest extends TestCase
             ['you_shall_not_pass'],
             [],
         ];
+    }
+
+    public function testPureEnumMemberDeserialization(): void
+    {
+        $serializer = SerializerBuilder::create()->build();
+        $obj = new ObjectWithPureEnum(PureEnum::a);
+        $array = $serializer->toArray($obj);
+        $this->assertEquals($obj, $serializer->fromArray($array, ObjectWithPureEnum::class));
     }
 }

--- a/tests/Deserializer/BaseDeserializationTest.php
+++ b/tests/Deserializer/BaseDeserializationTest.php
@@ -7,8 +7,10 @@ namespace JMS\Serializer\Tests\Deserializer;
 use JMS\Serializer\DeserializationContext;
 use JMS\Serializer\Exception\NonCastableTypeException;
 use JMS\Serializer\SerializerBuilder;
+use JMS\Serializer\Tests\Fixtures\BackedEnum;
 use JMS\Serializer\Tests\Fixtures\Discriminator\Car;
 use JMS\Serializer\Tests\Fixtures\GroupsObject;
+use JMS\Serializer\Tests\Fixtures\ObjectWithBackedEnum;
 use JMS\Serializer\Tests\Fixtures\ObjectWithPureEnum;
 use JMS\Serializer\Tests\Fixtures\Price;
 use JMS\Serializer\Tests\Fixtures\Publisher;
@@ -117,5 +119,13 @@ class BaseDeserializationTest extends TestCase
         $obj = new ObjectWithPureEnum(PureEnum::a);
         $array = $serializer->toArray($obj);
         $this->assertEquals($obj, $serializer->fromArray($array, ObjectWithPureEnum::class));
+    }
+
+    public function testBackedEnumMemberDeserialization(): void
+    {
+        $serializer = SerializerBuilder::create()->build();
+        $obj = new ObjectWithBackedEnum(BackedEnum::a);
+        $array = $serializer->toArray($obj);
+        $this->assertEquals($obj, $serializer->fromArray($array, ObjectWithBackedEnum::class));
     }
 }

--- a/tests/Fixtures/BackedEnum.php
+++ b/tests/Fixtures/BackedEnum.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace JMS\Serializer\Tests\Fixtures;
+
+enum BackedEnum: int
+{
+    case a = 1;
+    case b = 2;
+}

--- a/tests/Fixtures/ObjectWithBackedEnum.php
+++ b/tests/Fixtures/ObjectWithBackedEnum.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace JMS\Serializer\Tests\Fixtures;
+
+final class ObjectWithBackedEnum
+{
+    private BackedEnum $enum;
+
+    public function __construct(BackedEnum $enum)
+    {
+        $this->enum = $enum;
+    }
+}

--- a/tests/Fixtures/ObjectWithPureEnum.php
+++ b/tests/Fixtures/ObjectWithPureEnum.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace JMS\Serializer\Tests\Fixtures;
+
+final class ObjectWithPureEnum
+{
+    private PureEnum $enum;
+
+    public function __construct(PureEnum $enum)
+    {
+        $this->enum = $enum;
+    }
+}

--- a/tests/Fixtures/PureEnum.php
+++ b/tests/Fixtures/PureEnum.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace JMS\Serializer\Tests\Fixtures;
+
+enum PureEnum
+{
+    case a;
+    case b;
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes/no
| New feature?  | yes
| Doc updated   | no
| BC breaks?    | no
| Deprecations? | no 
| Tests pass?   | yes
| Fixed tickets | #1392 
| License       | MIT

Please check it, hope this can be accepted. I used undocumented `ReflectionClass::isEnum()` but I hope it will be added to documentation soon.

Also, codesniffer is not support enum syntax, so it report couple errors about fixture enum.