### PR TITLE
Serialization Context Naming Strategy

### DIFF
--- a/src/GraphNavigator/SerializationGraphNavigator.php
+++ b/src/GraphNavigator/SerializationGraphNavigator.php
@@ -24,6 +24,7 @@ use JMS\Serializer\GraphNavigator;
 use JMS\Serializer\GraphNavigatorInterface;
 use JMS\Serializer\Handler\HandlerRegistryInterface;
 use JMS\Serializer\Metadata\ClassMetadata;
+use JMS\Serializer\Naming\PropertyNamingStrategyInterface;
 use JMS\Serializer\NullAwareVisitorInterface;
 use JMS\Serializer\SerializationContext;
 use JMS\Serializer\Visitor\SerializationVisitorInterface;
@@ -80,6 +81,10 @@ final class SerializationGraphNavigator extends GraphNavigator
      * @var bool
      */
     private $shouldSerializeNull;
+    /**
+     * @var PropertyNamingStrategyInterface|null
+     */
+    private $contextPropertyNamingStrategy = null;
 
     public function __construct(
         MetadataFactoryInterface $metadataFactory,
@@ -104,6 +109,7 @@ final class SerializationGraphNavigator extends GraphNavigator
 
         parent::initialize($visitor, $context);
         $this->shouldSerializeNull = $context->shouldSerializeNull();
+        $this->contextPropertyNamingStrategy = $context->getPropertyNamingStrategy();
     }
 
     /**
@@ -253,6 +259,10 @@ final class SerializationGraphNavigator extends GraphNavigator
 
                     if (null !== $this->expressionExclusionStrategy && $this->expressionExclusionStrategy->shouldSkipProperty($propertyMetadata, $this->context)) {
                         continue;
+                    }
+
+                    if ($this->contextPropertyNamingStrategy) {
+                        $propertyMetadata->serializedName = $this->contextPropertyNamingStrategy->translateName($propertyMetadata);
                     }
 
                     $v = $this->accessor->getValue($data, $propertyMetadata, $this->context);

--- a/src/SerializationContext.php
+++ b/src/SerializationContext.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace JMS\Serializer;
 
 use JMS\Serializer\Exception\RuntimeException;
+use JMS\Serializer\Naming\PropertyNamingStrategyInterface;
 use Metadata\MetadataFactoryInterface;
 
 class SerializationContext extends Context
@@ -24,6 +25,10 @@ class SerializationContext extends Context
      * @var bool
      */
     private $serializeNull = false;
+    /**
+     * @var PropertyNamingStrategyInterface|null
+     */
+    private $propertyNamingStrategy = null;
 
     public static function create(): self
     {
@@ -50,6 +55,15 @@ class SerializationContext extends Context
         return $this;
     }
 
+    public function setPropertyNamingStrategy(PropertyNamingStrategyInterface $propertyNamingStrategy): self
+    {
+        $this->assertMutable();
+
+        $this->propertyNamingStrategy = $propertyNamingStrategy;
+
+        return $this;
+    }
+
     /**
      * Returns TRUE when NULLs should be serialized
      * Returns FALSE when NULLs should not be serialized
@@ -57,6 +71,11 @@ class SerializationContext extends Context
     public function shouldSerializeNull(): bool
     {
         return $this->serializeNull;
+    }
+
+    public function getPropertyNamingStrategy(): ?PropertyNamingStrategyInterface
+    {
+        return $this->propertyNamingStrategy;
     }
 
     /**

--- a/tests/Fixtures/CustomDeserializationObjectWithInnerClass.php
+++ b/tests/Fixtures/CustomDeserializationObjectWithInnerClass.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace JMS\Serializer\Tests\Fixtures;
+
+use JMS\Serializer\Annotation\Type;
+
+class CustomDeserializationObjectWithInnerClass
+{
+    /**
+     * @Type("JMS\Serializer\Tests\Fixtures\CustomDeserializationObject")
+     */
+    #[Type(name: CustomDeserializationObject::class)]
+    private $someProperty;
+
+    public function __construct(CustomDeserializationObject $value)
+    {
+        $this->someProperty = $value;
+    }
+}

--- a/tests/SerializerBuilderTest.php
+++ b/tests/SerializerBuilderTest.php
@@ -13,6 +13,7 @@ use JMS\Serializer\Naming\IdenticalPropertyNamingStrategy;
 use JMS\Serializer\SerializationContext;
 use JMS\Serializer\SerializerBuilder;
 use JMS\Serializer\Tests\Fixtures\CustomDeserializationObject;
+use JMS\Serializer\Tests\Fixtures\CustomDeserializationObjectWithInnerClass;
 use JMS\Serializer\Tests\Fixtures\DocBlockType\Collection\Details\ProductDescription;
 use JMS\Serializer\Tests\Fixtures\DocBlockType\SingleClassFromDifferentNamespaceTypeHint;
 use JMS\Serializer\Tests\Fixtures\PersonSecret;
@@ -251,6 +252,23 @@ class SerializerBuilderTest extends TestCase
 
         $object = new CustomDeserializationObject('johny');
         $json = '{"someProperty":"johny"}';
+
+        self::assertEquals($json, $serializer->serialize($object, 'json'));
+        self::assertEquals($object, $serializer->deserialize($json, get_class($object), 'json'));
+    }
+
+    public function testSetCallbackSerializationContextWithIdenticalPropertyNamingForInnerClass()
+    {
+        $this->builder->setSerializationContextFactory(static function () {
+            return SerializationContext::create()
+                ->setPropertyNamingStrategy(new CamelCaseNamingStrategy());
+        });
+
+        $serializer = $this->builder
+            ->build();
+
+        $object = new CustomDeserializationObjectWithInnerClass(new CustomDeserializationObject('johny'));
+        $json = '{"some_property":{"some_property":"johny"}}';
 
         self::assertEquals($json, $serializer->serialize($object, 'json'));
         self::assertEquals($object, $serializer->deserialize($json, get_class($object), 'json'));


### PR DESCRIPTION
This introduces possibility to set custom naming strategy for given serialization/deserialization using SerializationContext. 

| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| Doc updated   | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT

