### PR TITLE
Fix #1396

### DIFF
--- a/src/Type/Lexer.php
+++ b/src/Type/Lexer.php
@@ -54,6 +54,7 @@ final class Lexer extends AbstractLexer implements ParserInterface
 
     /**
      * {@inheritDoc}
+     * @return int|string|null
      */
     protected function getType(&$value)
     {


### PR DESCRIPTION
Set explicit return type on Lexer::getType into annotations to remove the related deprecation error message.

| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| Doc updated   | N/A
| BC breaks?    | no 
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #1396
| License       | MIT

