### PR TITLE
Fix compatibility of ReadOnly annotation for PHP8.1

### DIFF
--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -6,10 +6,8 @@ parameters:
         - '~Class Doctrine\\ODM\\MongoDB\\PersistentCollection not found~'
         - '~Class Symfony\\(Contracts|Component)\\Translation\\TranslatorInterface not found~'
         - '#Constructor of class JMS\\Serializer\\Annotation\\.*? has an unused parameter#'
+        - '#Class JMS\\Serializer\\Annotation\\DeprecatedReadOnly extends @final class JMS\\Serializer\\Annotation\\ReadOnlyProperty.#'
 
     paths:
         - %currentWorkingDirectory%/src
         - %currentWorkingDirectory%/tests
-    excludePaths:
-        - %currentWorkingDirectory%/src/Annotation/ReadOnly.php
-     

--- a/src/Annotation/DeprecatedReadOnly.php
+++ b/src/Annotation/DeprecatedReadOnly.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace JMS\Serializer\Annotation;
+
+/**
+ * @Annotation
+ * @Target({"CLASS","PROPERTY"})
+ *
+ * @deprecated use `@ReadOnlyProperty` instead
+ */
+#[\Attribute(\Attribute::TARGET_CLASS | \Attribute::TARGET_PROPERTY)]
+final class DeprecatedReadOnly extends ReadOnlyProperty
+{
+}

--- a/src/Annotation/ReadOnly.php
+++ b/src/Annotation/ReadOnly.php
@@ -2,15 +2,4 @@
 
 declare(strict_types=1);
 
-namespace JMS\Serializer\Annotation;
-
-/**
- * @Annotation
- * @Target({"CLASS","PROPERTY"})
- *
- * @deprecated use `@ReadOnlyProperty` instead
- */
-#[\Attribute(\Attribute::TARGET_CLASS | \Attribute::TARGET_PROPERTY)]
-final class ReadOnly extends ReadOnlyProperty
-{
-}
+class_alias('JMS\Serializer\Annotation\DeprecatedReadOnly', 'JMS\Serializer\Annotation\ReadOnly');

--- a/tests/Fixtures/AuthorDeprecatedReadOnly.php
+++ b/tests/Fixtures/AuthorDeprecatedReadOnly.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace JMS\Serializer\Tests\Fixtures;
+
+use JMS\Serializer\Annotation\Accessor;
+use JMS\Serializer\Annotation\ReadOnly;
+use JMS\Serializer\Annotation\SerializedName;
+use JMS\Serializer\Annotation\Type;
+use JMS\Serializer\Annotation\XmlRoot;
+
+/**
+ * @deprecated ReadOnly annotation is deprecated
+ *
+ * @XmlRoot("author")
+ */
+#[XmlRoot(name: 'author')]
+class AuthorDeprecatedReadOnly
+{
+    /**
+     * @JMS\Serializer\Annotation\ReadOnly
+     * @SerializedName("id")
+     */
+    #[SerializedName(name: 'id')]
+    private $id;
+
+    /**
+     * @Type("string")
+     * @SerializedName("full_name")
+     * @Accessor("getName")
+     */
+    #[Type(name: 'string')]
+    #[SerializedName(name: 'full_name')]
+    #[Accessor(getter: 'getName')]
+    private $name;
+
+    public function __construct($id, $name)
+    {
+        $this->id = $id;
+        $this->name = $name;
+    }
+
+    public function getId()
+    {
+        return $this->id;
+    }
+
+    public function getName()
+    {
+        return $this->name;
+    }
+}

--- a/tests/Fixtures/AuthorDeprecatedReadOnlyPerClass.php
+++ b/tests/Fixtures/AuthorDeprecatedReadOnlyPerClass.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+namespace JMS\Serializer\Tests\Fixtures;
+
+use JMS\Serializer\Annotation\Accessor;
+use JMS\Serializer\Annotation\ReadOnly;
+use JMS\Serializer\Annotation\SerializedName;
+use JMS\Serializer\Annotation\Type;
+use JMS\Serializer\Annotation\XmlRoot;
+
+/**
+ * @deprecated ReadOnly annotation is deprecated
+ *
+ * @XmlRoot("author")
+ * @ReadOnly
+ */
+#[XmlRoot(name: 'author')]
+class AuthorDeprecatedReadOnlyPerClass
+{
+    /**
+     * @ReadOnly
+     * @SerializedName("id")
+     */
+    #[SerializedName(name: 'id')]
+    private $id;
+
+    public function __construct($id, $name)
+    {
+        $this->id = $id;
+        $this->name = $name;
+    }
+
+    /**
+     * @Type("string")
+     * @SerializedName("full_name")
+     * @Accessor("getName")
+     * @ReadOnly(false)
+     */
+    #[Type(name: 'string')]
+    #[SerializedName(name: 'full_name')]
+    #[Accessor(getter: 'getName')]
+    private $name;
+
+    public function getId()
+    {
+        return $this->id;
+    }
+
+    public function getName()
+    {
+        return $this->name;
+    }
+}

--- a/tests/Serializer/BaseSerializationTest.php
+++ b/tests/Serializer/BaseSerializationTest.php
@@ -33,6 +33,8 @@ use JMS\Serializer\Tests\Fixtures\AccessorOrderChild;
 use JMS\Serializer\Tests\Fixtures\AccessorOrderMethod;
 use JMS\Serializer\Tests\Fixtures\AccessorOrderParent;
 use JMS\Serializer\Tests\Fixtures\Author;
+use JMS\Serializer\Tests\Fixtures\AuthorDeprecatedReadOnly;
+use JMS\Serializer\Tests\Fixtures\AuthorDeprecatedReadOnlyPerClass;
 use JMS\Serializer\Tests\Fixtures\AuthorExpressionAccess;
 use JMS\Serializer\Tests\Fixtures\AuthorExpressionAccessContext;
 use JMS\Serializer\Tests\Fixtures\AuthorList;
@@ -925,9 +927,33 @@ abstract class BaseSerializationTest extends TestCase
         }
     }
 
+    public function testDeprecatedReadOnly()
+    {
+        $author = new AuthorDeprecatedReadOnly(123, 'Ruud Kamphuis');
+        self::assertEquals($this->getContent('readonly'), $this->serialize($author));
+
+        if ($this->hasDeserializer()) {
+            $deserialized = $this->deserialize($this->getContent('readonly'), get_class($author));
+            self::assertNull($this->getField($deserialized, 'id'));
+            self::assertEquals('Ruud Kamphuis', $this->getField($deserialized, 'name'));
+        }
+    }
+
     public function testReadOnlyClass()
     {
         $author = new AuthorReadOnlyPerClass(123, 'Ruud Kamphuis');
+        self::assertEquals($this->getContent('readonly'), $this->serialize($author));
+
+        if ($this->hasDeserializer()) {
+            $deserialized = $this->deserialize($this->getContent('readonly'), get_class($author));
+            self::assertNull($this->getField($deserialized, 'id'));
+            self::assertEquals('Ruud Kamphuis', $this->getField($deserialized, 'name'));
+        }
+    }
+
+    public function testDeprecatedReadOnlyClass()
+    {
+        $author = new AuthorDeprecatedReadOnlyPerClass(123, 'Ruud Kamphuis');
         self::assertEquals($this->getContent('readonly'), $this->serialize($author));
 
         if ($this->hasDeserializer()) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Doc updated   | no
| BC breaks?    | no <!-- don't forget updating UPGRADING.md file -->
| Deprecations? | yes <!-- don't forget updating UPGRADING.md file -->
| Tests pass?   | yes
| Fixed tickets | #1390 #1381
| License       | MIT

ReadOnly is reveserved keyword in PHP8.1 but we can keep old class name in PHP8.1 when using class name aliases. 
- it works as `@ReadOnly` annotation in all PHP versions
- it doesn't work as #[ReadOnly] annotation in PHP8.1

@simPod I hope that it will help for your issue with keeping backward compatibility what was important for @goetas . :) 

Best, Marcin.
