### PR TITLE
Feature/uninitialize property exception

### DIFF
--- a/src/Exception/UninitializedPropertyException.php
+++ b/src/Exception/UninitializedPropertyException.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace JMS\Serializer\Exception;
+
+class UninitializedPropertyException extends RuntimeException implements Exception
+{
+}

--- a/src/GraphNavigator/SerializationGraphNavigator.php
+++ b/src/GraphNavigator/SerializationGraphNavigator.php
@@ -17,6 +17,7 @@ use JMS\Serializer\Exception\InvalidArgumentException;
 use JMS\Serializer\Exception\NotAcceptableException;
 use JMS\Serializer\Exception\RuntimeException;
 use JMS\Serializer\Exception\SkipHandlerException;
+use JMS\Serializer\Exception\UninitializedPropertyException;
 use JMS\Serializer\Exclusion\ExpressionLanguageExclusionStrategy;
 use JMS\Serializer\Expression\ExpressionEvaluatorInterface;
 use JMS\Serializer\Functions;
@@ -256,7 +257,11 @@ final class SerializationGraphNavigator extends GraphNavigator
                         continue;
                     }
 
-                    $v = $this->accessor->getValue($data, $propertyMetadata, $this->context);
+                    try {
+                        $v = $this->accessor->getValue($data, $propertyMetadata, $this->context);
+                    } catch (UninitializedPropertyException $e) {
+                        continue;
+                    }
 
                     if (null === $v && true !== $this->shouldSerializeNull) {
                         continue;

--- a/tests/Serializer/BaseSerializationTest.php
+++ b/tests/Serializer/BaseSerializationTest.php
@@ -1462,6 +1462,30 @@ abstract class BaseSerializationTest extends TestCase
         }
     }
 
+    public function testUninitializedTypedProperties()
+    {
+        if (PHP_VERSION_ID < 70400) {
+            $this->markTestSkipped(sprintf('%s requires PHP 7.4', __METHOD__));
+        }
+
+        $builder = SerializerBuilder::create($this->handlerRegistry, $this->dispatcher);
+        $builder->includeInterfaceMetadata(true);
+        $this->serializer = $builder->build();
+
+        $user = new TypedProperties\User();
+        $user->id = 1;
+        $role = new TypedProperties\Role();
+        $user->role = $role;
+
+        // Ensure uninitialized typed property exists
+        $reflectionProp = new \ReflectionProperty($user, 'vehicle');
+        $this->assertFalse($reflectionProp->isInitialized($user));
+
+        $result = $this->serialize($user);
+
+        self::assertEquals($this->getContent('uninitialized_typed_props'), $result);
+    }
+
     /**
      * @doesNotPerformAssertions
      */

--- a/tests/Serializer/JsonSerializationTest.php
+++ b/tests/Serializer/JsonSerializationTest.php
@@ -136,6 +136,7 @@ class JsonSerializationTest extends BaseSerializationTest
             $outputs['user_discriminator'] = '{"entityName":"User"}';
             $outputs['user_discriminator_extended'] = '{"entityName":"ExtendedUser"}';
             $outputs['typed_props'] = '{"id":1,"role":{"id":5},"vehicle":{"type":"car"},"created":"2010-10-01T00:00:00+00:00","updated":"2011-10-01T00:00:00+00:00","tags":["a","b"]}';
+            $outputs['uninitialized_typed_props'] = '{"id":1,"role":{},"tags":[]}';
             $outputs['custom_datetimeinterface'] = '{"custom":"2021-09-07"}';
             $outputs['data_integer'] = '{"data":10000}';
         }

--- a/tests/Serializer/xml/uninitialized_typed_props.xml
+++ b/tests/Serializer/xml/uninitialized_typed_props.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<result>
+  <id>1</id>
+  <role/>
+  <tags/>
+</result>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| Doc updated   | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #1367
| License       | MIT

Catch uninitialized property PHP Error and convert it into a UninitializedPropertyException if the Error message match the defined regex.