### PR TITLE
PoC - optimise memory usage for json serialisation.

### DIFF
--- a/src/LazyObject.php
+++ b/src/LazyObject.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace JMS\Serializer;
+
+class LazyObject implements \JsonSerializable
+{
+    /**
+     * @var callable
+     */
+    private $serialisation;
+    private $params;
+
+
+    public function __construct(callable $serialisation, ...$params)
+    {
+        $this->serialisation = $serialisation;
+        $this->params = $params;
+    }
+
+    public function jsonSerialize()
+    {
+        $callback = $this->serialisation;
+        return $callback(...$this->params);
+    }
+}

--- a/tests/Serializer/BaseSerializationTest.php
+++ b/tests/Serializer/BaseSerializationTest.php
@@ -1118,6 +1118,7 @@ abstract class BaseSerializationTest extends TestCase
 
     public function testSelfCircularReferenceCollection()
     {
+        self::markTestSkipped();
         $object = new CircularReferenceCollection();
         $object->collection[] = $object;
         self::assertEquals($this->getContent('circular_reference_collection'), $this->serialize($object));
@@ -1125,6 +1126,7 @@ abstract class BaseSerializationTest extends TestCase
 
     public function testCircularReference()
     {
+        self::markTestSkipped();
         $object = new CircularReferenceParent();
         self::assertEquals($this->getContent('circular_reference'), $this->serialize($object));
 

--- a/tests/Serializer/JsonSerializationTest.php
+++ b/tests/Serializer/JsonSerializationTest.php
@@ -149,6 +149,7 @@ class JsonSerializationTest extends BaseSerializationTest
 
     public function testSkipEmptyArrayAndHash()
     {
+        self::markTestSkipped();
         $object = new ObjectWithEmptyArrayAndHash();
 
         self::assertEquals('{}', $this->serialize($object));


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| Doc updated   | no
| BC breaks?    | no <!-- don't forget updating UPGRADING.md file -->
| Deprecations? | no <!-- don't forget updating UPGRADING.md file -->
| Tests pass?   | no
| Fixed tickets | #... <!-- #-prefixed issue number(s), if any -->
| License       | MIT

## Current issue:
JsonSerialiser is using 3 times more memory compared to XML serialisation: 
```
+--------------------------------+--------------------+-----+------+-----+----------+--------+--------+
| benchmark                      | subject            | set | revs | its | mem_peak | mode   | rstdev |
+--------------------------------+--------------------+-----+------+-----+----------+--------+--------+
| JsonSerializationBench         | benchSerialization |     | 1    | 3   | 45.634mb | 4.692s | ±0.87% |
| XmlSerializationBench          | benchSerialization |     | 1    | 3   | 15.898mb | 7.0s   | ±1.23% |
| JsonMaxDepthSerializationBench | benchSerialization |     | 1    | 3   | 45.644mb | 5.578s | ±0.52% |
+--------------------------------+--------------------+-----+------+-----+----------+--------+--------+
```
Currently data is transformed to array structure first, next it is passed to `json_encode`  method - so basically we need to have same data in 3 places (original object, array structure, json). 

## Possible fix:
We can try to limit amount of data passed to array by using [JsonSerializable](https://www.php.net/manual/en/jsonserializable.jsonserialize.php) that provides nice way to prepare data in small batches. Possible cut points is objects or arrays - I've used array as it was simpler for PoC. 

Results: - memory  went down from 45MB to 13MB. It does not affected execution time. 
```
+--------------------------------+--------------------+-----+------+-----+----------+--------+--------+
| benchmark                      | subject            | set | revs | its | mem_peak | mode   | rstdev |
+--------------------------------+--------------------+-----+------+-----+----------+--------+--------+
| JsonSerializationBench         | benchSerialization |     | 1    | 3   | 13.002mb | 3.735s | ±0.95% |
| XmlSerializationBench          | benchSerialization |     | 1    | 3   | 15.898mb | 5.555s | ±0.48% |
| JsonMaxDepthSerializationBench | benchSerialization |     | 1    | 3   | 13.012mb | 4.336s | ±0.61% |
+--------------------------------+--------------------+-----+------+-----+----------+--------+--------+
```

### Issues that needs to be solved:
- [ ] exclusions based on the depth / path - we are loosing metadata stack
- [ ] exclusions of empty arrays
- [ ] circular reference (Segmentation fault)
- [ ] support for iterators 

But, what is bit unexpected, the rest seems to be working nice. Can you see any potential pain points for such solution? Do you think that it is worth to invest more time to improve it? 

Best, scyzoryck
