### PR TITLE
ignore proxy object if not in hierarchy

### DIFF
--- a/src/EventDispatcher/Subscriber/DoctrineProxySubscriber.php
+++ b/src/EventDispatcher/Subscriber/DoctrineProxySubscriber.php
@@ -37,10 +37,9 @@ final class DoctrineProxySubscriber implements EventSubscriberInterface
         $object = $event->getObject();
         $type = $event->getType();
 
-        // If the set type name is not an actual class, but a faked type for which a custom handler exists, we do not
-        // modify it with this subscriber. Also, we forgo autoloading here as an instance of this type is already created,
-        // so it must be loaded if its a real class.
-        $virtualType = !class_exists($type['name'], false);
+        // If the set type name is not an actual class, but a faked type for which a custom handler exists or
+        // object is not an instance of that class we do not modify it with this subscriber.
+        $virtualType = !class_exists($type['name']) || !$object instanceof $type['name'];
 
         if (
             $object instanceof PersistentCollection
@@ -85,12 +84,13 @@ final class DoctrineProxySubscriber implements EventSubscriberInterface
     public function onPreSerializeTypedProxy(PreSerializeEvent $event, string $eventName, string $class, string $format, EventDispatcherInterface $dispatcher): void
     {
         $type = $event->getType();
-        // is a virtual type? then there is no need to change the event name
-        if (!class_exists($type['name'], false)) {
+        $object = $event->getObject();
+
+        // is a virtual type or not an instance of? then there is no need to change the event name
+        if (!class_exists($type['name']) || !$object instanceof $type['name']) {
             return;
         }
 
-        $object = $event->getObject();
         if ($object instanceof Proxy) {
             $parentClassName = get_parent_class($object);
 

--- a/tests/Serializer/EventDispatcher/Subscriber/DoctrineProxySubscriberTest.php
+++ b/tests/Serializer/EventDispatcher/Subscriber/DoctrineProxySubscriberTest.php
@@ -76,6 +76,17 @@ class DoctrineProxySubscriberTest extends TestCase
         self::assertFalse($obj->__isInitialized());
     }
 
+    public function testProxyLoadingCanBeSkippedForClassNotInHierarchy()
+    {
+        $subscriber = new DoctrineProxySubscriber(true);
+
+        $event = $this->createEvent($obj = new SimpleObjectProxy('a', 'b'), ['name' => 'stdClass', 'params' => []]);
+        $subscriber->onPreSerialize($event);
+
+        self::assertEquals(['name' => 'stdClass', 'params' => []], $event->getType());
+        self::assertFalse($obj->__isInitialized());
+    }
+
     public function testProxyLoadingCanBeSkippedByExclusionStrategy()
     {
         $subscriber = new DoctrineProxySubscriber(false, false);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | maybe
| New feature?  | yes
| Doc updated   | no
| BC breaks?    | maybe <!-- don't forget updating UPGRADING.md file -->
| Deprecations? | no <!-- don't forget updating UPGRADING.md file -->
| Tests pass?   | will see
| Fixed tickets | #... <!-- #-prefixed issue number(s), if any -->
| License       | MIT

This is to cover a use case like this:

```PHP
class MyEntity
{

  /**
   * @Serializer\Type("App\DTO\OtherEntity")
   */
  private OtherEntity $composition;
}

```

Currently the code will only work if the class is not currently loaded (since the class_exists don't use the autoload). But if the class is already loaded (E.g. Second object that go trough that loop).

This give the option to create a handler on a existing class like this:

```PHP

 public function serializeOtherEntity(
        JsonSerializationVisitor $visitor,
        $value,
        array $type,
        Context $context
    ) {
        if (null === $value) {
            return null;
        }

        if ($value instanceof OtherEntity) {
            throw new SkipHandlerException();
        }

        return $context->getNavigator()->accept(new OtherEntity($value));
    }

```
From my point of view it's a bug fix since I would have expect this to work like this but we can consider it a new feature. It should be backward compatible since nobody would have done this since the behaviour is bugged.
