### PR TITLE
float/double add third parameter to define fixed numbers of decimals.…

### DIFF
--- a/doc/reference/annotations.rst
+++ b/doc/reference/annotations.rst
@@ -360,6 +360,11 @@ Available Types:
 |                                                            | Rounding Mode.                                   |
 |                                                            | (HALF_UP, HALF_DOWN, HALF_EVEN HALF_ODD)         |
 +------------------------------------------------------------+--------------------------------------------------+
+| double<2, 'HALF_DOWN', 2> or float<2, 'HALF_DOWN', 2>      | Primitive double with percision,                 |
+| double<2, 'HALF_DOWN', 3> or float<2, 'HALF_DOWN', 3>      | Rounding Mode and fixed decimals (default 1).    |
+|                                                            | (HALF_UP, HALF_DOWN, HALF_EVEN HALF_ODD)         |
+|                                                            | NOTE: for json the value is cast to string       |
++------------------------------------------------------------+--------------------------------------------------+
 | string                                                     | Primitive string                                 |
 +------------------------------------------------------------+--------------------------------------------------+
 | array                                                      | An array with arbitrary keys, and values.        |

--- a/doc/reference/annotations.rst
+++ b/doc/reference/annotations.rst
@@ -354,13 +354,13 @@ Available Types:
 +------------------------------------------------------------+--------------------------------------------------+
 | double or float                                            | Primitive double                                 |
 +------------------------------------------------------------+--------------------------------------------------+
-| double<2> or float<2>                                      | Primitive double with percision                  |
+| double<2> or float<2>                                      | Primitive double with precision                  |
 +------------------------------------------------------------+--------------------------------------------------+
-| double<2, 'HALF_DOWN'> or float<2, 'HALF_DOWN'>            | Primitive double with percision and              |
+| double<2, 'HALF_DOWN'> or float<2, 'HALF_DOWN'>            | Primitive double with precision and              |
 |                                                            | Rounding Mode.                                   |
 |                                                            | (HALF_UP, HALF_DOWN, HALF_EVEN HALF_ODD)         |
 +------------------------------------------------------------+--------------------------------------------------+
-| double<2, 'HALF_DOWN', 2> or float<2, 'HALF_DOWN', 2>      | Primitive double with percision,                 |
+| double<2, 'HALF_DOWN', 2> or float<2, 'HALF_DOWN', 2>      | Primitive double with precision,                 |
 | double<2, 'HALF_DOWN', 3> or float<2, 'HALF_DOWN', 3>      | Rounding Mode and fixed decimals (default 1).    |
 |                                                            | (HALF_UP, HALF_DOWN, HALF_EVEN HALF_ODD)         |
 |                                                            | NOTE: for json the value is cast to string       |

--- a/src/JsonSerializationVisitor.php
+++ b/src/JsonSerializationVisitor.php
@@ -71,11 +71,11 @@ final class JsonSerializationVisitor extends AbstractVisitor implements Serializ
     public function visitDouble(float $data, array $type)
     {
         $dataResult = $data;
-        $percision = $type['params'][0] ?? null;
-        if ($percision) {
+        $precision = $type['params'][0] ?? null;
+        if (is_int($precision)) {
             $roundMode = $type['params'][1] ?? null;
             $roundMode = $this->mapRoundMode($roundMode);
-            $dataResult = round($dataResult, $percision, $roundMode);
+            $dataResult = round($dataResult, $precision, $roundMode);
         }
 
         $decimalsNumbers = $type['params'][2] ?? null;

--- a/src/JsonSerializationVisitor.php
+++ b/src/JsonSerializationVisitor.php
@@ -70,15 +70,20 @@ final class JsonSerializationVisitor extends AbstractVisitor implements Serializ
      */
     public function visitDouble(float $data, array $type)
     {
+        $dataResult = $data;
         $percision = $type['params'][0] ?? null;
-        if (!is_int($percision)) {
-            return $data;
+        if ($percision) {
+            $roundMode = $type['params'][1] ?? null;
+            $roundMode = $this->mapRoundMode($roundMode);
+            $dataResult = round($dataResult, $percision, $roundMode);
         }
 
-        $roundMode = $type['params'][1] ?? null;
-        $roundMode = $this->mapRoundMode($roundMode);
+        $decimalsNumbers = $type['params'][2] ?? null;
+        if ($decimalsNumbers !== null) {
+            $dataResult = number_format($dataResult, $decimalsNumbers, '.', '');
+        }
 
-        return round($data, $percision, $roundMode);
+        return $dataResult;
     }
 
     /**

--- a/src/XmlSerializationVisitor.php
+++ b/src/XmlSerializationVisitor.php
@@ -180,11 +180,11 @@ final class XmlSerializationVisitor extends AbstractVisitor implements Serializa
     public function visitDouble(float $data, array $type)
     {
         $dataResult = $data;
-        $percision = $type['params'][0] ?? null;
-        if ($percision) {
+        $precision = $type['params'][0] ?? null;
+        if (is_int($precision)) {
             $roundMode = $type['params'][1] ?? null;
             $roundMode = $this->mapRoundMode($roundMode);
-            $dataResult = round($dataResult, $percision, $roundMode);
+            $dataResult = round($dataResult, $precision, $roundMode);
         }
 
         $decimalsNumbers = $type['params'][2] ?? null;

--- a/src/XmlSerializationVisitor.php
+++ b/src/XmlSerializationVisitor.php
@@ -179,14 +179,26 @@ final class XmlSerializationVisitor extends AbstractVisitor implements Serializa
      */
     public function visitDouble(float $data, array $type)
     {
+        $dataResult = $data;
         $percision = $type['params'][0] ?? null;
-        if (is_int($percision)) {
+        if ($percision) {
             $roundMode = $type['params'][1] ?? null;
             $roundMode = $this->mapRoundMode($roundMode);
-            $data = round($data, $percision, $roundMode);
+            $dataResult = round($dataResult, $percision, $roundMode);
         }
 
-        return $this->document->createTextNode(var_export((float) $data, true));
+        $decimalsNumbers = $type['params'][2] ?? null;
+        if ($decimalsNumbers === null) {
+            $parts = explode('.', (string) $dataResult);
+            if (count($parts) < 2 || !$parts[1]) {
+                $decimalsNumbers = 1;
+            }
+        }
+        if ($decimalsNumbers !== null) {
+            $dataResult = number_format($dataResult, $decimalsNumbers, '.', '');
+        }
+
+        return $this->document->createTextNode((string) $dataResult);
     }
 
     /**

--- a/tests/Fixtures/ObjectWithFloatProperty.php
+++ b/tests/Fixtures/ObjectWithFloatProperty.php
@@ -16,6 +16,13 @@ class ObjectWithFloatProperty
     private $floatingPointUnchanged;
 
     /**
+     * @Type("float<0>")
+     * @var float
+     */
+    #[Type(name: 'float<0>')]
+    private $floatingPointPrecisionZero;
+
+    /**
      * @Type("float<2,'HALF_DOWN'>")
      * @var float
      */
@@ -66,6 +73,7 @@ class ObjectWithFloatProperty
 
     public function __construct(
         float $floatingPointUnchanged,
+        float $floatingPointPrecisionZero,
         float $floatingPointHalfDown,
         float $floatingPointHalfEven,
         float $floatingPointHalfOdd,
@@ -75,6 +83,7 @@ class ObjectWithFloatProperty
         float $floatingPointFixedDecimalsMore
     ) {
         $this->floatingPointUnchanged = $floatingPointUnchanged;
+        $this->floatingPointPrecisionZero = $floatingPointPrecisionZero;
         $this->floatingPointHalfDown = $floatingPointHalfDown;
         $this->floatingPointHalfEven = $floatingPointHalfEven;
         $this->floatingPointHalfOdd = $floatingPointHalfOdd;

--- a/tests/Fixtures/ObjectWithFloatProperty.php
+++ b/tests/Fixtures/ObjectWithFloatProperty.php
@@ -43,18 +43,45 @@ class ObjectWithFloatProperty
     #[Type(name: 'double<2, "HALF_UP">')]
     private $floatingPointHalfUp;
 
+    /**
+     * @Type("double<2,null,2>")
+     * @var float
+     */
+    #[Type(name: 'double<2, null, 2>')]
+    private $floatingPointFixedDecimals;
+
+    /**
+     * @Type("double<2,null,1>")
+     * @var float
+     */
+    #[Type(name: 'double<2, null, 1>')]
+    private $floatingPointFixedDecimalsLess;
+
+    /**
+     * @Type("double<2,null,3>")
+     * @var float
+     */
+    #[Type(name: 'double<2, null, 3>')]
+    private $floatingPointFixedDecimalsMore;
+
     public function __construct(
         float $floatingPointUnchanged,
         float $floatingPointHalfDown,
         float $floatingPointHalfEven,
         float $floatingPointHalfOdd,
-        float $floatingPointHalfUp
+        float $floatingPointHalfUp,
+        float $floatingPointFixedDecimals,
+        float $floatingPointFixedDecimalsLess,
+        float $floatingPointFixedDecimalsMore
     ) {
         $this->floatingPointUnchanged = $floatingPointUnchanged;
         $this->floatingPointHalfDown = $floatingPointHalfDown;
         $this->floatingPointHalfEven = $floatingPointHalfEven;
         $this->floatingPointHalfOdd = $floatingPointHalfOdd;
         $this->floatingPointHalfUp = $floatingPointHalfUp;
+        $this->floatingPointFixedDecimals = $floatingPointFixedDecimals;
+        $this->floatingPointFixedDecimalsLess = $floatingPointFixedDecimalsLess;
+        $this->floatingPointFixedDecimalsMore = $floatingPointFixedDecimalsMore;
     }
 
     public function getFloatingPointUnchanged(): float
@@ -80,5 +107,20 @@ class ObjectWithFloatProperty
     public function getFloatingPointHalfUp(): float
     {
         return $this->floatingPointHalfUp;
+    }
+
+    public function getFloatingPointFixedDecimals(): float
+    {
+        return $this->floatingPointFixedDecimals;
+    }
+
+    public function getFloatingPointFixedDecimalsLess(): float
+    {
+        return $this->floatingPointFixedDecimalsLess;
+    }
+
+    public function getFloatingPointFixedDecimalsMore(): float
+    {
+        return $this->floatingPointFixedDecimalsMore;
     }
 }

--- a/tests/Serializer/JsonSerializationTest.php
+++ b/tests/Serializer/JsonSerializationTest.php
@@ -440,9 +440,10 @@ class JsonSerializationTest extends BaseSerializationTest
         self::assertEquals($expected, $this->serialize($array, $context));
     }
 
-    public function testSerialisationWithPercisionForFloat(): void
+    public function testSerialisationWithPrecisionForFloat(): void
     {
         $objectWithFloat = new ObjectWithFloatProperty(
+            1.555555555,
             1.555555555,
             1.555,
             1.15,
@@ -458,6 +459,7 @@ class JsonSerializationTest extends BaseSerializationTest
         static::assertEquals(
             '{'
             . '"floating_point_unchanged":1.555555555,'
+            . '"floating_point_precision_zero":2.0,'
             . '"floating_point_half_down":1.55,'
             . '"floating_point_half_even":1.2,'
             . '"floating_point_half_odd":1.1,'

--- a/tests/Serializer/JsonSerializationTest.php
+++ b/tests/Serializer/JsonSerializationTest.php
@@ -447,6 +447,9 @@ class JsonSerializationTest extends BaseSerializationTest
             1.555,
             1.15,
             1.15,
+            1.555,
+            1.5,
+            1.555,
             1.555
         );
 
@@ -458,7 +461,10 @@ class JsonSerializationTest extends BaseSerializationTest
             . '"floating_point_half_down":1.55,'
             . '"floating_point_half_even":1.2,'
             . '"floating_point_half_odd":1.1,'
-            . '"floating_point_half_up":1.56'
+            . '"floating_point_half_up":1.56,'
+            . '"floating_point_fixed_decimals":"1.50",'
+            . '"floating_point_fixed_decimals_less":"1.6",'
+            . '"floating_point_fixed_decimals_more":"1.560"'
             . '}',
             $result
         );

--- a/tests/Serializer/XmlSerializationTest.php
+++ b/tests/Serializer/XmlSerializationTest.php
@@ -577,6 +577,9 @@ class XmlSerializationTest extends BaseSerializationTest
             1.555,
             1.15,
             1.15,
+            1.555,
+            1.5,
+            1.555,
             1.555
         );
 
@@ -590,6 +593,9 @@ class XmlSerializationTest extends BaseSerializationTest
               <floating_point_half_even>1.2</floating_point_half_even>
               <floating_point_half_odd>1.1</floating_point_half_odd>
               <floating_point_half_up>1.56</floating_point_half_up>
+              <floating_point_fixed_decimals>1.50</floating_point_fixed_decimals>
+              <floating_point_fixed_decimals_less>1.6</floating_point_fixed_decimals_less>
+              <floating_point_fixed_decimals_more>1.560</floating_point_fixed_decimals_more>
             </result>',
             $result
         );

--- a/tests/Serializer/XmlSerializationTest.php
+++ b/tests/Serializer/XmlSerializationTest.php
@@ -570,9 +570,10 @@ class XmlSerializationTest extends BaseSerializationTest
         setlocale(LC_ALL, $locale);
     }
 
-    public function testSerialisationWithPercisionForFloat(): void
+    public function testSerialisationWithPrecisionForFloat(): void
     {
         $objectWithFloat = new ObjectWithFloatProperty(
+            1.555555555,
             1.555555555,
             1.555,
             1.15,
@@ -589,6 +590,7 @@ class XmlSerializationTest extends BaseSerializationTest
             '<?xml version="1.0" encoding="UTF-8"?>
             <result>
               <floating_point_unchanged>1.555555555</floating_point_unchanged>
+              <floating_point_precision_zero>2.0</floating_point_precision_zero>
               <floating_point_half_down>1.55</floating_point_half_down>
               <floating_point_half_even>1.2</floating_point_half_even>
               <floating_point_half_odd>1.1</floating_point_half_odd>


### PR DESCRIPTION
… In json this param force to cast the result as a string. fix #1415

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | yes
| Doc updated   | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #1415
| License       | MIT

