### PR TITLE
Fixed "PHP 8 support" header in annotations documentation

### DIFF
--- a/doc/reference/annotations.rst
+++ b/doc/reference/annotations.rst
@@ -870,7 +870,7 @@ Resulting XML:
 
 
 PHP 8 support
--------------
+~~~~~~~~~~~~~
 
 JMS serializer now supports PHP 8 attributes, with a few caveats:
 - Due to the missing support for nested annotations, the syntax for a few annotations has changed


### PR DESCRIPTION
In the current docs the PHP 8 section was a submenu of @XmlNamespace.

| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| Doc updated   | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
| License       | MIT

