### PR TITLE
fix(FormErrorHandler): add method to FormInterface

### DIFF
--- a/src/Handler/FormErrorHandler.php
+++ b/src/Handler/FormErrorHandler.php
@@ -43,6 +43,7 @@ final class FormErrorHandler implements SubscribingHandlerInterface
                 'direction' => GraphNavigatorInterface::DIRECTION_SERIALIZATION,
                 'type' => FormInterface::class,
                 'format' => $format,
+                'method' => 'serializeFormTo' . ucfirst($format),
             ];
             $methods[] = [
                 'direction' => GraphNavigatorInterface::DIRECTION_SERIALIZATION,

--- a/tests/Handler/FormErrorHandlerTest.php
+++ b/tests/Handler/FormErrorHandlerTest.php
@@ -17,6 +17,7 @@ use Symfony\Component\Form\Extension\Validator\ValidatorExtension;
 use Symfony\Component\Form\FormBuilder;
 use Symfony\Component\Form\FormError;
 use Symfony\Component\Form\FormFactoryInterface;
+use Symfony\Component\Form\FormInterface;
 use Symfony\Component\Form\Forms;
 use Symfony\Component\Translation\Translator;
 use Symfony\Component\Translation\TranslatorInterface as LegacyTranslatorInterface;
@@ -270,6 +271,21 @@ class FormErrorHandlerTest extends TestCase
         $this->invokeMethod($handler, 'getErrorMessage', [$formError]);
     }
 
+    public function testFormInterfaceCouldBeSerializeTheSameWayAsForm ()
+    {
+        foreach ( FormErrorHandler::getSubscribingMethods() as $method ){
+            if($method['type'] === FormInterface::class){
+                switch ($method['format']){
+                    case 'json':
+                        self::assertSame('serializeFormToJson',$method['method']);
+                        break;
+                    case 'xml':
+                        self::assertSame('serializeFormToXml',$method['method']);
+                        break;
+                }
+            }
+        }
+    }
     /**
      * @param string $name
      * @param EventDispatcherInterface $dispatcher


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Doc updated   | no
| BC breaks?    | no 
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #... <!-- #-prefixed issue number(s), if any -->
| License       | MIT

Since Symfony 6.1 FormErrorIterator property $form is typehint to FormInterface since https://github.com/symfony/symfony/commit/85065e4f76eb0e75163277498bbc4fadb3ae49f8 .

This PR https://github.com/schmittjoh/serializer/pull/1362 add the possibility to serialize Interface but lead to the following error
`call_user_func_array(): Argument #1 ($callback) must be a valid callback, class JMS\Serializer\Handler\FormErrorHandler does not have a method "serializeFormInterfaceTojson"`
( see also https://github.com/FriendsOfSymfony/FOSRestBundle/pull/2371 )

Adding the method option fix this issue 

