### PR TITLE
Define method for the `FormInterface` type in the `FormErrorHandler`

### DIFF
--- a/src/Handler/FormErrorHandler.php
+++ b/src/Handler/FormErrorHandler.php
@@ -43,6 +43,7 @@ final class FormErrorHandler implements SubscribingHandlerInterface
                 'direction' => GraphNavigatorInterface::DIRECTION_SERIALIZATION,
                 'type' => FormInterface::class,
                 'format' => $format,
+                'method' => 'serializeFormTo' . ucfirst($format),
             ];
             $methods[] = [
                 'direction' => GraphNavigatorInterface::DIRECTION_SERIALIZATION,


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Doc updated   | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| License       | MIT

The `HandlerRegistry` tries to [determine the method](https://github.com/schmittjoh/serializer/blob/32956d3e3e1938f8130523a94297399d2b26fea7/src/Handler/HandlerRegistry.php#L29) based on the type and format. When the type is a `FormInterface`, the resulting method would be `serializeFormInterfaceToJson`, but as this method currently does not exist in the `FormErrorHandler` an error is thrown.

Adding a proper `method` definition to the subscribing methods for the `FormInterface` type resolves this issue.