### PR TITLE
fix(ci): Python 3.6 is no longer supported

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -15,7 +15,7 @@ jobs:
       -   name: Set up Python
           uses: actions/setup-python@v2
           with:
-            python-version: 3.6
+            python-version: 3.11
       -   name: Install dependencies
           run: |
             python -m pip install --upgrade pip

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -1,3 +1,5 @@
 Sphinx==1.8.5
 git+https://github.com/fabpot/sphinx-php.git
 sphinx_rtd_theme
+Jinja2<3.0
+MarkupSafe<2.1


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Doc updated   | no
| BC breaks?    | no <!-- don't forget updating UPGRADING.md file -->
| Deprecations? | no <!-- don't forget updating UPGRADING.md file -->
| Tests pass?   | yes
| Fixed tickets | https://github.com/schmittjoh/serializer/actions/runs/3655992902
| License       | MIT

Python 3.6 is no longer supported in new Ubuntu. Let's use 3.11. 
Related to: https://github.com/actions/setup-python/issues/544

![localhost_63342_serializer_doc__build_html_usage html](https://user-images.githubusercontent.com/8014727/208443839-5f8979c9-9fff-4e9c-9d7c-d826e31a261c.png)
