### PR TITLE
Allow doctrine/lexer 2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
         "php": "^7.2||^8.0",
         "doctrine/annotations": "^1.13",
         "doctrine/instantiator": "^1.0.3",
-        "doctrine/lexer": "^1.1",
+        "doctrine/lexer": "^1.1 || ^2",
         "jms/metadata": "^2.6",
         "phpstan/phpdoc-parser": "^0.4 || ^0.5 || ^1.0"
     },


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Doc updated   | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | N/A
| License       | MIT

This PR allows the installation of `doctrine/lexer` 2.x.