### PR TITLE
Don't use the `FilesystemCache` class if it doesn't exist

### DIFF
--- a/src/SerializerBuilder.php
+++ b/src/SerializerBuilder.php
@@ -639,7 +639,7 @@ final class SerializerBuilder
             if (class_exists(FilesystemAdapter::class)) {
                 $annotationsCache = new FilesystemAdapter('', 0, $this->cacheDir . '/annotations');
                 $annotationReader = new PsrCachedReader($annotationReader, $annotationsCache, $this->debug);
-            } else {
+            } elseif (class_exists(FilesystemCache::class) && class_exists(CachedReader::class)) {
                 $annotationsCache = new FilesystemCache($this->cacheDir . '/annotations');
                 $annotationReader = new CachedReader($annotationReader, $annotationsCache, $this->debug);
             }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Doc updated   | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | no
| Fixed tickets | https://github.com/schmittjoh/serializer/pull/1445#issuecomment-1368456236
| License       | MIT

If Symfony Cache is not installed and the Doctrine Cache package is installed in version 2, we effectively cannot produce a cached annotation reader. Right now, we would run into an error because `SerializerBuilder` would attempt to create an instance of `FilesystemCache` which doesn't exist anymore.

With the proposed change, we would silently fall back to an uncached reader which might just be good enough. The alternative would be to throw an exception, telling the caller to either install Symfony Cache or turn off caching.