### PR TITLE
Handle constructor property promotion 

### DIFF
--- a/phpstan-7-4.neon.dist
+++ b/phpstan-7-4.neon.dist
@@ -15,6 +15,7 @@ parameters:
         - %currentWorkingDirectory%/tests/Fixtures/TypedProperties/UnionTypedProperties.php
         - %currentWorkingDirectory%/tests/Fixtures/TypedProperties/ConstructorPromotion/Vase.php
         - %currentWorkingDirectory%/tests/Fixtures/TypedProperties/UnionTypedProperties.php
+        - %currentWorkingDirectory%/tests/Fixtures/DocBlockType/Collection/ConstructorPropertyPromotion.php
         - %currentWorkingDirectory%/tests/Metadata/Driver/UnionTypedPropertiesDriverTest.php
         - %currentWorkingDirectory%/tests/Serializer/BaseSerializationTest.php
 

--- a/src/Metadata/Driver/DocBlockDriver/DocBlockTypeResolver.php
+++ b/src/Metadata/Driver/DocBlockDriver/DocBlockTypeResolver.php
@@ -144,7 +144,7 @@ final class DocBlockTypeResolver
             return [];
         }
 
-        $parameterName = sprintf("$%s", $parameterName);
+        $parameterName = sprintf('$%s', $parameterName);
         $types = [];
         foreach ($varTagValues as $node) {
             if ($parameterName !== $node->parameterName) {

--- a/tests/Fixtures/DocBlockType/Collection/ConstructorPropertyPromotion.php
+++ b/tests/Fixtures/DocBlockType/Collection/ConstructorPropertyPromotion.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace JMS\Serializer\Tests\Fixtures\DocBlockType\Collection;
+
+final class ConstructorPropertyPromotion
+{
+    /**
+     * @param string[] $data
+     */
+    public function __construct(
+        private array $data,
+    ) {}
+}

--- a/tests/Fixtures/DocBlockType/Collection/ConstructorPropertyPromotion.php
+++ b/tests/Fixtures/DocBlockType/Collection/ConstructorPropertyPromotion.php
@@ -11,5 +11,6 @@ final class ConstructorPropertyPromotion
      */
     public function __construct(
         private array $data,
-    ) {}
+    ) {
+    }
 }

--- a/tests/Metadata/Driver/DocBlockDriverTest.php
+++ b/tests/Metadata/Driver/DocBlockDriverTest.php
@@ -27,6 +27,7 @@ use JMS\Serializer\Tests\Fixtures\DocBlockType\Collection\CollectionOfInterfaces
 use JMS\Serializer\Tests\Fixtures\DocBlockType\Collection\CollectionOfNotExistingClasses;
 use JMS\Serializer\Tests\Fixtures\DocBlockType\Collection\CollectionOfScalars;
 use JMS\Serializer\Tests\Fixtures\DocBlockType\Collection\CollectionTypedAsGenericClass;
+use JMS\Serializer\Tests\Fixtures\DocBlockType\Collection\ConstructorPropertyPromotion;
 use JMS\Serializer\Tests\Fixtures\DocBlockType\Collection\Details\ProductColor;
 use JMS\Serializer\Tests\Fixtures\DocBlockType\Collection\Details\ProductDescription;
 use JMS\Serializer\Tests\Fixtures\DocBlockType\Collection\Details\ProductName;
@@ -354,6 +355,20 @@ class DocBlockDriverTest extends TestCase
 
         self::assertEquals(
             null,
+            $m->propertyMetadata['data']->type
+        );
+    }
+
+    public function testInferTypeForConstructorPropertyPromotion()
+    {
+        if (PHP_VERSION_ID < 80000) {
+            $this->markTestSkipped('Constructor property promotion requires PHP 8.0');
+        }
+
+        $m = $this->resolve(ConstructorPropertyPromotion::class);
+
+        self::assertEquals(
+            ['name' => "array", 'params' => [['name' => 'string', 'params' => []]]],
             $m->propertyMetadata['data']->type
         );
     }

--- a/tests/Metadata/Driver/DocBlockDriverTest.php
+++ b/tests/Metadata/Driver/DocBlockDriverTest.php
@@ -368,7 +368,7 @@ class DocBlockDriverTest extends TestCase
         $m = $this->resolve(ConstructorPropertyPromotion::class);
 
         self::assertEquals(
-            ['name' => "array", 'params' => [['name' => 'string', 'params' => []]]],
+            ['name' => 'array', 'params' => [['name' => 'string', 'params' => []]]],
             $m->propertyMetadata['data']->type
         );
     }


### PR DESCRIPTION
This PR handles constructor property promotion for docblock type resolver.

| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| Doc updated   | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
| License       | MIT

