### PR TITLE
Allow doctrine/annotations 2.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
     ],
     "require": {
         "php": "^7.2||^8.0",
-        "doctrine/annotations": "^1.13",
+        "doctrine/annotations": "^1.13 || ^2.0",
         "doctrine/instantiator": "^1.0.3",
         "doctrine/lexer": "^1.1 || ^2",
         "jms/metadata": "^2.6",

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -2,7 +2,6 @@
 
 declare(strict_types=1);
 
-use Doctrine\Common\Annotations\AnnotationRegistry;
 use JMS\Serializer\Tests\Util\DeprecationLogger;
 
 (static function () {
@@ -11,8 +10,6 @@ use JMS\Serializer\Tests\Util\DeprecationLogger;
     }
 
     require $autoloadFile;
-
-    AnnotationRegistry::registerLoader('class_exists');
 })();
 
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| Doc updated   | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | N/A
| License       | MIT

This will allow using the `doctrine/annotations` package's 2.x release with the serializer.  The only B/C issue in https://github.com/doctrine/annotations/blob/2.0.x/UPGRADE.md that looks to impact this package was already addressed by #1447 so there shouldn't be any other problems.