### PR TITLE
feat: use generic types for deserialization

### DIFF
--- a/src/SerializerInterface.php
+++ b/src/SerializerInterface.php
@@ -25,9 +25,13 @@ interface SerializerInterface
     /**
      * Deserializes the given data to the specified type.
      *
-     * @return mixed
+     * @param class-string<T> $type
+     *
+     * @return T
      *
      * @throws RuntimeException
+     *
+     * @template T
      */
     public function deserialize(string $data, string $type, string $format, ?DeserializationContext $context = null);
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| Doc updated   | no
| BC breaks?    | no <!-- don't forget updating UPGRADING.md file -->
| Deprecations? | no <!-- don't forget updating UPGRADING.md file -->
| Tests pass?   | yes
| Fixed tickets | 
| License       | MIT

It looks like right now to have a proper type hints for it required additional plugin. Inspired by: https://phpstan.org/blog/generics-by-examples it allowed to use generics for type hinting. 

### Debug file
```php
<?php

declare(strict_types=1);

namespace JMS\Serializer\Tests;

use JMS\Serializer\SerializerBuilder;
use JMS\Serializer\Tests\Fixtures\Author;


$serializer = SerializerBuilder::create()->build();
$d = $serializer->deserialize('{}', Author::class, 'json' );
\PHPStan\dumpType($d); // MyDerivative :)


$serializer = SerializerBuilder::create()->build();
$d = $serializer->deserialize('{}', Author::class . '[]', 'json' );
\PHPStan\dumpType($d); //
```
### Before
```
 ------ ----------------------------------------------------- 
  Line   PHPStanTypesTest.php                                 
 ------ ----------------------------------------------------- 
  13     Dumped type: mixed
  18     Dumped type: mixed
 ------ ----------------------------------------------------- 
```

### After
```
 ------ ----------------------------------------------------- 
  Line   PHPStanTypesTest.php                                 
 ------ ----------------------------------------------------- 
  13     Dumped type: JMS\Serializer\Tests\Fixtures\Author    
  18     Dumped type: JMS\Serializer\Tests\Fixtures\Author[]  
 ------ ----------------------------------------------------- 
```