### PR TITLE
Make doblock type resolver compatibile with newest phpdoc

### DIFF
--- a/src/Metadata/Driver/DocBlockDriver/DocBlockTypeResolver.php
+++ b/src/Metadata/Driver/DocBlockDriver/DocBlockTypeResolver.php
@@ -360,7 +360,7 @@ final class DocBlockTypeResolver
 
         foreach ($phpDocNode->children as $node) {
             if ($node instanceof PhpDocTagNode && '@phpstan-type' === $node->name) {
-                $phpstanType = $node->value->value;
+                $phpstanType = (string) $node->value;
                 preg_match_all(self::PHPSTAN_ARRAY_SHAPE, $phpstanType, $foundPhpstanArray);
                 if (isset($foundPhpstanArray[1][0]) && $foundPhpstanArray[1][0] === $typeHint) {
                     return 'array';

--- a/tests/Fixtures/DocBlockType/Phpstan/PhpstanNestedArrayShape.php
+++ b/tests/Fixtures/DocBlockType/Phpstan/PhpstanNestedArrayShape.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace JMS\Serializer\Tests\Fixtures\DocBlockType\Phpstan;
+
+/**
+ * @phpstan-type Settings array{
+ *  amount: array{type: string, value: string|null},
+ * }
+ */
+final class PhpstanNestedArrayShape
+{
+    /**
+     * @var Settings
+     */
+    public $data;
+}

--- a/tests/Metadata/Driver/DocBlockDriverTest.php
+++ b/tests/Metadata/Driver/DocBlockDriverTest.php
@@ -37,6 +37,7 @@ use JMS\Serializer\Tests\Fixtures\DocBlockType\Collection\Vehicle;
 use JMS\Serializer\Tests\Fixtures\DocBlockType\Phpstan\PhpstanArrayCollectionShape;
 use JMS\Serializer\Tests\Fixtures\DocBlockType\Phpstan\PhpstanArrayShape;
 use JMS\Serializer\Tests\Fixtures\DocBlockType\Phpstan\PhpstanMultipleArrayShapes;
+use JMS\Serializer\Tests\Fixtures\DocBlockType\Phpstan\PhpstanNestedArrayShape;
 use JMS\Serializer\Tests\Fixtures\DocBlockType\Phpstan\ProductType;
 use JMS\Serializer\Tests\Fixtures\DocBlockType\SingleClassFromDifferentNamespaceTypeHint;
 use JMS\Serializer\Tests\Fixtures\DocBlockType\SingleClassFromGlobalNamespaceTypeHint;
@@ -380,6 +381,16 @@ class DocBlockDriverTest extends TestCase
     public function testInferTypeForPhpstanArray()
     {
         $m = $this->resolve(PhpstanArrayShape::class);
+
+        self::assertEquals(
+            ['name' => 'array', 'params' => []],
+            $m->propertyMetadata['data']->type
+        );
+    }
+
+    public function testInferTypeForPhpstanNestedArrayShape()
+    {
+        $m = $this->resolve(PhpstanNestedArrayShape::class);
 
         self::assertEquals(
             ['name' => 'array', 'params' => []],


### PR DESCRIPTION
This fixes compatibility with newest version of `phpstan/phpdoc-parser`:
![Screenshot from 2023-01-06 18-36-21](https://user-images.githubusercontent.com/6060791/211067985-48698eeb-b27b-455b-a16d-b4667bfb6eb7.png)


| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Doc updated   | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
| License       | MIT

