### PR TITLE
Ignore enums in TypedPropertiesDriver

### DIFF
--- a/src/Metadata/Driver/TypedPropertiesDriver.php
+++ b/src/Metadata/Driver/TypedPropertiesDriver.php
@@ -117,6 +117,10 @@ class TypedPropertiesDriver implements DriverInterface
             return true;
         }
 
+        if (PHP_VERSION_ID >= 80100 && enum_exists($reflectionType->getName())) {
+            return false; // handled by EnumPropertiesDriver
+        }
+
         return class_exists($reflectionType->getName())
             || interface_exists($reflectionType->getName());
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  |no
| Doc updated   |no
| BC breaks?    |no 
| Deprecations? |no
| Tests pass?   | yes
| Fixed tickets | #1457
| License       | MIT

This is handled by the EnumPropertiesDriver.

If the TypedPropertiesDriver sets the type, it will be skipped by the EnumPropertiesDriver and causes deserialization to fail.
