### PR TITLE
fix: do not try to tokenize doc comment when there's none

### DIFF
--- a/src/Metadata/Driver/DocBlockDriver/DocBlockTypeResolver.php
+++ b/src/Metadata/Driver/DocBlockDriver/DocBlockTypeResolver.php
@@ -329,7 +329,15 @@ final class DocBlockTypeResolver
     {
         $docComment = $reflectionProperty->getDocComment();
         if (!$docComment && PHP_VERSION_ID >= 80000 && $reflectionProperty->isPromoted()) {
-            $docComment = $reflectionProperty->getDeclaringClass()->getConstructor()->getDocComment();
+            $constructor = $reflectionProperty->getDeclaringClass()->getConstructor();
+            if (null === $constructor) {
+                return [];
+            }
+
+            $docComment = $constructor->getDocComment();
+            if (!$docComment) {
+                return [];
+            }
 
             $tokens = $this->lexer->tokenize($docComment);
             $phpDocNode = $this->phpDocParser->parse(new TokenIterator($tokens));


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| License       | MIT

This fixes another type issues (will be covered by phpstan when we ship https://github.com/schmittjoh/serializer/pull/1446 and following PRs)