### PR TITLE
Add support for symfony/uid UUID type

### DIFF
--- a/src/Handler/SymfonyUidHandler.php
+++ b/src/Handler/SymfonyUidHandler.php
@@ -13,6 +13,7 @@ use JMS\Serializer\Visitor\SerializationVisitorInterface;
 use JMS\Serializer\XmlSerializationVisitor;
 use Symfony\Component\Uid\AbstractUid;
 use Symfony\Component\Uid\Ulid;
+use Symfony\Component\Uid\Uuid;
 use Symfony\Component\Uid\UuidV1;
 use Symfony\Component\Uid\UuidV3;
 use Symfony\Component\Uid\UuidV4;
@@ -28,6 +29,7 @@ final class SymfonyUidHandler implements SubscribingHandlerInterface
 
     private const UID_CLASSES = [
         Ulid::class,
+        Uuid::class,
         UuidV1::class,
         UuidV3::class,
         UuidV4::class,

--- a/tests/Handler/SymfonyUidHandlerTest.php
+++ b/tests/Handler/SymfonyUidHandlerTest.php
@@ -25,6 +25,7 @@ final class SymfonyUidHandlerTest extends TestCase
     public function dataUid(): \Generator
     {
         yield sprintf('%s instance', Ulid::class) => [new Ulid()];
+        yield sprintf('%s instance', Uuid::class) => [Uuid::v1()];
         yield sprintf('%s instance', UuidV1::class) => [Uuid::v1()];
         yield sprintf('%s instance', UuidV3::class) => [Uuid::v3(Uuid::v4(), 'serializer-test')];
         yield sprintf('%s instance', UuidV4::class) => [Uuid::v4()];


### PR DESCRIPTION
The SymfonyUidHandler is lacking support for the `\Symfony\Component\Uid\Uuid` super type that is available since v5.1 of the `symfony/uid` component.

Supporting this super type is helpful in situations in which an interface does not care about which exact UUID version is actually used.

| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| Doc updated   | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT

