### PR TITLE
Add support for UUIDv7 and UUIDv8 classes

### DIFF
--- a/src/Handler/SymfonyUidHandler.php
+++ b/src/Handler/SymfonyUidHandler.php
@@ -18,6 +18,8 @@ use Symfony\Component\Uid\UuidV3;
 use Symfony\Component\Uid\UuidV4;
 use Symfony\Component\Uid\UuidV5;
 use Symfony\Component\Uid\UuidV6;
+use Symfony\Component\Uid\UuidV7;
+use Symfony\Component\Uid\UuidV8;
 
 final class SymfonyUidHandler implements SubscribingHandlerInterface
 {
@@ -33,6 +35,8 @@ final class SymfonyUidHandler implements SubscribingHandlerInterface
         UuidV4::class,
         UuidV5::class,
         UuidV6::class,
+        UuidV7::class,
+        UuidV8::class,
     ];
 
     /**

--- a/tests/Handler/SymfonyUidHandlerTest.php
+++ b/tests/Handler/SymfonyUidHandlerTest.php
@@ -19,6 +19,8 @@ use Symfony\Component\Uid\UuidV3;
 use Symfony\Component\Uid\UuidV4;
 use Symfony\Component\Uid\UuidV5;
 use Symfony\Component\Uid\UuidV6;
+use Symfony\Component\Uid\UuidV7;
+use Symfony\Component\Uid\UuidV8;
 
 final class SymfonyUidHandlerTest extends TestCase
 {
@@ -30,6 +32,14 @@ final class SymfonyUidHandlerTest extends TestCase
         yield sprintf('%s instance', UuidV4::class) => [Uuid::v4()];
         yield sprintf('%s instance', UuidV5::class) => [Uuid::v5(Uuid::v4(), 'serializer-test')];
         yield sprintf('%s instance', UuidV6::class) => [Uuid::v6()];
+
+        if (class_exists(UuidV7::class)) {
+            yield sprintf('%s instance', UuidV7::class) => [Uuid::v7()];
+        }
+
+        if (class_exists(UuidV8::class)) {
+            yield sprintf('%s instance', UuidV8::class) => [Uuid::v8('216fff40-98d9-81e3-a5e2-0800200c9a66')];
+        }
     }
 
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| Doc updated   | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | N/A
| License       | MIT

Symfony 6.2 adds support for UUIDv7 and UUIDv8, this adds those classes to the serialization handler.