### PR TITLE
Create an attribute driver decoupled from the annotations driver, deprecate the annotation based attribute reader

### DIFF
--- a/src/Metadata/Driver/AnnotationDriver.php
+++ b/src/Metadata/Driver/AnnotationDriver.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace JMS\Serializer\Metadata\Driver;
+
+use Doctrine\Common\Annotations\Reader;
+use JMS\Serializer\Expression\CompilableExpressionEvaluatorInterface;
+use JMS\Serializer\Naming\PropertyNamingStrategyInterface;
+use JMS\Serializer\Type\ParserInterface;
+
+class AnnotationDriver extends AnnotationOrAttributeDriver
+{
+    /**
+     * @var Reader
+     */
+    private $reader;
+
+    public function __construct(Reader $reader, PropertyNamingStrategyInterface $namingStrategy, ?ParserInterface $typeParser = null, ?CompilableExpressionEvaluatorInterface $expressionEvaluator = null)
+    {
+        parent::__construct($namingStrategy, $typeParser, $expressionEvaluator);
+
+        $this->reader = $reader;
+    }
+
+    /**
+     * @return list<object>
+     */
+    protected function getClassAnnotations(\ReflectionClass $class): array
+    {
+        return $this->reader->getClassAnnotations($class);
+    }
+
+    /**
+     * @return list<object>
+     */
+    protected function getMethodAnnotations(\ReflectionMethod $method): array
+    {
+        return $this->reader->getMethodAnnotations($method);
+    }
+
+    /**
+     * @return list<object>
+     */
+    protected function getPropertyAnnotations(\ReflectionProperty $property): array
+    {
+        return $this->reader->getPropertyAnnotations($property);
+    }
+}

--- a/src/Metadata/Driver/AttributeDriver.php
+++ b/src/Metadata/Driver/AttributeDriver.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace JMS\Serializer\Metadata\Driver;
+
+class AttributeDriver extends AnnotationOrAttributeDriver
+{
+    /**
+     * @return list<object>
+     */
+    protected function getClassAnnotations(\ReflectionClass $class): array
+    {
+        return array_map(
+            static function (\ReflectionAttribute $attribute): object {
+                return $attribute->newInstance();
+            },
+            $class->getAttributes()
+        );
+    }
+
+    /**
+     * @return list<object>
+     */
+    protected function getMethodAnnotations(\ReflectionMethod $method): array
+    {
+        return array_map(
+            static function (\ReflectionAttribute $attribute): object {
+                return $attribute->newInstance();
+            },
+            $method->getAttributes()
+        );
+    }
+
+    /**
+     * @return list<object>
+     */
+    protected function getPropertyAnnotations(\ReflectionProperty $property): array
+    {
+        return array_map(
+            static function (\ReflectionAttribute $attribute): object {
+                return $attribute->newInstance();
+            },
+            $property->getAttributes()
+        );
+    }
+}

--- a/src/Metadata/Driver/AttributeDriver/AttributeReader.php
+++ b/src/Metadata/Driver/AttributeDriver/AttributeReader.php
@@ -9,6 +9,9 @@ use ReflectionClass;
 use ReflectionMethod;
 use ReflectionProperty;
 
+/**
+ * @deprecated use {@see \JMS\Serializer\Metadata\Driver\AttributeDriver} instead
+ */
 class AttributeReader implements Reader
 {
     /**

--- a/tests/Metadata/Driver/AnnotationDriverTest.php
+++ b/tests/Metadata/Driver/AnnotationDriverTest.php
@@ -7,32 +7,12 @@ namespace JMS\Serializer\Tests\Metadata\Driver;
 use Doctrine\Common\Annotations\AnnotationReader;
 use JMS\Serializer\Metadata\Driver\AnnotationDriver;
 use JMS\Serializer\Naming\IdenticalPropertyNamingStrategy;
-use JMS\Serializer\Tests\Fixtures\AllExcludedObject;
 use Metadata\Driver\DriverInterface;
 
-class AnnotationDriverTest extends BaseDriverTest
+class AnnotationDriverTest extends BaseAnnotationOrAttributeDriverTest
 {
-    public function testAllExcluded()
-    {
-        $a = new AllExcludedObject();
-        $m = $this->getDriver()->loadMetadataForClass(new \ReflectionClass($a));
-
-        self::assertArrayNotHasKey('foo', $m->propertyMetadata);
-        self::assertArrayHasKey('bar', $m->propertyMetadata);
-    }
-
     protected function getDriver(?string $subDir = null, bool $addUnderscoreDir = true): DriverInterface
     {
         return new AnnotationDriver(new AnnotationReader(), new IdenticalPropertyNamingStrategy(), null, $this->getExpressionEvaluator());
-    }
-
-    public function testCanDefineMetadataForInternalClass()
-    {
-        $this->markTestSkipped('Can not define annotation metadata for internal classes');
-    }
-
-    public function testShortExposeSyntax(): void
-    {
-        $this->markTestSkipped('Short expose syntax not supported on annotations');
     }
 }

--- a/tests/Metadata/Driver/AttributeDriverTest.php
+++ b/tests/Metadata/Driver/AttributeDriverTest.php
@@ -4,13 +4,11 @@ declare(strict_types=1);
 
 namespace JMS\Serializer\Tests\Metadata\Driver;
 
-use Doctrine\Common\Annotations\AnnotationReader;
-use JMS\Serializer\Metadata\Driver\AnnotationDriver;
 use JMS\Serializer\Metadata\Driver\AttributeDriver;
 use JMS\Serializer\Naming\IdenticalPropertyNamingStrategy;
 use Metadata\Driver\DriverInterface;
 
-class AttributeDriverTest extends AnnotationDriverTest
+class AttributeDriverTest extends BaseAnnotationOrAttributeDriverTest
 {
     protected function setUp(): void
     {
@@ -23,8 +21,6 @@ class AttributeDriverTest extends AnnotationDriverTest
 
     protected function getDriver(?string $subDir = null, bool $addUnderscoreDir = true): DriverInterface
     {
-        $annotationsReader = new AttributeDriver\AttributeReader(new AnnotationReader());
-
-        return new AnnotationDriver($annotationsReader, new IdenticalPropertyNamingStrategy(), null, $this->getExpressionEvaluator());
+        return new AttributeDriver(new IdenticalPropertyNamingStrategy(), null, $this->getExpressionEvaluator());
     }
 }

--- a/tests/Metadata/Driver/BaseAnnotationOrAttributeDriverTest.php
+++ b/tests/Metadata/Driver/BaseAnnotationOrAttributeDriverTest.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace JMS\Serializer\Tests\Metadata\Driver;
+
+use JMS\Serializer\Tests\Fixtures\AllExcludedObject;
+use Metadata\Driver\DriverInterface;
+
+abstract class BaseAnnotationOrAttributeDriverTest extends BaseDriverTest
+{
+    abstract protected function getDriver(?string $subDir = null, bool $addUnderscoreDir = true): DriverInterface;
+
+    public function testAllExcluded(): void
+    {
+        $a = new AllExcludedObject();
+        $m = $this->getDriver()->loadMetadataForClass(new \ReflectionClass($a));
+
+        self::assertArrayNotHasKey('foo', $m->propertyMetadata);
+        self::assertArrayHasKey('bar', $m->propertyMetadata);
+    }
+
+    public function testCanDefineMetadataForInternalClass(): void
+    {
+        $this->markTestSkipped('Can not define annotation or attribute metadata for internal classes');
+    }
+
+    public function testShortExposeSyntax(): void
+    {
+        $this->markTestSkipped('Short expose syntax not supported on annotations or attribute');
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| Doc updated   | yes/no
| BC breaks?    | no
| Deprecations? | yes
| Tests pass?   | yes
| Fixed tickets | #1452
| License       | MIT

As suggested with https://github.com/schmittjoh/serializer/issues/1452#issuecomment-1377511748 this makes a new base driver class for annotations and attributes, moves the `loadMetadataForClass()` method to that base class for reuse by child objects, and declares methods for child classes to handle loading whatever's needed.  The current attribute reader (which implements the Annotations `Reader` interface) which is used as a decorator around an annotations reader for use inside the annotations driver is deprecated in favor of the new attributes driver.

(By design, the first commit here is a rename to try and retain the file history, otherwise doing it all in one go (rightfully) treats `AnnotationOrAttributeDriver.php` as a new file and the blame history gets really ugly; the commits individually show the moves right, even if GitHub's PR viewer doesn't)