### PR TITLE
[B/C Break] Make the Annotations package optional in the builder API

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,6 @@
     ],
     "require": {
         "php": "^7.4 || ^8.0",
-        "doctrine/annotations": "^1.14 || ^2.0",
         "doctrine/instantiator": "^1.3.1 || ^2.0",
         "doctrine/lexer": "^2.0 || ^3.0",
         "jms/metadata": "^2.6",
@@ -37,6 +36,7 @@
     },
     "require-dev": {
         "ext-pdo_sqlite": "*",
+        "doctrine/annotations": "^1.14 || ^2.0",
         "doctrine/coding-standard": "^12.0",
         "doctrine/orm": "^2.14 || ^3.0",
         "doctrine/persistence": "^2.5.2 || ^3.0",

--- a/src/Builder/CallbackDriverFactory.php
+++ b/src/Builder/CallbackDriverFactory.php
@@ -12,15 +12,19 @@ final class CallbackDriverFactory implements DriverFactoryInterface
 {
     /**
      * @var callable
+     * @phpstan-var callable(array $metadataDirs, Reader|null $reader): DriverInterface
      */
     private $callback;
 
+    /**
+     * @phpstan-param callable(array $metadataDirs, Reader|null $reader): DriverInterface $callable
+     */
     public function __construct(callable $callable)
     {
         $this->callback = $callable;
     }
 
-    public function createDriver(array $metadataDirs, Reader $reader): DriverInterface
+    public function createDriver(array $metadataDirs, ?Reader $reader = null): DriverInterface
     {
         $driver = \call_user_func($this->callback, $metadataDirs, $reader);
         if (!$driver instanceof DriverInterface) {

--- a/src/Builder/DocBlockDriverFactory.php
+++ b/src/Builder/DocBlockDriverFactory.php
@@ -26,7 +26,7 @@ class DocBlockDriverFactory implements DriverFactoryInterface
         $this->typeParser = $typeParser;
     }
 
-    public function createDriver(array $metadataDirs, Reader $annotationReader): DriverInterface
+    public function createDriver(array $metadataDirs, ?Reader $annotationReader = null): DriverInterface
     {
         $driver = $this->driverFactoryToDecorate->createDriver($metadataDirs, $annotationReader);
 

--- a/src/Builder/DriverFactoryInterface.php
+++ b/src/Builder/DriverFactoryInterface.php
@@ -9,5 +9,5 @@ use Metadata\Driver\DriverInterface;
 
 interface DriverFactoryInterface
 {
-    public function createDriver(array $metadataDirs, Reader $annotationReader): DriverInterface;
+    public function createDriver(array $metadataDirs, ?Reader $annotationReader = null): DriverInterface;
 }

--- a/src/SerializerBuilder.php
+++ b/src/SerializerBuilder.php
@@ -552,9 +552,8 @@ final class SerializerBuilder
     public function build(): Serializer
     {
         $annotationReader = $this->annotationReader;
-        if (null === $annotationReader) {
-            $annotationReader = new AnnotationReader();
-            $annotationReader = $this->decorateAnnotationReader($annotationReader);
+        if (null === $annotationReader && class_exists(AnnotationReader::class)) {
+            $annotationReader = $this->decorateAnnotationReader(new AnnotationReader());
         }
 
         if (null === $this->driverFactory) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| Doc updated   | no
| BC breaks?    | yes
| Deprecations? | no
| Tests pass?   | no
| Fixed tickets | N/A
| License       | MIT

The below are the changes needed to (in theory) make the Annotations package an optional thing (note that Annotations is hard required by the dev PHPCR ODM and PHPBench dependencies, so right now it's not possible to actually not install the package without playing with Composer)