### PR TITLE
Allow psr/container 2.0.2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -40,7 +40,7 @@
         "phpbench/phpbench": "^1.0",
         "phpstan/phpstan": "^1.0.2",
         "phpunit/phpunit": "^8.5.21||^9.0",
-        "psr/container": "^1.0",
+        "psr/container": "^1.0|^2.0",
         "symfony/dependency-injection": "^3.0|^4.0|^5.0|^6.0",
         "symfony/expression-language": "^3.2|^4.0|^5.0|^6.0",
         "symfony/filesystem": "^3.0|^4.0|^5.0|^6.0",

--- a/tests/Handler/LazyHandlerRegistryWithPsr11ContainerTest.php
+++ b/tests/Handler/LazyHandlerRegistryWithPsr11ContainerTest.php
@@ -28,7 +28,7 @@ class Psr11Container implements ContainerInterface
         return $this->services[$id];
     }
 
-    public function has($id)
+    public function has($id): bool
     {
         return isset($this->services[$id]);
     }

--- a/tests/Serializer/EventDispatcher/LazyEventDispatcherWithPsr11ContainerTest.php
+++ b/tests/Serializer/EventDispatcher/LazyEventDispatcherWithPsr11ContainerTest.php
@@ -28,7 +28,7 @@ class Psr11Container implements ContainerInterface
         return $this->services[$id];
     }
 
-    public function has($id)
+    public function has($id): bool
     {
         return isset($this->services[$id]);
     }


### PR DESCRIPTION
Should allow psr/container 2.0.2 - not only 1.1.2

Changes:
https://github.com/php-fig/container/compare/2.0.2...1.1.2

| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| Doc updated   | no
| BC breaks?    | no <!-- don't forget updating UPGRADING.md file -->
| Deprecations? | no <!-- don't forget updating UPGRADING.md file -->
| Tests pass?   | yes
| License       | MIT

