### PR TITLE
refactor(handlers): Unregister unused YML handlers

### DIFF
--- a/src/Handler/ArrayCollectionHandler.php
+++ b/src/Handler/ArrayCollectionHandler.php
@@ -51,7 +51,7 @@ final class ArrayCollectionHandler implements SubscribingHandlerInterface
     public static function getSubscribingMethods()
     {
         $methods = [];
-        $formats = ['json', 'xml', 'yml'];
+        $formats = ['json', 'xml'];
 
         foreach (self::COLLECTION_TYPES as $type) {
             foreach ($formats as $format) {

--- a/src/Handler/StdClassHandler.php
+++ b/src/Handler/StdClassHandler.php
@@ -20,7 +20,7 @@ final class StdClassHandler implements SubscribingHandlerInterface
     public static function getSubscribingMethods()
     {
         $methods = [];
-        $formats = ['json', 'xml', 'yml'];
+        $formats = ['json', 'xml'];
 
         foreach ($formats as $format) {
             $methods[] = [


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| Doc updated   | no
| BC breaks?    | no <!-- don't forget updating UPGRADING.md file -->
| Deprecations? | no <!-- don't forget updating UPGRADING.md file -->
| Tests pass?   | yes
| Fixed tickets | 
| License       | MIT

YML serialization has been removed in version 2.X. Let's remove remaining handlers too. 