### PR TITLE
feat(driver): TypedPropertiesDriver support virtual property getter

### DIFF
--- a/tests/Fixtures/DocBlockType/VirtualPropertyGetter.php
+++ b/tests/Fixtures/DocBlockType/VirtualPropertyGetter.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace JMS\Serializer\Tests\Fixtures\DocBlockType;
+
+use JMS\Serializer\Annotation as Serializer;
+
+class VirtualPropertyGetter
+{
+    /**
+     * @Serializer\VirtualProperty
+     *
+     * @return string[]
+     */
+    #[Serializer\VirtualProperty]
+    public function getArrayOfStrings(): array
+    {
+        return ['foo', 'bar'];
+    }
+}

--- a/tests/Fixtures/TypedProperties/User.php
+++ b/tests/Fixtures/TypedProperties/User.php
@@ -24,4 +24,13 @@ class User
      */
     #[Serializer\ReadOnlyProperty]
     public iterable $tags = [];
+
+    /**
+     * @Serializer\VirtualProperty()
+     */
+    #[Serializer\VirtualProperty]
+    public function getVirtualRole(): Role
+    {
+        return $this->role;
+    }
 }

--- a/tests/Metadata/Driver/DocBlockDriverTest.php
+++ b/tests/Metadata/Driver/DocBlockDriverTest.php
@@ -45,6 +45,7 @@ use JMS\Serializer\Tests\Fixtures\DocBlockType\Phpstan\ProductType;
 use JMS\Serializer\Tests\Fixtures\DocBlockType\SingleClassFromDifferentNamespaceTypeHint;
 use JMS\Serializer\Tests\Fixtures\DocBlockType\SingleClassFromGlobalNamespaceTypeHint;
 use JMS\Serializer\Tests\Fixtures\DocBlockType\UnionTypedDocBLockProperty;
+use JMS\Serializer\Tests\Fixtures\DocBlockType\VirtualPropertyGetter;
 use PHPUnit\Framework\TestCase;
 
 class DocBlockDriverTest extends TestCase
@@ -449,6 +450,16 @@ class DocBlockDriverTest extends TestCase
         self::assertEquals(
             ['name' => 'array', 'params' => [['name' => 'int', 'params' => []], ['name' => ProductType::class, 'params' => []]]],
             $m->propertyMetadata['data']->type
+        );
+    }
+
+    public function testInferTypeForVirtualPropertyGetter()
+    {
+        $m = $this->resolve(VirtualPropertyGetter::class);
+
+        self::assertEquals(
+            ['name' => 'array', 'params' => [['name' => 'string', 'params' => []]]],
+            $m->propertyMetadata['arrayOfStrings']->type
         );
     }
 }

--- a/tests/Metadata/Driver/TypedPropertiesDriverTest.php
+++ b/tests/Metadata/Driver/TypedPropertiesDriverTest.php
@@ -32,6 +32,7 @@ class TypedPropertiesDriverTest extends TestCase
             'vehicle' => 'JMS\Serializer\Tests\Fixtures\TypedProperties\Vehicle',
             'created' => 'DateTime',
             'tags' => 'iterable',
+            'virtualRole' => 'JMS\Serializer\Tests\Fixtures\TypedProperties\Role',
         ];
 
         foreach ($expectedPropertyTypes as $property => $type) {

--- a/tests/Serializer/JsonSerializationTest.php
+++ b/tests/Serializer/JsonSerializationTest.php
@@ -135,9 +135,9 @@ class JsonSerializationTest extends BaseSerializationTestCase
             $outputs['user_discriminator_array'] = '[{"entityName":"User"},{"entityName":"ExtendedUser"}]';
             $outputs['user_discriminator'] = '{"entityName":"User"}';
             $outputs['user_discriminator_extended'] = '{"entityName":"ExtendedUser"}';
-            $outputs['typed_props'] = '{"id":1,"role":{"id":5},"vehicle":{"type":"car"},"created":"2010-10-01T00:00:00+00:00","updated":"2011-10-01T00:00:00+00:00","tags":["a","b"]}';
+            $outputs['typed_props'] = '{"virtual_role":{"id":5},"id":1,"role":{"id":5},"vehicle":{"type":"car"},"created":"2010-10-01T00:00:00+00:00","updated":"2011-10-01T00:00:00+00:00","tags":["a","b"]}';
             $outputs['typed_props_constructor_promotion_with_default_values'] = '{"color":"blue","size":"big","type_of_soil":"potting mix","days_since_potting":-1,"weight":10}';
-            $outputs['uninitialized_typed_props'] = '{"id":1,"role":{},"tags":[]}';
+            $outputs['uninitialized_typed_props'] = '{"virtual_role":{},"id":1,"role":{},"tags":[]}';
             $outputs['custom_datetimeinterface'] = '{"custom":"2021-09-07"}';
             $outputs['data_integer'] = '{"data":10000}';
             $outputs['uid'] = '"66b3177c-e03b-4a22-9dee-ddd7d37a04d5"';

--- a/tests/Serializer/xml/typed_props.xml
+++ b/tests/Serializer/xml/typed_props.xml
@@ -1,5 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <result>
+  <virtual_role>
+    <id>5</id>
+  </virtual_role>
   <id>1</id>
   <role>
     <id>5</id>

--- a/tests/Serializer/xml/uninitialized_typed_props.xml
+++ b/tests/Serializer/xml/uninitialized_typed_props.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <result>
+  <virtual_role/>
   <id>1</id>
   <role/>
   <tags/>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| Doc updated   | no
| BC breaks?    | no <!-- don't forget updating UPGRADING.md file -->
| Deprecations? | no <!-- don't forget updating UPGRADING.md file -->
| Tests pass?   | yes
| Fixed tickets | #... <!-- #-prefixed issue number(s), if any -->
| License       | MIT

This allow to extract return type of virtual property when they are a getter on the class.
Same logic as a type properties but also supporting virtual property getter.

Also support type from php doc for virtual property getter.
