### PR TITLE
feat(TypeResolvers): Add support for alternative name in doc blocs.

### DIFF
--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -14,7 +14,7 @@
 
     <file>src/</file>
     <file>tests/</file>
-
+    <exclude-pattern>tests/Fixtures/DocBlockType/AlternativePHPDocsNames.php</exclude-pattern>
     <rule ref="Doctrine">
         <exclude name="Generic.Formatting.SpaceAfterNot"/>
         <exclude name="Generic.Formatting.MultipleStatementAlignment"/>
@@ -40,7 +40,7 @@
 
     <rule ref="SlevomatCodingStandard.ControlStructures.RequireYodaComparison"/>
 
-     <rule ref="SlevomatCodingStandard.Commenting.ForbiddenAnnotations">
+    <rule ref="SlevomatCodingStandard.Commenting.ForbiddenAnnotations">
         <properties>
             <property
                 name="forbiddenAnnotations"

--- a/src/Metadata/Driver/DocBlockDriver/DocBlockTypeResolver.php
+++ b/src/Metadata/Driver/DocBlockDriver/DocBlockTypeResolver.php
@@ -293,7 +293,7 @@ final class DocBlockTypeResolver
 
     private function isPrimitiveType(string $type): bool
     {
-        return in_array($type, ['int', 'float', 'bool', 'string']);
+        return in_array($type, ['int', 'integer', 'float', 'bool', 'boolean', 'double', 'string']);
     }
 
     private function hasGlobalNamespacePrefix(string $typeHint): bool

--- a/tests/Fixtures/DocBlockType/AlternativePHPDocsNames.php
+++ b/tests/Fixtures/DocBlockType/AlternativePHPDocsNames.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace JMS\Serializer\Tests\Fixtures\DocBlockType;
+
+class AlternativePHPDocsNames
+{
+    /** @var integer */
+    public $integer;
+
+    /** @var double */
+    public $double;
+
+    /** @var boolean */
+    public $boolean;
+}

--- a/tests/Metadata/Driver/DocBlockDriverTest.php
+++ b/tests/Metadata/Driver/DocBlockDriverTest.php
@@ -10,6 +10,7 @@ use JMS\Serializer\Metadata\Driver\AnnotationDriver;
 use JMS\Serializer\Metadata\Driver\DocBlockDriver;
 use JMS\Serializer\Metadata\Driver\TypedPropertiesDriver;
 use JMS\Serializer\Naming\IdenticalPropertyNamingStrategy;
+use JMS\Serializer\Tests\Fixtures\DocBlockType\AlternativePHPDocsNames;
 use JMS\Serializer\Tests\Fixtures\DocBlockType\Collection\CollectionAsList;
 use JMS\Serializer\Tests\Fixtures\DocBlockType\Collection\CollectionOfClassesFromDifferentNamespace;
 use JMS\Serializer\Tests\Fixtures\DocBlockType\Collection\CollectionOfClassesFromDifferentNamespaceUsingGroupAlias;
@@ -460,6 +461,26 @@ class DocBlockDriverTest extends TestCase
         self::assertEquals(
             ['name' => 'array', 'params' => [['name' => 'string', 'params' => []]]],
             $m->propertyMetadata['arrayOfStrings']->type
+        );
+    }
+
+    public function testAlternativeNames()
+    {
+        $m = $this->resolve(AlternativePHPDocsNames::class);
+
+        self::assertEquals(
+            ['name' => 'integer', 'params' => []],
+            $m->propertyMetadata['integer']->type
+        );
+
+        self::assertEquals(
+            ['name' => 'double', 'params' => []],
+            $m->propertyMetadata['double']->type
+        );
+
+        self::assertEquals(
+            ['name' => 'boolean', 'params' => []],
+            $m->propertyMetadata['boolean']->type
         );
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| Doc updated   | no
| BC breaks?    | no <!-- don't forget updating UPGRADING.md file -->
| Deprecations? | no <!-- don't forget updating UPGRADING.md file -->
| Tests pass?   | yes
| Fixed tickets | #1489
| License       | MIT

Add alternative names that can be used in the doc blocs.
