### PR TITLE
feat(stringable-type): Allow stringable object as type.

### DIFF
--- a/doc/reference/annotations.rst
+++ b/doc/reference/annotations.rst
@@ -577,6 +577,34 @@ Examples:
         private $keyValueStore;
     }
 
+.. note ::
+
+    if you are using ``PHP attributes`` with PHP 8.1 you can pass an object which implements ``__toString()`` method as a value for ``#[Type]`` attribute.
+    
+    .. code-block :: php
+
+		  <?php
+
+		  namespace MyNamespace;
+
+		  use JMS\Serializer\Annotation\Type;
+
+		  class BlogPost
+		  {
+		      #[Type(new ArrayOf(Comment::class))]
+		      private $comments;
+		  }
+		  
+		  class ArrayOf
+		  {
+		  		public function __construct(private string $className) {}
+		  		
+		  		public function __toString(): string
+		  		{
+		  				return "array<$className>";
+		  		}
+		  }
+
 .. _configuration: https://jmsyst.com/bundles/JMSSerializerBundle/master/configuration#configuration-block-2-0
 
 @XmlRoot

--- a/src/Annotation/Type.php
+++ b/src/Annotation/Type.php
@@ -15,12 +15,22 @@ final class Type
 
     /**
      * @Required
-     * @var string|null
+     * @var string|\Stringable|null
      */
     public $name = null;
 
-    public function __construct($values = [], ?string $name = null)
+    public function __construct($values = [], $name = null)
     {
+        if ((null !== $name) && !is_string($name) && !(is_object($name) && method_exists($name, '__toString'))) {
+            throw new \RuntimeException(
+                'Type must be either string, null or object implements __toString() method.'
+            );
+        }
+
+        if (is_object($name)) {
+            $name = (string) $name;
+        }
+
         $this->loadAnnotationParameters(get_defined_vars());
     }
 }

--- a/tests/Fixtures/ObjectWithTypeAsNonStringableObject.php
+++ b/tests/Fixtures/ObjectWithTypeAsNonStringableObject.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace JMS\Serializer\Tests\Fixtures;
+
+use JMS\Serializer\Annotation as Serializer;
+
+class ObjectWithTypeAsNonStringableObject
+{
+    #[Serializer\Type(name: new NonStringableObjectType())]
+    private $array;
+
+    /**
+     * @param array<string> $array
+     */
+    public function __construct(array $array)
+    {
+        $this->array = $array;
+    }
+}
+
+class NonStringableObjectType
+{
+}

--- a/tests/Fixtures/ObjectWithTypeAsStringableObject.php
+++ b/tests/Fixtures/ObjectWithTypeAsStringableObject.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace JMS\Serializer\Tests\Fixtures;
+
+use JMS\Serializer\Annotation as Serializer;
+
+class ObjectWithTypeAsStringableObject
+{
+    #[Serializer\Type(name: new StringableObjectType())]
+    private $array;
+
+    /**
+     * @param array<string> $array
+     */
+    public function __construct(array $array)
+    {
+        $this->array = $array;
+    }
+}
+
+class StringableObjectType
+{
+    public function __toString(): string
+    {
+        return 'array<string>';
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| Doc updated   | no
| BC breaks?    | no <!-- don't forget updating UPGRADING.md file -->
| Deprecations? | no <!-- don't forget updating UPGRADING.md file -->
| Tests pass?   | yes
| Fixed tickets | #... <!-- #-prefixed issue number(s), if any -->
| License       | MIT

Allow pass type as stringable object (object implementing __toString() method).

**Before**
```php
#[Serializer\Type('array<MyHandler<My\Class>>')]
private $array;
```

**After**
```php
#[Serializer\Type(new ArrayOfMyHandler(MyClass::class))]
private $array;
```

Better readability. IDE can autocomplete.
If this pull request make sens I will update doc.