### PR TITLE
fix(stringable-type): Allow stringable object as type.

### DIFF
--- a/src/Annotation/Type.php
+++ b/src/Annotation/Type.php
@@ -31,6 +31,16 @@ final class Type
             $name = (string) $name;
         }
 
+        if (is_object($values)) {
+            if (false === method_exists($values, '__toString')) {
+                throw new \RuntimeException(
+                    'Type must be either string or object implements __toString() method.'
+                );
+            }
+
+            $values = (string) $values;
+        }
+
         $this->loadAnnotationParameters(get_defined_vars());
     }
 }

--- a/tests/Fixtures/ObjectWithTypeAsNonStringableObject.php
+++ b/tests/Fixtures/ObjectWithTypeAsNonStringableObject.php
@@ -8,15 +8,20 @@ use JMS\Serializer\Annotation as Serializer;
 
 class ObjectWithTypeAsNonStringableObject
 {
-    #[Serializer\Type(name: new NonStringableObjectType())]
+    #[Serializer\Type(new NonStringableObjectType())]
     private $array;
+
+    #[Serializer\Type(name: new NonStringableObjectType())]
+    private $array2;
 
     /**
      * @param array<string> $array
+     * @param array<string> $array2
      */
-    public function __construct(array $array)
+    public function __construct(array $array, array $array2)
     {
         $this->array = $array;
+        $this->array2 = $array2;
     }
 }
 

--- a/tests/Fixtures/ObjectWithTypeAsStringableObject.php
+++ b/tests/Fixtures/ObjectWithTypeAsStringableObject.php
@@ -8,15 +8,20 @@ use JMS\Serializer\Annotation as Serializer;
 
 class ObjectWithTypeAsStringableObject
 {
-    #[Serializer\Type(name: new StringableObjectType())]
+    #[Serializer\Type(new StringableObjectType())]
     private $array;
+
+    #[Serializer\Type(name: new StringableObjectType())]
+    private $array2;
 
     /**
      * @param array<string> $array
+     * @param array<string> $array2
      */
-    public function __construct(array $array)
+    public function __construct(array $array, array $array2)
     {
         $this->array = $array;
+        $this->array2 = $array2;
     }
 }
 

--- a/tests/Metadata/Driver/BaseDriverTestCase.php
+++ b/tests/Metadata/Driver/BaseDriverTestCase.php
@@ -679,6 +679,7 @@ abstract class BaseDriverTestCase extends TestCase
         \assert($m instanceof ClassMetadata);
 
         self::assertSame(['name' => 'array', 'params' => [['name' => 'string', 'params' => []]]], $m->propertyMetadata['array']->type);
+        self::assertSame(['name' => 'array', 'params' => [['name' => 'string', 'params' => []]]], $m->propertyMetadata['array2']->type);
     }
 
     public function testTypeAsNonStringableObject(): void


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Doc updated   | no
| BC breaks?    | no <!-- don't forget updating UPGRADING.md file -->
| Deprecations? | no <!-- don't forget updating UPGRADING.md file -->
| Tests pass?   | yes
| Fixed tickets | #... <!-- #-prefixed issue number(s), if any -->
| License       | MIT

I'm sorry but I made a small mistake in previous pull request #1492 . Documentation is updated correctly. I've updated code to fulfill documentation. Now you can use
```php
#[Serializer\Type(new ArrayOfMyHandler(MyClass::class))]
private $array;
```
and also
```php
#[Serializer\Type(name: new ArrayOfMyHandler(MyClass::class))]
private $array;
```
