### PR TITLE
Don't return a metadata object unless there is explicit annotation or attribute configuration

### DIFF
--- a/src/Metadata/Driver/AnnotationDriver.php
+++ b/src/Metadata/Driver/AnnotationDriver.php
@@ -18,7 +18,7 @@ class AnnotationDriver extends AnnotationOrAttributeDriver
 
     public function __construct(Reader $reader, PropertyNamingStrategyInterface $namingStrategy, ?ParserInterface $typeParser = null, ?CompilableExpressionEvaluatorInterface $expressionEvaluator = null)
     {
-        parent::__construct($namingStrategy, $typeParser, $expressionEvaluator);
+        parent::__construct($namingStrategy, $typeParser, $expressionEvaluator, $reader);
 
         $this->reader = $reader;
     }

--- a/src/Metadata/Driver/AnnotationOrAttributeDriver.php
+++ b/src/Metadata/Driver/AnnotationOrAttributeDriver.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace JMS\Serializer\Metadata\Driver;
 
+use Doctrine\Common\Annotations\Reader;
 use JMS\Serializer\Annotation\Accessor;
 use JMS\Serializer\Annotation\AccessorOrder;
 use JMS\Serializer\Annotation\AccessType;
@@ -47,7 +48,7 @@ use Metadata\ClassMetadata as BaseClassMetadata;
 use Metadata\Driver\DriverInterface;
 use Metadata\MethodMetadata;
 
-abstract class AnnotationOrAttributeDriver implements DriverInterface
+class AnnotationOrAttributeDriver implements DriverInterface
 {
     use ExpressionMetadataTrait;
 
@@ -61,15 +62,23 @@ abstract class AnnotationOrAttributeDriver implements DriverInterface
      */
     private $namingStrategy;
 
-    public function __construct(PropertyNamingStrategyInterface $namingStrategy, ?ParserInterface $typeParser = null, ?CompilableExpressionEvaluatorInterface $expressionEvaluator = null)
+    /**
+     * @var Reader
+     */
+    private $reader;
+
+    public function __construct(PropertyNamingStrategyInterface $namingStrategy, ?ParserInterface $typeParser = null, ?CompilableExpressionEvaluatorInterface $expressionEvaluator = null, ?Reader $reader = null)
     {
         $this->typeParser = $typeParser ?: new Parser();
         $this->namingStrategy = $namingStrategy;
         $this->expressionEvaluator = $expressionEvaluator;
+        $this->reader = $reader;
     }
 
     public function loadMetadataForClass(\ReflectionClass $class): ?BaseClassMetadata
     {
+        $configured = false;
+
         $classMetadata = new ClassMetadata($name = $class->name);
         $fileResource =  $class->getFilename();
 
@@ -86,6 +95,8 @@ abstract class AnnotationOrAttributeDriver implements DriverInterface
         $readOnlyClass = false;
 
         foreach ($this->getClassAnnotations($class) as $annot) {
+            $configured = true;
+
             if ($annot instanceof ExclusionPolicy) {
                 $exclusionPolicy = $annot->policy;
             } elseif ($annot instanceof XmlRoot) {
@@ -135,6 +146,8 @@ abstract class AnnotationOrAttributeDriver implements DriverInterface
             $methodAnnotations = $this->getMethodAnnotations($method);
 
             foreach ($methodAnnotations as $annot) {
+                $configured = true;
+
                 if ($annot instanceof PreSerialize) {
                     $classMetadata->addPreSerializeMethod(new MethodMetadata($name, $method->name));
                     continue 2;
@@ -174,6 +187,8 @@ abstract class AnnotationOrAttributeDriver implements DriverInterface
                 $propertyAnnotations = $propertiesAnnotations[$propertyKey];
 
                 foreach ($propertyAnnotations as $annot) {
+                    $configured = true;
+
                     if ($annot instanceof Since) {
                         $propertyMetadata->sinceVersion = $annot->version;
                     } elseif ($annot instanceof Until) {
@@ -274,21 +289,79 @@ abstract class AnnotationOrAttributeDriver implements DriverInterface
             }
         }
 
+        if (!$configured) {
+            return null;
+        }
+
         return $classMetadata;
     }
 
     /**
      * @return list<object>
      */
-    abstract protected function getClassAnnotations(\ReflectionClass $class): array;
+    protected function getClassAnnotations(\ReflectionClass $class): array
+    {
+        $annotations = [];
+
+        if (PHP_VERSION_ID >= 80000) {
+            $annotations = array_map(
+                static function (\ReflectionAttribute $attribute): object {
+                    return $attribute->newInstance();
+                },
+                $class->getAttributes()
+            );
+        }
+
+        if (null !== $this->reader) {
+            $annotations = array_merge($annotations, $this->reader->getClassAnnotations($class));
+        }
+
+        return $annotations;
+    }
 
     /**
      * @return list<object>
      */
-    abstract protected function getMethodAnnotations(\ReflectionMethod $method): array;
+    protected function getMethodAnnotations(\ReflectionMethod $method): array
+    {
+        $annotations = [];
+
+        if (PHP_VERSION_ID >= 80000) {
+            $annotations = array_map(
+                static function (\ReflectionAttribute $attribute): object {
+                    return $attribute->newInstance();
+                },
+                $method->getAttributes()
+            );
+        }
+
+        if (null !== $this->reader) {
+            $annotations = array_merge($annotations, $this->reader->getMethodAnnotations($method));
+        }
+
+        return $annotations;
+    }
 
     /**
      * @return list<object>
      */
-    abstract protected function getPropertyAnnotations(\ReflectionProperty $property): array;
+    protected function getPropertyAnnotations(\ReflectionProperty $property): array
+    {
+        $annotations = [];
+
+        if (PHP_VERSION_ID >= 80000) {
+            $annotations = array_map(
+                static function (\ReflectionAttribute $attribute): object {
+                    return $attribute->newInstance();
+                },
+                $property->getAttributes()
+            );
+        }
+
+        if (null !== $this->reader) {
+            $annotations = array_merge($annotations, $this->reader->getPropertyAnnotations($property));
+        }
+
+        return $annotations;
+    }
 }

--- a/src/Metadata/Driver/NullDriver.php
+++ b/src/Metadata/Driver/NullDriver.php
@@ -5,17 +5,43 @@ declare(strict_types=1);
 namespace JMS\Serializer\Metadata\Driver;
 
 use JMS\Serializer\Metadata\ClassMetadata;
+use JMS\Serializer\Metadata\PropertyMetadata;
+use JMS\Serializer\Naming\PropertyNamingStrategyInterface;
 use Metadata\ClassMetadata as BaseClassMetadata;
 use Metadata\Driver\DriverInterface;
 
 class NullDriver implements DriverInterface
 {
+    /**
+     * @var PropertyNamingStrategyInterface
+     */
+    private $namingStrategy;
+
+    public function __construct(PropertyNamingStrategyInterface $namingStrategy)
+    {
+        $this->namingStrategy = $namingStrategy;
+    }
+
     public function loadMetadataForClass(\ReflectionClass $class): ?BaseClassMetadata
     {
         $classMetadata = new ClassMetadata($name = $class->name);
         $fileResource =  $class->getFilename();
         if (false !== $fileResource) {
             $classMetadata->fileResources[] = $fileResource;
+        }
+
+        foreach ($class->getProperties() as $property) {
+            if ($property->class !== $name || (isset($property->info) && $property->info['class'] !== $name)) {
+                continue;
+            }
+
+            $propertyMetadata = new PropertyMetadata($name, $property->getName());
+
+            if (!$propertyMetadata->serializedName) {
+                $propertyMetadata->serializedName = $this->namingStrategy->translateName($propertyMetadata);
+            }
+
+            $classMetadata->addPropertyMetadata($propertyMetadata);
         }
 
         return $classMetadata;

--- a/tests/Fixtures/AuthorDeprecatedReadOnly.php
+++ b/tests/Fixtures/AuthorDeprecatedReadOnly.php
@@ -19,9 +19,10 @@ use JMS\Serializer\Annotation\XmlRoot;
 class AuthorDeprecatedReadOnly
 {
     /**
-     * @JMS\Serializer\Annotation\ReadOnly
+     * @ReadOnly
      * @SerializedName("id")
      */
+    #[\JMS\Serializer\Annotation\DeprecatedReadOnly]
     #[SerializedName(name: 'id')]
     private $id;
 

--- a/tests/Fixtures/AuthorDeprecatedReadOnlyPerClass.php
+++ b/tests/Fixtures/AuthorDeprecatedReadOnlyPerClass.php
@@ -17,12 +17,14 @@ use JMS\Serializer\Annotation\XmlRoot;
  * @ReadOnly
  */
 #[XmlRoot(name: 'author')]
+#[\JMS\Serializer\Annotation\DeprecatedReadOnly]
 class AuthorDeprecatedReadOnlyPerClass
 {
     /**
      * @ReadOnly
      * @SerializedName("id")
      */
+    #[\JMS\Serializer\Annotation\DeprecatedReadOnly]
     #[SerializedName(name: 'id')]
     private $id;
 
@@ -41,6 +43,7 @@ class AuthorDeprecatedReadOnlyPerClass
     #[Type(name: 'string')]
     #[SerializedName(name: 'full_name')]
     #[Accessor(getter: 'getName')]
+    #[\JMS\Serializer\Annotation\DeprecatedReadOnly(readOnly: false)]
     private $name;
 
     public function getId()

--- a/tests/Fixtures/AuthorList.php
+++ b/tests/Fixtures/AuthorList.php
@@ -43,8 +43,7 @@ class AuthorList implements \IteratorAggregate, \Countable, \ArrayAccess
     /**
      * @see ArrayAccess
      */
-    #[\ReturnTypeWillChange]
-    public function offsetExists($offset)
+    public function offsetExists($offset): bool
     {
         return isset($this->authors[$offset]);
     }
@@ -52,8 +51,7 @@ class AuthorList implements \IteratorAggregate, \Countable, \ArrayAccess
     /**
      * @see ArrayAccess
      */
-    #[\ReturnTypeWillChange]
-    public function offsetGet($offset)
+    public function offsetGet($offset): ?Author
     {
         return $this->authors[$offset] ?? null;
     }
@@ -61,8 +59,7 @@ class AuthorList implements \IteratorAggregate, \Countable, \ArrayAccess
     /**
      * @see ArrayAccess
      */
-    #[\ReturnTypeWillChange]
-    public function offsetSet($offset, $value)
+    public function offsetSet($offset, $value): void
     {
         if (null === $offset) {
             $this->authors[] = $value;
@@ -74,8 +71,7 @@ class AuthorList implements \IteratorAggregate, \Countable, \ArrayAccess
     /**
      * @see ArrayAccess
      */
-    #[\ReturnTypeWillChange]
-    public function offsetUnset($offset)
+    public function offsetUnset($offset): void
     {
         unset($this->authors[$offset]);
     }

--- a/tests/Fixtures/Doctrine/PersistendCollection/SmartPhone.php
+++ b/tests/Fixtures/Doctrine/PersistendCollection/SmartPhone.php
@@ -21,6 +21,7 @@ class SmartPhone
      *
      * @var string
      */
+    #[Serializer\SerializedName(name: 'id')]
     #[Serializer\Type(name: 'string')]
     protected $id;
 
@@ -40,6 +41,7 @@ class SmartPhone
      *
      * @var ArrayCollection<int, App>
      */
+    #[Serializer\SerializedName(name: 'applications')]
     #[Serializer\Type(name: 'ArrayCollection<JMS\Serializer\Tests\Fixtures\Doctrine\PersistendCollection\App>')]
     private $apps;
 

--- a/tests/Fixtures/ObjectWithLifecycleCallbacks.php
+++ b/tests/Fixtures/ObjectWithLifecycleCallbacks.php
@@ -39,6 +39,7 @@ class ObjectWithLifecycleCallbacks
     /**
      * @PreSerialize
      */
+    #[PreSerialize]
     private function prepareForSerialization()
     {
         $this->name = $this->firstname . ' ' . $this->lastname;
@@ -47,6 +48,7 @@ class ObjectWithLifecycleCallbacks
     /**
      * @PostSerialize
      */
+    #[PostSerialize]
     private function cleanUpAfterSerialization()
     {
         $this->name = null;
@@ -55,6 +57,7 @@ class ObjectWithLifecycleCallbacks
     /**
      * @PostDeserialize
      */
+    #[PostDeserialize]
     private function afterDeserialization()
     {
         [$this->firstname, $this->lastname] = explode(' ', $this->name);

--- a/tests/Metadata/Driver/AnnotationDriverTest.php
+++ b/tests/Metadata/Driver/AnnotationDriverTest.php
@@ -6,13 +6,20 @@ namespace JMS\Serializer\Tests\Metadata\Driver;
 
 use Doctrine\Common\Annotations\AnnotationReader;
 use JMS\Serializer\Metadata\Driver\AnnotationDriver;
+use JMS\Serializer\Metadata\Driver\NullDriver;
 use JMS\Serializer\Naming\IdenticalPropertyNamingStrategy;
+use Metadata\Driver\DriverChain;
 use Metadata\Driver\DriverInterface;
 
 class AnnotationDriverTest extends BaseAnnotationOrAttributeDriverTestCase
 {
     protected function getDriver(?string $subDir = null, bool $addUnderscoreDir = true): DriverInterface
     {
-        return new AnnotationDriver(new AnnotationReader(), new IdenticalPropertyNamingStrategy(), null, $this->getExpressionEvaluator());
+        $namingStrategy = new IdenticalPropertyNamingStrategy();
+
+        return new DriverChain([
+            new AnnotationDriver(new AnnotationReader(), $namingStrategy, null, $this->getExpressionEvaluator()),
+            new NullDriver($namingStrategy),
+        ]);
     }
 }

--- a/tests/Metadata/Driver/AttributeDriverTest.php
+++ b/tests/Metadata/Driver/AttributeDriverTest.php
@@ -5,7 +5,9 @@ declare(strict_types=1);
 namespace JMS\Serializer\Tests\Metadata\Driver;
 
 use JMS\Serializer\Metadata\Driver\AttributeDriver;
+use JMS\Serializer\Metadata\Driver\NullDriver;
 use JMS\Serializer\Naming\IdenticalPropertyNamingStrategy;
+use Metadata\Driver\DriverChain;
 use Metadata\Driver\DriverInterface;
 
 class AttributeDriverTest extends BaseAnnotationOrAttributeDriverTestCase
@@ -21,6 +23,11 @@ class AttributeDriverTest extends BaseAnnotationOrAttributeDriverTestCase
 
     protected function getDriver(?string $subDir = null, bool $addUnderscoreDir = true): DriverInterface
     {
-        return new AttributeDriver(new IdenticalPropertyNamingStrategy(), null, $this->getExpressionEvaluator());
+        $namingStrategy = new IdenticalPropertyNamingStrategy();
+
+        return new DriverChain([
+            new AttributeDriver($namingStrategy, null, $this->getExpressionEvaluator()),
+            new NullDriver($namingStrategy),
+        ]);
     }
 }

--- a/tests/Metadata/Driver/BaseAnnotationOrAttributeDriverTestCase.php
+++ b/tests/Metadata/Driver/BaseAnnotationOrAttributeDriverTestCase.php
@@ -5,12 +5,9 @@ declare(strict_types=1);
 namespace JMS\Serializer\Tests\Metadata\Driver;
 
 use JMS\Serializer\Tests\Fixtures\AllExcludedObject;
-use Metadata\Driver\DriverInterface;
 
 abstract class BaseAnnotationOrAttributeDriverTestCase extends BaseDriverTestCase
 {
-    abstract protected function getDriver(?string $subDir = null, bool $addUnderscoreDir = true): DriverInterface;
-
     public function testAllExcluded(): void
     {
         $a = new AllExcludedObject();

--- a/tests/Metadata/Driver/NullDriverTest.php
+++ b/tests/Metadata/Driver/NullDriverTest.php
@@ -6,13 +6,14 @@ namespace JMS\Serializer\Tests\Metadata\Driver;
 
 use JMS\Serializer\Metadata\ClassMetadata;
 use JMS\Serializer\Metadata\Driver\NullDriver;
+use JMS\Serializer\Naming\IdenticalPropertyNamingStrategy;
 use PHPUnit\Framework\TestCase;
 
 class NullDriverTest extends TestCase
 {
     public function testReturnsValidMetadata()
     {
-        $driver = new NullDriver();
+        $driver = new NullDriver(new IdenticalPropertyNamingStrategy());
 
         $metadata = $driver->loadMetadataForClass(new \ReflectionClass('stdClass'));
 

--- a/tests/Metadata/Driver/UnionTypedPropertiesDriverTest.php
+++ b/tests/Metadata/Driver/UnionTypedPropertiesDriverTest.php
@@ -7,9 +7,11 @@ namespace JMS\Serializer\Tests\Metadata\Driver;
 use Doctrine\Common\Annotations\AnnotationReader;
 use JMS\Serializer\Metadata\ClassMetadata;
 use JMS\Serializer\Metadata\Driver\AnnotationDriver;
+use JMS\Serializer\Metadata\Driver\NullDriver;
 use JMS\Serializer\Metadata\Driver\TypedPropertiesDriver;
 use JMS\Serializer\Naming\IdenticalPropertyNamingStrategy;
 use JMS\Serializer\Tests\Fixtures\TypedProperties\UnionTypedProperties;
+use Metadata\Driver\DriverChain;
 use PHPUnit\Framework\TestCase;
 use ReflectionClass;
 
@@ -34,8 +36,14 @@ final class UnionTypedPropertiesDriverTest extends TestCase
 
     private function resolve(string $classToResolve): ClassMetadata
     {
-        $baseDriver = new AnnotationDriver(new AnnotationReader(), new IdenticalPropertyNamingStrategy());
-        $driver = new TypedPropertiesDriver($baseDriver);
+        $namingStrategy = new IdenticalPropertyNamingStrategy();
+
+        $driver = new DriverChain([
+            new AnnotationDriver(new AnnotationReader(), $namingStrategy),
+            new NullDriver($namingStrategy),
+        ]);
+
+        $driver = new TypedPropertiesDriver($driver);
 
         $m = $driver->loadMetadataForClass(new ReflectionClass($classToResolve));
         self::assertNotNull($m);

--- a/tests/Serializer/GraphNavigatorTest.php
+++ b/tests/Serializer/GraphNavigatorTest.php
@@ -21,11 +21,13 @@ use JMS\Serializer\GraphNavigatorInterface;
 use JMS\Serializer\Handler\HandlerRegistry;
 use JMS\Serializer\Handler\SubscribingHandlerInterface;
 use JMS\Serializer\Metadata\Driver\AnnotationDriver;
+use JMS\Serializer\Metadata\Driver\NullDriver;
 use JMS\Serializer\Naming\IdenticalPropertyNamingStrategy;
 use JMS\Serializer\SerializationContext;
 use JMS\Serializer\Visitor\DeserializationVisitorInterface;
 use JMS\Serializer\Visitor\SerializationVisitorInterface;
 use JMS\Serializer\VisitorInterface;
+use Metadata\Driver\DriverChain;
 use Metadata\MetadataFactory;
 use PHPUnit\Framework\TestCase;
 
@@ -243,7 +245,14 @@ class GraphNavigatorTest extends TestCase
         $this->handlerRegistry = new HandlerRegistry();
         $this->objectConstructor = new UnserializeObjectConstructor();
 
-        $this->metadataFactory = new MetadataFactory(new AnnotationDriver(new AnnotationReader(), new IdenticalPropertyNamingStrategy()));
+        $namingStrategy = new IdenticalPropertyNamingStrategy();
+
+        $driver = new DriverChain([
+            new AnnotationDriver(new AnnotationReader(), $namingStrategy),
+            new NullDriver($namingStrategy),
+        ]);
+
+        $this->metadataFactory = new MetadataFactory($driver);
 
         $this->serializationNavigator = new SerializationGraphNavigator($this->metadataFactory, $this->handlerRegistry, $this->accessor, $this->dispatcher);
         $this->serializationNavigator->initialize($this->serializationVisitor, $this->context);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Doc updated   | no
| BC breaks?    | maybe?
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | Partially schmittjoh/JMSSerializerBundle#931
| License       | MIT

Before #1469 the annotation driver would always return a `JMS\Serializer\Metadata\ClassMetadata` regardless of whether the object had any configured annotations or attributes.  With the changes in #1469, the new attribute driver inherited the same behavior.  And with schmittjoh/JMSSerializerBundle#920 prioritizing the attribute driver over the annotation driver, the end result is now that the attribute driver will always return a metadata object even if there were no attributes on the object and the chain will never fall through to a later driver (in this case, the annotation driver).

Untested, but this should change the behavior for these two drivers so that it returns null if there are no explicitly configured annotations or attributes on an object instead of a metadata object without any information.  The toggle on whether to return the metadata object or null is based solely on the presence of annotations or attributes; once the code gets into the loops processing those, we'll assume there is a configuration that should be used (as those loops won't be entered for empty lists).

I mark this as "maybe" a B/C break because it's really a weird edge case.  `Metadata\Driver\DriverInterface::loadMetadataForClass()` supports null returns, which are accounted for already in the metadata package, but there is a change in runtime behavior in that a metadata instance will no longer be provided on objects that never had configuration in the first place.  If someone's relying on this behavior, they might be in for an unwelcome surprise on upgrade.