### PR TITLE
Improve null checks in drivers with a delegate

### DIFF
--- a/src/Metadata/Driver/AbstractDoctrineTypeDriver.php
+++ b/src/Metadata/Driver/AbstractDoctrineTypeDriver.php
@@ -83,6 +83,11 @@ abstract class AbstractDoctrineTypeDriver implements DriverInterface
     public function loadMetadataForClass(\ReflectionClass $class): ?BaseClassMetadata
     {
         $classMetadata = $this->delegate->loadMetadataForClass($class);
+
+        if (null === $classMetadata) {
+            return null;
+        }
+
         \assert($classMetadata instanceof ClassMetadata);
 
         // Abort if the given class is not a mapped entity

--- a/src/Metadata/Driver/DefaultValuePropertyDriver.php
+++ b/src/Metadata/Driver/DefaultValuePropertyDriver.php
@@ -30,11 +30,12 @@ class DefaultValuePropertyDriver implements DriverInterface
     public function loadMetadataForClass(ReflectionClass $class): ?ClassMetadata
     {
         $classMetadata = $this->delegate->loadMetadataForClass($class);
-        \assert($classMetadata instanceof SerializerClassMetadata);
 
         if (null === $classMetadata) {
             return null;
         }
+
+        \assert($classMetadata instanceof SerializerClassMetadata);
 
         foreach ($classMetadata->propertyMetadata as $key => $propertyMetadata) {
             \assert($propertyMetadata instanceof PropertyMetadata);

--- a/src/Metadata/Driver/DocBlockDriver.php
+++ b/src/Metadata/Driver/DocBlockDriver.php
@@ -45,11 +45,12 @@ class DocBlockDriver implements DriverInterface
     public function loadMetadataForClass(ReflectionClass $class): ?ClassMetadata
     {
         $classMetadata = $this->delegate->loadMetadataForClass($class);
-        \assert($classMetadata instanceof SerializerClassMetadata);
 
         if (null === $classMetadata) {
             return null;
         }
+
+        \assert($classMetadata instanceof SerializerClassMetadata);
 
         // We base our scan on the internal driver's property list so that we
         // respect any internal allow/blocklist like in the AnnotationDriver

--- a/src/Metadata/Driver/EnumPropertiesDriver.php
+++ b/src/Metadata/Driver/EnumPropertiesDriver.php
@@ -30,11 +30,12 @@ class EnumPropertiesDriver implements DriverInterface
     public function loadMetadataForClass(ReflectionClass $class): ?ClassMetadata
     {
         $classMetadata = $this->delegate->loadMetadataForClass($class);
-        \assert($classMetadata instanceof SerializerClassMetadata);
 
         if (null === $classMetadata) {
             return null;
         }
+
+        \assert($classMetadata instanceof SerializerClassMetadata);
 
         // We base our scan on the internal driver's property list so that we
         // respect any internal allow/blocklist like in the AnnotationDriver

--- a/src/Metadata/Driver/TypedPropertiesDriver.php
+++ b/src/Metadata/Driver/TypedPropertiesDriver.php
@@ -67,6 +67,11 @@ class TypedPropertiesDriver implements DriverInterface
     public function loadMetadataForClass(ReflectionClass $class): ?ClassMetadata
     {
         $classMetadata = $this->delegate->loadMetadataForClass($class);
+
+        if (null === $classMetadata) {
+            return null;
+        }
+
         \assert($classMetadata instanceof SerializerClassMetadata);
 
         if (PHP_VERSION_ID <= 70400) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Doc updated   | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | N/A
| License       | MIT

Split off from #1494

The metadata drivers with delegates inconsistently check for null responses, either the check is made after an `assert()` or it's not made at all.  So this PR ensures we have these null checks and early returns before asserting the metadata object is a specific subclass.