### PR TITLE
Enable constants in YAML files with `!php/const` prefix.

### DIFF
--- a/doc/reference/yml_reference.rst
+++ b/doc/reference/yml_reference.rst
@@ -1,6 +1,7 @@
 YAML Reference
 --------------
-::
+
+.. code-block :: yaml
 
     # Vendor\MyBundle\Resources\config\serializer\Model.ClassName.yml
     Vendor\MyBundle\Model\ClassName:
@@ -76,3 +77,16 @@ YAML Reference
             pre_serialize: [foo, bar]
             post_serialize: [foo, bar]
             post_deserialize: [foo, bar]
+
+Constants
+---------
+
+In some cases, it may be helpful to reference constants in your YAML files.
+You can do this by prefixing the constant with the special `!php/const` syntax.
+
+.. code-block :: yaml
+
+    Vendor\MyBundle\Model\ClassName:
+        properties:
+            some-property:
+                serialized_name: !php/const Vendor\MyBundle\Model\ClassName::SOME_CONSTANT

--- a/src/Metadata/Driver/YamlDriver.php
+++ b/src/Metadata/Driver/YamlDriver.php
@@ -91,7 +91,7 @@ class YamlDriver extends AbstractFileDriver
 
     protected function loadMetadataFromFile(ReflectionClass $class, string $file): ?BaseClassMetadata
     {
-        $config = Yaml::parse(file_get_contents($file));
+        $config = Yaml::parseFile($file, Yaml::PARSE_CONSTANT);
 
         if (!isset($config[$name = $class->name])) {
             throw new InvalidMetadataException(

--- a/tests/Fixtures/Person.php
+++ b/tests/Fixtures/Person.php
@@ -15,6 +15,8 @@ use JMS\Serializer\Annotation\XmlValue;
 #[XmlRoot(name: 'child')]
 class Person
 {
+    public const ALTERNATE_SERIALIZED_NAME = 'personName';
+
     /**
      * @Type("string")
      * @XmlValue(cdata=false)

--- a/tests/Metadata/Driver/YamlDriverTest.php
+++ b/tests/Metadata/Driver/YamlDriverTest.php
@@ -26,7 +26,7 @@ class YamlDriverTest extends BaseDriverTestCase
         $m = $this->getDriver('const')->loadMetadataForClass(new \ReflectionClass(Person::class));
 
         self::assertArrayHasKey('name', $m->propertyMetadata);
-        self::assertNotNull($m->propertyMetadata['name']->serializedName);
+        self::assertNotNull($m->propertyMetadata['name']->serializedName ?? null);
         self::assertEquals(Person::ALTERNATE_SERIALIZED_NAME, $m->propertyMetadata['name']->serializedName);
     }
 

--- a/tests/Metadata/Driver/YamlDriverTest.php
+++ b/tests/Metadata/Driver/YamlDriverTest.php
@@ -21,6 +21,15 @@ class YamlDriverTest extends BaseDriverTestCase
         self::assertEquals(['age', 'name'], array_keys($m->propertyMetadata));
     }
 
+    public function testConstantIsParsed(): void
+    {
+        $m = $this->getDriver('const')->loadMetadataForClass(new \ReflectionClass(Person::class));
+
+        self::assertArrayHasKey('name', $m->propertyMetadata);
+        self::assertNotNull($m->propertyMetadata['name']->serializedName);
+        self::assertEquals(Person::ALTERNATE_SERIALIZED_NAME, $m->propertyMetadata['name']->serializedName);
+    }
+
     public function testShortExposeSyntax(): void
     {
         $m = $this->getDriver('short_expose')->loadMetadataForClass(new \ReflectionClass(Person::class));

--- a/tests/Metadata/Driver/yml/const/Person.yml
+++ b/tests/Metadata/Driver/yml/const/Person.yml
@@ -1,0 +1,5 @@
+JMS\Serializer\Tests\Fixtures\Person:
+    exclusion_policy: ALL
+    properties:
+        name:
+            serialized_name: !php/const JMS\Serializer\Tests\Fixtures\Person::ALTERNATE_SERIALIZED_NAME


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| Doc updated   | yes
| BC breaks?    | no (unless `!php/const Some\Class::CONSTANT` was used as a literal YAML string)
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | no
| License       | MIT

Enables a helpful feature in the Symfony Yaml component. See [here](https://symfony.com/doc/current/components/yaml.html#parsing-php-constants).