### PR TITLE
Only add the YamlDriver to the chain when `symfony/yaml` is installed

### DIFF
--- a/src/Builder/DefaultDriverFactory.php
+++ b/src/Builder/DefaultDriverFactory.php
@@ -19,6 +19,7 @@ use JMS\Serializer\Type\ParserInterface;
 use Metadata\Driver\DriverChain;
 use Metadata\Driver\DriverInterface;
 use Metadata\Driver\FileLocator;
+use Symfony\Component\Yaml\Yaml;
 
 final class DefaultDriverFactory implements DriverFactoryInterface
 {
@@ -56,19 +57,27 @@ final class DefaultDriverFactory implements DriverFactoryInterface
 
     public function createDriver(array $metadataDirs, Reader $annotationReader): DriverInterface
     {
-        $driver = new DriverChain([
-            new AnnotationOrAttributeDriver($this->propertyNamingStrategy, $this->typeParser, $this->expressionEvaluator, $annotationReader),
-        ]);
+        /*
+         * Build the sorted list of metadata drivers based on the environment. The final order should be:
+         *
+         * - YAML Driver
+         * - XML Driver
+         * - Annotations/Attributes Driver
+         * - Null (Fallback) Driver
+         */
+        $metadataDrivers = [new AnnotationOrAttributeDriver($this->propertyNamingStrategy, $this->typeParser, $this->expressionEvaluator, $annotationReader)];
 
         if (!empty($metadataDirs)) {
             $fileLocator = new FileLocator($metadataDirs);
-            $driver = new DriverChain([
-                new YamlDriver($fileLocator, $this->propertyNamingStrategy, $this->typeParser, $this->expressionEvaluator),
-                new XmlDriver($fileLocator, $this->propertyNamingStrategy, $this->typeParser, $this->expressionEvaluator),
-                $driver,
-            ]);
+
+            array_unshift($metadataDrivers, new XmlDriver($fileLocator, $this->propertyNamingStrategy, $this->typeParser, $this->expressionEvaluator));
+
+            if (class_exists(Yaml::class)) {
+                array_unshift($metadataDrivers, new YamlDriver($fileLocator, $this->propertyNamingStrategy, $this->typeParser, $this->expressionEvaluator));
+            }
         }
 
+        $driver = new DriverChain($metadataDrivers);
         $driver->addDriver(new NullDriver($this->propertyNamingStrategy));
 
         if ($this->enableEnumSupport) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Doc updated   | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | N/A
| License       | MIT

The `JMS\Serializer\Metadata\Driver\YamlDriver` class requires `Symfony\Component\Yaml\Yaml` to function.  Given `symfony/yaml` is an optional dependency, it shouldn't be arbitrarily included in the driver chain when using the default driver factory and specifying a list of metadata paths.  This PR updates the factory to check for the `Yaml` class before adding the YAML driver to the chain.