### PR TITLE
chore(dependencies): Allow doctrine/lexer:^3.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
         "php": "^7.2||^8.0",
         "doctrine/annotations": "^1.13 || ^2.0",
         "doctrine/instantiator": "^1.0.3 || ^2.0",
-        "doctrine/lexer": "^2",
+        "doctrine/lexer": "^2.0 || ^3.0",
         "jms/metadata": "^2.6",
         "phpstan/phpdoc-parser": "^0.4 || ^0.5 || ^1.0"
     },


### PR DESCRIPTION
Looking at
https://github.com/doctrine/lexer/releases/tag/3.0.0 it seems all that was changed with major release 3 was the dropped support for some older PHP versions. Hence we should be able to use this version as well without any additional changes.
Since the doctrine/lexer team is properly limiting the php version the package works with here
https://github.com/doctrine/lexer/blob/3.0.0/composer.json#L29 composer should automatically figure out to use
v2.x with older PHP versions.

| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| Doc updated   | no
| BC breaks?    | no <!-- don't forget updating UPGRADING.md file -->
| Deprecations? | yes <!-- don't forget updating UPGRADING.md file -->
| Tests pass?   | yes/no
| Fixed tickets | - <!-- #-prefixed issue number(s), if any -->
| License       | MIT

