### PR TITLE
fix(builder): enableEnumSupport should return self

### DIFF
--- a/src/SerializerBuilder.php
+++ b/src/SerializerBuilder.php
@@ -524,13 +524,15 @@ final class SerializerBuilder
         return $this;
     }
 
-    public function enableEnumSupport(bool $enableEnumSupport = true): void
+    public function enableEnumSupport(bool $enableEnumSupport = true): self
     {
         if ($enableEnumSupport && PHP_VERSION_ID < 80100) {
             throw new InvalidArgumentException('Enum support can be enabled only on PHP 8.1 or higher.');
         }
 
         $this->enableEnumSupport = $enableEnumSupport;
+
+        return $this;
     }
 
     public function setMetadataCache(CacheInterface $cache): self


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes/no
| New feature?  | yes/no
| Doc updated   | no
| BC breaks?    | no <!-- don't forget updating UPGRADING.md file -->
| Deprecations? | no <!-- don't forget updating UPGRADING.md file -->
| Tests pass?   | yes/no
| Fixed tickets | -
| License       | MIT

Not sure whether this should be classified as fix or feature.

With this PR the `SerializerBuilder::enableEnumSupport` method now returns `$this` to retain the fluent interface.