### PR TITLE
do not return null when no annotations or attributes are found by the…

### DIFF
--- a/src/Metadata/Driver/AnnotationDriver.php
+++ b/src/Metadata/Driver/AnnotationDriver.php
@@ -9,6 +9,9 @@ use JMS\Serializer\Expression\CompilableExpressionEvaluatorInterface;
 use JMS\Serializer\Naming\PropertyNamingStrategyInterface;
 use JMS\Serializer\Type\ParserInterface;
 
+/**
+ * @deprecated
+ */
 class AnnotationDriver extends AnnotationOrAttributeDriver
 {
     /**

--- a/src/Metadata/Driver/AnnotationOrAttributeDriver.php
+++ b/src/Metadata/Driver/AnnotationOrAttributeDriver.php
@@ -290,7 +290,8 @@ class AnnotationOrAttributeDriver implements DriverInterface
         }
 
         if (!$configured) {
-            return null;
+            // return null;
+            // uncomment the above line afetr a couple of months
         }
 
         return $classMetadata;


### PR DESCRIPTION

This reverts a small part of https://github.com/schmittjoh/serializer/pull/1494 to minimize the BC break introduced by it.

The plan is to add the NullDriver in the chain of the bundle, and then put back this line