### PR TITLE
Fix - change the order of instantiation checks

### DIFF
--- a/src/Metadata/Driver/DocBlockDriver/DocBlockTypeResolver.php
+++ b/src/Metadata/Driver/DocBlockDriver/DocBlockTypeResolver.php
@@ -249,10 +249,6 @@ final class DocBlockTypeResolver
      */
     private function expandClassNameUsingUseStatements(string $typeHint, \ReflectionClass $declaringClass, $reflector): string
     {
-        if ($this->isClassOrInterface($typeHint)) {
-            return $typeHint;
-        }
-
         $expandedClassName = $declaringClass->getNamespaceName() . '\\' . $typeHint;
         if ($this->isClassOrInterface($expandedClassName)) {
             return $expandedClassName;
@@ -280,6 +276,10 @@ final class DocBlockTypeResolver
             if ($phpstanArrayType) {
                 return $phpstanArrayType;
             }
+        }
+
+        if ($this->isClassOrInterface($typeHint)) {
+            return $typeHint;
         }
 
         throw new \InvalidArgumentException(sprintf("Can't use incorrect type %s for collection in %s:%s", $typeHint, $declaringClass->getName(), $reflector->getName()));


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Doc updated   | no
| BC breaks?    | no <!-- don't forget updating UPGRADING.md file -->
| Deprecations? | no <!-- don't forget updating UPGRADING.md file -->
| Tests pass?   | yes
| Fixed tickets | #1512
| License       | MIT


Fix for issue described in #1512 all this does is rearrange the resolution logic so when a type is described as eg:

```
@var Product
```

The resolution order now will be:

1. Look for a class in the current namespace called `Product`
2. Parse the `use` statements and look for a class defined as `Namespace\Example\Product`
3. Finally fallback to a class or interface defined in the global namespace `\Product`

Currently steps 1 and 3 are reversed and that effectively means that a precisely defined class is ignored in favour of a more loosely specified one.


