### PR TITLE
Run the ORM tests using an attribute driver when able

### DIFF
--- a/tests/Fixtures/Doctrine/Embeddable/BlogPostSeo.php
+++ b/tests/Fixtures/Doctrine/Embeddable/BlogPostSeo.php
@@ -4,11 +4,13 @@ declare(strict_types=1);
 
 namespace JMS\Serializer\Tests\Fixtures\Doctrine\Embeddable;
 
+use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\Mapping as ORM;
 
 /**
  * @ORM\Embeddable()
  */
+#[ORM\Embeddable]
 class BlogPostSeo
 {
     /**
@@ -16,5 +18,6 @@ class BlogPostSeo
      *
      * @var string
      */
+    #[ORM\Column(type: Types::STRING, name: 'meta_title')]
     private $metaTitle;
 }

--- a/tests/Fixtures/Doctrine/Embeddable/BlogPostWithEmbedded.php
+++ b/tests/Fixtures/Doctrine/Embeddable/BlogPostWithEmbedded.php
@@ -4,11 +4,13 @@ declare(strict_types=1);
 
 namespace JMS\Serializer\Tests\Fixtures\Doctrine\Embeddable;
 
+use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\Mapping as ORM;
 
 /**
  * @ORM\Entity
  */
+#[ORM\Entity]
 class BlogPostWithEmbedded
 {
     /**
@@ -16,10 +18,14 @@ class BlogPostWithEmbedded
      * @ORM\Column(type="integer")
      * @ORM\GeneratedValue(strategy="AUTO")
      */
+    #[ORM\Id]
+    #[ORM\Column(type: Types::INTEGER)]
+    #[ORM\GeneratedValue(strategy: 'AUTO')]
     protected $id;
 
     /**
      * @ORM\Embedded(class="BlogPostSeo", columnPrefix="seo_")
      */
+    #[ORM\Embedded(class: BlogPostSeo::class, columnPrefix: 'seo_')]
     private $seo;
 }

--- a/tests/Fixtures/Doctrine/Entity/Author.php
+++ b/tests/Fixtures/Doctrine/Entity/Author.php
@@ -4,11 +4,13 @@ declare(strict_types=1);
 
 namespace JMS\Serializer\Tests\Fixtures\Doctrine\Entity;
 
+use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\Mapping as ORM;
 use JMS\Serializer\Annotation\Groups;
 use JMS\Serializer\Annotation\SerializedName;
 
 /** @ORM\Entity */
+#[ORM\Entity]
 class Author
 {
     /**
@@ -17,6 +19,9 @@ class Author
      *
      * @Groups({"id_group"})
      */
+    #[ORM\Id]
+    #[ORM\Column(type: Types::INTEGER)]
+    #[Groups(groups: ['id_group'])]
     protected $id;
 
     /**
@@ -24,6 +29,8 @@ class Author
      *
      * @SerializedName("full_name")
      */
+    #[ORM\Column(type: Types::STRING)]
+    #[SerializedName(name: 'full_name')]
     private $name;
 
     public function __construct($name, $id = null)

--- a/tests/Fixtures/Doctrine/Entity/AuthorExcludedId.php
+++ b/tests/Fixtures/Doctrine/Entity/AuthorExcludedId.php
@@ -4,11 +4,13 @@ declare(strict_types=1);
 
 namespace JMS\Serializer\Tests\Fixtures\Doctrine\Entity;
 
+use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\Mapping as ORM;
 use JMS\Serializer\Annotation\Exclude;
 use JMS\Serializer\Annotation\SerializedName;
 
 /** @ORM\Entity */
+#[ORM\Entity]
 class AuthorExcludedId
 {
     /**
@@ -17,6 +19,8 @@ class AuthorExcludedId
      *
      * @Exclude
      */
+    #[ORM\Id]
+    #[ORM\Column(type: Types::INTEGER)]
     #[Exclude]
     protected $id;
 
@@ -25,6 +29,7 @@ class AuthorExcludedId
      *
      * @SerializedName("full_name")
      */
+    #[ORM\Column(type: Types::STRING)]
     #[SerializedName(name: 'full_name')]
     private $name;
 

--- a/tests/Fixtures/Doctrine/Entity/BlogPost.php
+++ b/tests/Fixtures/Doctrine/Entity/BlogPost.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace JMS\Serializer\Tests\Fixtures\Doctrine\Entity;
 
 use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\Mapping as ORM;
 use JMS\Serializer\Annotation as Serializer;
 use JMS\Serializer\Annotation\Groups;
@@ -19,6 +20,7 @@ use JMS\Serializer\Annotation\XmlRoot;
  *
  * @XmlRoot("blog-post")
  */
+#[ORM\Entity]
 #[XmlRoot(name: 'blog-post')]
 class BlogPost
 {
@@ -27,11 +29,15 @@ class BlogPost
      * @ORM\Column(type="integer")
      * @ORM\GeneratedValue(strategy="AUTO")
      */
+    #[ORM\Id]
+    #[ORM\Column(type: Types::INTEGER)]
+    #[ORM\GeneratedValue(strategy: 'AUTO')]
     protected $id;
 
     /**
      * @ORM\Column(type="guid")
      */
+    #[ORM\Column(type: Types::GUID)]
     private $guid;
 
     /**
@@ -39,12 +45,14 @@ class BlogPost
      *
      * @Groups({"comments","post"})
      */
+    #[ORM\Column(type: Types::STRING)]
     #[Groups(groups: ['comments', 'post'])]
     private $title;
 
     /**
      * @ORM\Column(type="some_custom_type")
      */
+    #[ORM\Column(type: 'some_custom_type')]
     protected $slug;
 
     /**
@@ -52,6 +60,7 @@ class BlogPost
      *
      * @XmlAttribute
      */
+    #[ORM\Column(type: Types::DATETIME_MUTABLE)]
     #[XmlAttribute]
     private $createdAt;
 
@@ -66,6 +75,7 @@ class BlogPost
      * @Groups({"post"})
      * @XmlAttribute
      */
+    #[ORM\Column(type: Types::BOOLEAN)]
     #[Type(name: 'integer')]
     #[SerializedName(name: 'is_published')]
     #[Groups(groups: ['post'])]
@@ -78,6 +88,7 @@ class BlogPost
      * @XmlList(inline=true, entry="comment")
      * @Groups({"comments"})
      */
+    #[ORM\OneToMany(targetEntity: Comment::class, mappedBy: 'blogPost')]
     #[XmlList(entry: 'comment', inline: true)]
     #[Groups(groups: ['comments'])]
     private $comments;
@@ -87,13 +98,15 @@ class BlogPost
      *
      * @Groups({"post"})
      */
+    #[ORM\OneToOne(targetEntity: Author::class)]
     #[Groups(groups: ['post'])]
     private $author;
 
     /**
-     * @Serializer\Exclude()
      * @ORM\Column(type="integer")
+     * @Serializer\Exclude()
      */
+    #[ORM\Column(type: Types::INTEGER)]
     #[Serializer\Exclude]
     private $ref;
 

--- a/tests/Fixtures/Doctrine/Entity/Comment.php
+++ b/tests/Fixtures/Doctrine/Entity/Comment.php
@@ -5,28 +5,35 @@ declare(strict_types=1);
 namespace JMS\Serializer\Tests\Fixtures\Doctrine\Entity;
 
 use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\Mapping as ORM;
 
 /** @ORM\Entity */
+#[ORM\Entity]
 class Comment
 {
     /**
      * @ORM\Id
      * @ORM\Column(type="integer")
      */
+    #[ORM\Id]
+    #[ORM\Column(type: Types::INTEGER)]
     protected $id;
 
     /**
-     * @ORM\Column(type="Author")
+     * @ORM\OneToOne(targetEntity="Author")
      */
+    #[ORM\OneToOne(targetEntity: Author::class)]
     private $author;
 
     /** @ORM\ManyToOne(targetEntity="BlogPost") */
+    #[ORM\ManyToOne(targetEntity: BlogPost::class)]
     private $blogPost;
 
     /**
      * @ORM\Column(type="string")
      */
+    #[ORM\Column(type: Types::STRING)]
     private $text;
 
     public function __construct(Author $author, $text)

--- a/tests/Fixtures/Doctrine/IdentityFields/Server.php
+++ b/tests/Fixtures/Doctrine/IdentityFields/Server.php
@@ -4,10 +4,12 @@ declare(strict_types=1);
 
 namespace JMS\Serializer\Tests\Fixtures\Doctrine\IdentityFields;
 
+use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\Mapping as ORM;
 use JMS\Serializer\Annotation as Serializer;
 
 /** @ORM\Entity */
+#[ORM\Entity]
 class Server
 {
     /**
@@ -18,6 +20,8 @@ class Server
      * @var string
      */
     #[Serializer\Type(name: 'string')]
+    #[ORM\Id]
+    #[ORM\Column(type: Types::STRING, name: 'ip_address')]
     protected $ipAddress;
 
     /**
@@ -30,6 +34,8 @@ class Server
      */
     #[Serializer\SerializedName(name: 'server_id_extracted')]
     #[Serializer\Type(name: 'string')]
+    #[ORM\Id]
+    #[ORM\Column(type: Types::STRING, name: 'server_id')]
     protected $serverId;
 
     /**
@@ -39,6 +45,7 @@ class Server
      * @var string
      */
     #[Serializer\Type(name: 'string')]
+    #[ORM\Column(type: Types::STRING)]
     private $name;
 
     /**

--- a/tests/Fixtures/Doctrine/PersistendCollection/App.php
+++ b/tests/Fixtures/Doctrine/PersistendCollection/App.php
@@ -4,10 +4,12 @@ declare(strict_types=1);
 
 namespace JMS\Serializer\Tests\Fixtures\Doctrine\PersistendCollection;
 
+use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\Mapping as ORM;
 use JMS\Serializer\Annotation as Serializer;
 
 /** @ORM\Entity */
+#[ORM\Entity]
 class App
 {
     /**
@@ -18,7 +20,10 @@ class App
      *
      * @var string
      */
+    #[Serializer\SerializedName(name: 'id')]
     #[Serializer\Type(name: 'string')]
+    #[ORM\Id]
+    #[ORM\Column(type: Types::STRING, name: 'id')]
     protected $id;
 
     /**
@@ -28,13 +33,16 @@ class App
      * @var string
      */
     #[Serializer\Type(name: 'string')]
+    #[ORM\Column(type: Types::STRING)]
     private $name;
 
     /**
      * @ORM\ManyToOne(targetEntity="SmartPhone")
+     * @Serializer\Type("JMS\Serializer\Tests\Fixtures\Doctrine\PersistendCollection\SmartPhone")
      *
      * @var SmartPhone
      */
+    #[ORM\ManyToOne(targetEntity: SmartPhone::class)]
     #[Serializer\Type(name: SmartPhone::class)]
     private $smartPhone;
 

--- a/tests/Fixtures/Doctrine/PersistendCollection/SmartPhone.php
+++ b/tests/Fixtures/Doctrine/PersistendCollection/SmartPhone.php
@@ -7,10 +7,12 @@ namespace JMS\Serializer\Tests\Fixtures\Doctrine\PersistendCollection;
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
 use Doctrine\Common\Collections\Criteria;
+use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\Mapping as ORM;
 use JMS\Serializer\Annotation as Serializer;
 
 /** @ORM\Entity */
+#[ORM\Entity]
 class SmartPhone
 {
     /**
@@ -23,6 +25,8 @@ class SmartPhone
      */
     #[Serializer\SerializedName(name: 'id')]
     #[Serializer\Type(name: 'string')]
+    #[ORM\Id]
+    #[ORM\Column(type: Types::STRING, name: 'id')]
     protected $id;
 
     /**
@@ -32,6 +36,7 @@ class SmartPhone
      * @var string
      */
     #[Serializer\Type(name: 'string')]
+    #[ORM\Column(type: Types::STRING)]
     private $name;
 
     /**
@@ -43,6 +48,7 @@ class SmartPhone
      */
     #[Serializer\SerializedName(name: 'applications')]
     #[Serializer\Type(name: 'ArrayCollection<JMS\Serializer\Tests\Fixtures\Doctrine\PersistendCollection\App>')]
+    #[ORM\OneToMany(targetEntity: App::class, mappedBy: 'smartPhone', cascade: ['persist'], orphanRemoval: true)]
     private $apps;
 
     /**

--- a/tests/Fixtures/Doctrine/SingleTableInheritance/Clazz.php
+++ b/tests/Fixtures/Doctrine/SingleTableInheritance/Clazz.php
@@ -5,11 +5,13 @@ declare(strict_types=1);
 namespace JMS\Serializer\Tests\Fixtures\Doctrine\SingleTableInheritance;
 
 use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\Mapping as ORM;
 
 /**
  * @ORM\Entity
  */
+#[ORM\Entity]
 class Clazz extends AbstractModel
 {
     /**
@@ -17,12 +19,17 @@ class Clazz extends AbstractModel
      * @ORM\Column(type="integer")
      * @ORM\GeneratedValue(strategy="AUTO")
      */
+    #[ORM\Id]
+    #[ORM\Column(type: Types::INTEGER)]
+    #[ORM\GeneratedValue(strategy: 'AUTO')]
     private $id;
 
     /** @ORM\ManyToOne(targetEntity = "JMS\Serializer\Tests\Fixtures\Doctrine\SingleTableInheritance\Teacher") */
+    #[ORM\ManyToOne(targetEntity: Teacher::class)]
     private $teacher;
 
     /** @ORM\ManyToMany(targetEntity = "JMS\Serializer\Tests\Fixtures\Doctrine\SingleTableInheritance\Student") */
+    #[ORM\ManyToMany(targetEntity: Student::class)]
     private $students;
 
     public function __construct(Teacher $teacher, array $students)

--- a/tests/Fixtures/Doctrine/SingleTableInheritance/Organization.php
+++ b/tests/Fixtures/Doctrine/SingleTableInheritance/Organization.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace JMS\Serializer\Tests\Fixtures\Doctrine\SingleTableInheritance;
 
+use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\Mapping as ORM;
 
 /**
@@ -14,6 +15,10 @@ use Doctrine\ORM\Mapping as ORM;
  *     "school" = "JMS\Serializer\Tests\Fixtures\Doctrine\SingleTableInheritance\School"
  * })
  */
+#[ORM\Entity]
+#[ORM\InheritanceType('SINGLE_TABLE')]
+#[ORM\DiscriminatorColumn(name: 'type', type: Types::STRING)]
+#[ORM\DiscriminatorMap(['school' => School::class])]
 abstract class Organization
 {
     /**
@@ -21,5 +26,8 @@ abstract class Organization
      * @ORM\Column(type="integer")
      * @ORM\GeneratedValue(strategy="AUTO")
      */
+    #[ORM\Id]
+    #[ORM\Column(type: Types::INTEGER)]
+    #[ORM\GeneratedValue(strategy: 'AUTO')]
     private $id;
 }

--- a/tests/Fixtures/Doctrine/SingleTableInheritance/Person.php
+++ b/tests/Fixtures/Doctrine/SingleTableInheritance/Person.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace JMS\Serializer\Tests\Fixtures\Doctrine\SingleTableInheritance;
 
+use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\Mapping as ORM;
 
 /**
@@ -15,6 +16,10 @@ use Doctrine\ORM\Mapping as ORM;
  *     "teacher" = "JMS\Serializer\Tests\Fixtures\Doctrine\SingleTableInheritance\Teacher",
  * })
  */
+#[ORM\Entity]
+#[ORM\InheritanceType('SINGLE_TABLE')]
+#[ORM\DiscriminatorColumn(name: 'type', type: Types::STRING)]
+#[ORM\DiscriminatorMap(['student' => Student::class, 'teacher' => Teacher::class])]
 abstract class Person extends AbstractModel
 {
     /**
@@ -22,5 +27,8 @@ abstract class Person extends AbstractModel
      * @ORM\Column(type = "integer")
      * @ORM\GeneratedValue(strategy = "AUTO")
      */
+    #[ORM\Id]
+    #[ORM\Column(type: Types::INTEGER)]
+    #[ORM\GeneratedValue(strategy: 'AUTO')]
     private $id;
 }

--- a/tests/Fixtures/Doctrine/SingleTableInheritance/School.php
+++ b/tests/Fixtures/Doctrine/SingleTableInheritance/School.php
@@ -9,6 +9,7 @@ use Doctrine\ORM\Mapping as ORM;
 /**
  * @ORM\Entity
  */
+#[ORM\Entity]
 class School extends Organization
 {
 }

--- a/tests/Fixtures/Doctrine/SingleTableInheritance/Student.php
+++ b/tests/Fixtures/Doctrine/SingleTableInheritance/Student.php
@@ -9,6 +9,7 @@ use Doctrine\ORM\Mapping as ORM;
 /**
  * @ORM\Entity
  */
+#[ORM\Entity]
 class Student extends Person
 {
 }

--- a/tests/Fixtures/Doctrine/SingleTableInheritance/Teacher.php
+++ b/tests/Fixtures/Doctrine/SingleTableInheritance/Teacher.php
@@ -9,6 +9,7 @@ use Doctrine\ORM\Mapping as ORM;
 /**
  * @ORM\Entity
  */
+#[ORM\Entity]
 class Teacher extends Person
 {
 }

--- a/tests/Metadata/Driver/DoctrineDriverTest.php
+++ b/tests/Metadata/Driver/DoctrineDriverTest.php
@@ -7,7 +7,8 @@ namespace JMS\Serializer\Tests\Metadata\Driver;
 use Doctrine\Common\Annotations\AnnotationReader;
 use Doctrine\ORM\Configuration;
 use Doctrine\ORM\EntityManager;
-use Doctrine\ORM\Mapping\Driver\AnnotationDriver as DoctrineDriver;
+use Doctrine\ORM\Mapping\Driver\AnnotationDriver as DoctrineAnnotationDriver;
+use Doctrine\ORM\Mapping\Driver\AttributeDriver as DoctrineAttributeDriver;
 use Doctrine\ORM\Version as ORMVersion;
 use Doctrine\Persistence\ManagerRegistry;
 use JMS\Serializer\Metadata\Driver\AnnotationDriver;
@@ -134,9 +135,16 @@ class DoctrineDriverTest extends TestCase
         $config = new Configuration();
         $config->setProxyDir(sys_get_temp_dir() . '/JMSDoctrineTestProxies');
         $config->setProxyNamespace('JMS\Tests\Proxies');
-        $config->setMetadataDriverImpl(
-            new DoctrineDriver(new AnnotationReader(), __DIR__ . '/../../Fixtures/Doctrine')
-        );
+
+        if (PHP_VERSION_ID >= 80000 && class_exists(DoctrineAttributeDriver::class)) {
+            $config->setMetadataDriverImpl(
+                new DoctrineAttributeDriver([__DIR__ . '/../../Fixtures/Doctrine'], true)
+            );
+        } else {
+            $config->setMetadataDriverImpl(
+                new DoctrineAnnotationDriver(new AnnotationReader(), __DIR__ . '/../../Fixtures/Doctrine')
+            );
+        }
 
         $conn = [
             'driver' => 'pdo_sqlite',

--- a/tests/Serializer/Doctrine/IntegrationTest.php
+++ b/tests/Serializer/Doctrine/IntegrationTest.php
@@ -11,6 +11,7 @@ use Doctrine\DBAL\DriverManager;
 use Doctrine\ORM\Configuration;
 use Doctrine\ORM\EntityManager;
 use Doctrine\ORM\Mapping\Driver\AnnotationDriver;
+use Doctrine\ORM\Mapping\Driver\AttributeDriver;
 use Doctrine\ORM\ORMException;
 use Doctrine\ORM\Tools\SchemaTool;
 use Doctrine\Persistence\AbstractManagerRegistry;
@@ -135,9 +136,17 @@ class IntegrationTest extends TestCase
     private function createEntityManager(Connection $con)
     {
         $cfg = new Configuration();
-        $cfg->setMetadataDriverImpl(new AnnotationDriver(new AnnotationReader(), [
-            __DIR__ . '/../../Fixtures/Doctrine/SingleTableInheritance',
-        ]));
+
+        if (PHP_VERSION_ID >= 80000 && class_exists(AttributeDriver::class)) {
+            $cfg->setMetadataDriverImpl(new AttributeDriver([
+                __DIR__ . '/../../Fixtures/Doctrine/SingleTableInheritance',
+            ]));
+        } else {
+            $cfg->setMetadataDriverImpl(new AnnotationDriver(new AnnotationReader(), [
+                __DIR__ . '/../../Fixtures/Doctrine/SingleTableInheritance',
+            ]));
+        }
+
         $cfg->setAutoGenerateProxyClasses(true);
         $cfg->setProxyNamespace('JMS\Serializer\DoctrineProxy');
         $cfg->setProxyDir(sys_get_temp_dir() . '/serializer-test-proxies');

--- a/tests/Serializer/Doctrine/ObjectConstructorTest.php
+++ b/tests/Serializer/Doctrine/ObjectConstructorTest.php
@@ -13,6 +13,7 @@ use Doctrine\DBAL\Types\Type;
 use Doctrine\ORM\Configuration;
 use Doctrine\ORM\EntityManager;
 use Doctrine\ORM\Mapping\Driver\AnnotationDriver;
+use Doctrine\ORM\Mapping\Driver\AttributeDriver;
 use Doctrine\ORM\Mapping\Driver\XmlDriver;
 use Doctrine\ORM\ORMException;
 use Doctrine\ORM\PersistentCollection;
@@ -534,11 +535,20 @@ class ObjectConstructorTest extends TestCase
     {
         if (!$cfg) {
             $cfg = new Configuration();
-            $cfg->setMetadataDriverImpl(new AnnotationDriver(new AnnotationReader(), [
-                __DIR__ . '/../../Fixtures/Doctrine/Entity',
-                __DIR__ . '/../../Fixtures/Doctrine/IdentityFields',
-                __DIR__ . '/../../Fixtures/Doctrine/PersistendCollection',
-            ]));
+
+            if (PHP_VERSION_ID >= 80000 && class_exists(AttributeDriver::class)) {
+                $cfg->setMetadataDriverImpl(new AttributeDriver([
+                    __DIR__ . '/../../Fixtures/Doctrine/Entity',
+                    __DIR__ . '/../../Fixtures/Doctrine/IdentityFields',
+                    __DIR__ . '/../../Fixtures/Doctrine/PersistendCollection',
+                ]));
+            } else {
+                $cfg->setMetadataDriverImpl(new AnnotationDriver(new AnnotationReader(), [
+                    __DIR__ . '/../../Fixtures/Doctrine/Entity',
+                    __DIR__ . '/../../Fixtures/Doctrine/IdentityFields',
+                    __DIR__ . '/../../Fixtures/Doctrine/PersistendCollection',
+                ]));
+            }
         }
 
         $cfg->setAutoGenerateProxyClasses(true);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| Doc updated   | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | Partially #1516
| License       | MIT

This PR changes the test suite to run the ORM's integration tests configuring the entity manager to use the attribute driver on PHP 8 and it exists, falling back to the annotation driver when not available.  The bulk of this PR is actually adding attributes to all the fixture classes, there're only 3 test classes that actually changed.