### PR TITLE
build(tests): Run tests without Doctrine ODM

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -45,6 +45,9 @@ jobs:
         if: ${{ matrix.composer-stability }}
         run: composer config minimum-stability ${{ matrix.composer-stability }}
 
+      - name: Uninstall Doctrine ODM
+        run: composer remove doctrine/phpcr-odm jackalope/jackalope-doctrine-dbal --no-update --dev
+
       - name: "Install dependencies with Composer"
         uses: "ramsey/composer-install@v1"
         with:


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| Doc updated   | no
| BC breaks?    | no <!-- don't forget updating UPGRADING.md file -->
| Deprecations? | no <!-- don't forget updating UPGRADING.md file -->
| Tests pass?   | yes
| Fixed tickets | partially #1516
| License       | MIT

It looks like Doctrine ODM is not covered with tests - it is only used during the static analysis. 
Let's remove it from the dev dependencies during tests, but keep them for static analysis. 
This MR should unblock integration with ORM 3.0 - it looks like ODM will need a lot of changes to make it compatible with `doctrine/persistence` 3.0. 
