### PR TITLE
Bump minimum dependencies to match what's actually tested

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,12 +16,12 @@
         }
     ],
     "require": {
-        "php": "^7.2||^8.0",
-        "doctrine/annotations": "^1.13 || ^2.0",
-        "doctrine/instantiator": "^1.0.3 || ^2.0",
+        "php": "^7.2 || ^8.0",
+        "doctrine/annotations": "^1.14 || ^2.0",
+        "doctrine/instantiator": "^1.3.1 || ^2.0",
         "doctrine/lexer": "^2.0 || ^3.0",
         "jms/metadata": "^2.6",
-        "phpstan/phpdoc-parser": "^0.4 || ^0.5 || ^1.0"
+        "phpstan/phpdoc-parser": "^1.20"
     },
     "suggest": {
         "doctrine/collections": "Required if you like to use doctrine collection types as ArrayCollection.",
@@ -32,24 +32,24 @@
     "require-dev": {
         "ext-pdo_sqlite": "*",
         "doctrine/coding-standard": "^12.0",
-        "doctrine/orm": "~2.1",
-        "doctrine/persistence": "^1.3.3|^2.0|^3.0",
-        "doctrine/phpcr-odm": "^1.3|^2.0",
-        "jackalope/jackalope-doctrine-dbal": "^1.1.5",
-        "ocramius/proxy-manager": "^1.0|^2.0",
+        "doctrine/orm": "^2.14",
+        "doctrine/persistence": "^2.5.2 || ^3.0",
+        "doctrine/phpcr-odm": "^1.5.2 || ^2.0",
+        "jackalope/jackalope-doctrine-dbal": "^1.3",
+        "ocramius/proxy-manager": "^1.0 || ^2.0",
         "phpbench/phpbench": "^1.0",
         "phpstan/phpstan": "^1.0.2",
-        "phpunit/phpunit": "^8.5.21||^9.0||^10.0",
-        "psr/container": "^1.0|^2.0",
-        "symfony/dependency-injection": "^3.0|^4.0|^5.0|^6.0|^7.0",
-        "symfony/expression-language": "^3.2|^4.0|^5.0|^6.0|^7.0",
-        "symfony/filesystem": "^3.0|^4.0|^5.0|^6.0|^7.0",
-        "symfony/form": "^3.0|^4.0|^5.0|^6.0|^7.0",
-        "symfony/translation": "^3.0|^4.0|^5.0|^6.0|^7.0",
-        "symfony/uid": "^5.1|^6.0|^7.0",
-        "symfony/validator": "^3.1.9|^4.0|^5.0|^6.0|^7.0",
-        "symfony/yaml": "^3.3|^4.0|^5.0|^6.0|^7.0",
-        "twig/twig": "~1.34|~2.4|^3.0"
+        "phpunit/phpunit": "^8.5.21 || ^9.0 || ^10.0",
+        "psr/container": "^1.0 || ^2.0",
+        "symfony/dependency-injection": "^3.4 || ^4.0 || ^5.0 || ^6.0 || ^7.0",
+        "symfony/expression-language": "^3.2 || ^4.0 || ^5.0 || ^6.0 || ^7.0",
+        "symfony/filesystem": "^4.2 || ^5.0 || ^6.0 || ^7.0",
+        "symfony/form": "^3.4 || ^4.0 || ^5.0 || ^6.0 || ^7.0",
+        "symfony/translation": "^3.0 || ^4.0 || ^5.0 || ^6.0 || ^7.0",
+        "symfony/uid": "^5.1 || ^6.0 || ^7.0",
+        "symfony/validator": "^3.1.9 || ^4.0 || ^5.0 || ^6.0 || ^7.0",
+        "symfony/yaml": "^3.4 || ^4.0 || ^5.0 || ^6.0 || ^7.0",
+        "twig/twig": "^1.34 || ^2.4 || ^3.0"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| Doc updated   | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | N/A
| License       | MIT

This just bumps the minimum dependency versions in `composer.json` to match the actual versions installed on the PHP 7.2 lowest deps build (https://github.com/schmittjoh/serializer/actions/runs/6449612330/job/17508114478) and normalizes the file's formatting.  The only one that might have a practical impact on folks is if they use `phpstan/phpdoc-parser` at an older release as it's probably constrained by the dev dependency chain here in ways the production dependencies won't be, otherwise a lot of this stuff is somewhat old anyway and with upcoming major releases from a number of tools, the wider ranges eventually start causing extra maintenance burden.