### PR TITLE
Allow`doctrine/orm` 3.0

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -45,6 +45,9 @@ jobs:
         if: ${{ matrix.composer-stability }}
         run: composer config minimum-stability ${{ matrix.composer-stability }}
 
+      - name: Uninstall Doctrine ODM
+        run: composer remove doctrine/phpcr-odm jackalope/jackalope-doctrine-dbal --no-update --dev
+
       - name: "Install dependencies with Composer"
         uses: "ramsey/composer-install@v1"
         with:

--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,7 @@
     "require-dev": {
         "ext-pdo_sqlite": "*",
         "doctrine/coding-standard": "^12.0",
-        "doctrine/orm": "^2.14",
+        "doctrine/orm": "^2.14 || ^3.0",
         "doctrine/persistence": "^2.5.2 || ^3.0",
         "doctrine/phpcr-odm": "^1.5.2 || ^2.0",
         "jackalope/jackalope-doctrine-dbal": "^1.3",
@@ -72,5 +72,6 @@
         "branch-alias": {
             "dev-master": "3.x-dev"
         }
-    }
+    },
+    "minimum-stability": "dev"
 }

--- a/tests/Fixtures/Doctrine/XmlMapping/JMS.Serializer.Tests.Fixtures.Doctrine.Embeddable.BlogPostSeo.dcm.xml
+++ b/tests/Fixtures/Doctrine/XmlMapping/JMS.Serializer.Tests.Fixtures.Doctrine.Embeddable.BlogPostSeo.dcm.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<doctrine-mapping xmlns="http://doctrine-project.org/schemas/orm/doctrine-mapping" xsi="http://www.w3.org/2001/XMLSchema-instance" schemaLocation="http://doctrine-project.org/schemas/orm/doctrine-mapping.xsd">
+<doctrine-mapping xmlns="http://doctrine-project.org/schemas/orm/doctrine-mapping">
   <embeddable name="JMS\Serializer\Tests\Fixtures\Doctrine\Embeddable\BlogPostSeo">
     <field name="metaTitle" column="meta_title" type="string" nullable="false"/>
   </embeddable>

--- a/tests/Serializer/Doctrine/IntegrationTest.php
+++ b/tests/Serializer/Doctrine/IntegrationTest.php
@@ -141,6 +141,7 @@ class IntegrationTest extends TestCase
             $cfg->setMetadataDriverImpl(new AttributeDriver([
                 __DIR__ . '/../../Fixtures/Doctrine/SingleTableInheritance',
             ]));
+            AnnotationReader::addGlobalIgnoredNamespace('Doctrine\ORM\Mapping');
         } else {
             $cfg->setMetadataDriverImpl(new AnnotationDriver(new AnnotationReader(), [
                 __DIR__ . '/../../Fixtures/Doctrine/SingleTableInheritance',

--- a/tests/Serializer/Doctrine/ObjectConstructorTest.php
+++ b/tests/Serializer/Doctrine/ObjectConstructorTest.php
@@ -58,7 +58,6 @@ use PHPUnit\Framework\TestCase;
 use ReflectionClass;
 use RuntimeException;
 use SimpleXMLElement;
-
 use function assert;
 
 class ObjectConstructorTest extends TestCase
@@ -471,8 +470,7 @@ class ObjectConstructorTest extends TestCase
     protected function setUp(): void
     {
         $this->visitor = $this->getMockBuilder(DeserializationVisitorInterface::class)->getMock();
-        $this->context = $this->getMockBuilder('JMS\Serializer\DeserializationContext')->getMock();
-
+        $this->context = $this->getMockBuilder(DeserializationContext::class)->getMock();
         $connection = $this->createConnection();
         $entityManager = $this->createEntityManager($connection);
 
@@ -528,6 +526,7 @@ class ObjectConstructorTest extends TestCase
             $cfg = new Configuration();
 
             if (PHP_VERSION_ID >= 80000 && class_exists(AttributeDriver::class)) {
+                AnnotationReader::addGlobalIgnoredNamespace('Doctrine\ORM\Mapping');
                 $cfg->setMetadataDriverImpl(new AttributeDriver([
                     __DIR__ . '/../../Fixtures/Doctrine/Entity',
                     __DIR__ . '/../../Fixtures/Doctrine/IdentityFields',


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| Doc updated   | no
| BC breaks?    | no <!-- don't forget updating UPGRADING.md file -->
| Deprecations? | no <!-- don't forget updating UPGRADING.md file -->
| Tests pass?   | no
| Fixed tickets | #1516 
| License       | MIT

Build on top of #1518 to allow testing in CI with new ORM version.

