### PR TITLE
Allow missing attributes in serialized objects

### DIFF
--- a/phpstan/ignore-by-php-version.neon.php
+++ b/phpstan/ignore-by-php-version.neon.php
@@ -10,7 +10,7 @@ if (PHP_VERSION_ID < 80100) {
     $includes[] = __DIR__ . '/no-enum.neon';
 }
 if (PHP_VERSION_ID >= 80000) {
-    $includes[] = __DIR__ . '/ignore-missing-attributes.neon';
+    $includes[] = __DIR__ . '/ignore-missing-attribute.neon';
 }
 if (PHP_VERSION_ID >= 80100 && PHP_VERSION_ID < 80200) {
     $includes[] = __DIR__ . '/php-81.neon';

--- a/phpstan/ignore-by-php-version.neon.php
+++ b/phpstan/ignore-by-php-version.neon.php
@@ -9,6 +9,9 @@ if (PHP_VERSION_ID < 80000) {
 if (PHP_VERSION_ID < 80100) {
     $includes[] = __DIR__ . '/no-enum.neon';
 }
+if (PHP_VERSION_ID >= 80000) {
+    $includes[] = __DIR__ . '/ignore-missing-attributes.neon';
+}
 if (PHP_VERSION_ID >= 80100 && PHP_VERSION_ID < 80200) {
     $includes[] = __DIR__ . '/php-81.neon';
 }

--- a/phpstan/ignore-missing-attribute.neon
+++ b/phpstan/ignore-missing-attribute.neon
@@ -1,0 +1,3 @@
+parameters:
+  ignoreErrors:
+    - '#^Attribute class JMS\\Serializer\\Tests\\Fixtures\\MissingAttribute does not exist\.$#'

--- a/src/Metadata/Driver/AnnotationOrAttributeDriver.php
+++ b/src/Metadata/Driver/AnnotationOrAttributeDriver.php
@@ -48,6 +48,8 @@ use Metadata\ClassMetadata as BaseClassMetadata;
 use Metadata\Driver\DriverInterface;
 use Metadata\MethodMetadata;
 
+use function array_filter;
+
 class AnnotationOrAttributeDriver implements DriverInterface
 {
     use ExpressionMetadataTrait;
@@ -309,7 +311,12 @@ class AnnotationOrAttributeDriver implements DriverInterface
                 static function (\ReflectionAttribute $attribute): object {
                     return $attribute->newInstance();
                 },
-                $class->getAttributes()
+                array_filter(
+                    $class->getAttributes(),
+                    static function (\ReflectionAttribute $attribute): bool {
+                        return class_exists($attribute->getName());
+                    }
+                )
             );
         }
 
@@ -332,7 +339,12 @@ class AnnotationOrAttributeDriver implements DriverInterface
                 static function (\ReflectionAttribute $attribute): object {
                     return $attribute->newInstance();
                 },
-                $method->getAttributes()
+                array_filter(
+                    $method->getAttributes(),
+                    static function (\ReflectionAttribute $attribute): bool {
+                        return class_exists($attribute->getName());
+                    }
+                )
             );
         }
 
@@ -355,7 +367,12 @@ class AnnotationOrAttributeDriver implements DriverInterface
                 static function (\ReflectionAttribute $attribute): object {
                     return $attribute->newInstance();
                 },
-                $property->getAttributes()
+                array_filter(
+                    $property->getAttributes(),
+                    static function (\ReflectionAttribute $attribute): bool {
+                        return class_exists($attribute->getName());
+                    }
+                )
             );
         }
 

--- a/src/Metadata/Driver/AttributeDriver.php
+++ b/src/Metadata/Driver/AttributeDriver.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace JMS\Serializer\Metadata\Driver;
 
+use function array_filter;
+
 class AttributeDriver extends AnnotationOrAttributeDriver
 {
     /**
@@ -15,7 +17,12 @@ class AttributeDriver extends AnnotationOrAttributeDriver
             static function (\ReflectionAttribute $attribute): object {
                 return $attribute->newInstance();
             },
-            $class->getAttributes()
+            array_filter(
+                $class->getAttributes(),
+                static function (\ReflectionAttribute $attribute): bool {
+                    return class_exists($attribute->getName());
+                }
+            )
         );
     }
 
@@ -28,7 +35,12 @@ class AttributeDriver extends AnnotationOrAttributeDriver
             static function (\ReflectionAttribute $attribute): object {
                 return $attribute->newInstance();
             },
-            $method->getAttributes()
+            array_filter(
+                $method->getAttributes(),
+                static function (\ReflectionAttribute $attribute): bool {
+                    return class_exists($attribute->getName());
+                }
+            )
         );
     }
 
@@ -41,7 +53,12 @@ class AttributeDriver extends AnnotationOrAttributeDriver
             static function (\ReflectionAttribute $attribute): object {
                 return $attribute->newInstance();
             },
-            $property->getAttributes()
+            array_filter(
+                $property->getAttributes(),
+                static function (\ReflectionAttribute $attribute): bool {
+                    return class_exists($attribute->getName());
+                }
+            )
         );
     }
 }

--- a/tests/Fixtures/MissingAttributeObject.php
+++ b/tests/Fixtures/MissingAttributeObject.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace JMS\Serializer\Tests\Fixtures;
+
+use JMS\Serializer\Annotation\VirtualProperty;
+
+#[MissingAttribute]
+final class MissingAttributeObject
+{
+    #[MissingAttribute]
+    public $property;
+
+    #[MissingAttribute]
+    #[VirtualProperty(name: 'propertyFromMethod')]
+    public function propertyMethod()
+    {
+        return '';
+    }
+}

--- a/tests/Fixtures/MissingAttributeObject.php
+++ b/tests/Fixtures/MissingAttributeObject.php
@@ -12,6 +12,9 @@ final class MissingAttributeObject
     #[MissingAttribute]
     public $property;
 
+    /**
+     * @VirtualProperty(name="propertyFromMethod")
+     */
     #[MissingAttribute]
     #[VirtualProperty(name: 'propertyFromMethod')]
     public function propertyMethod()

--- a/tests/Metadata/Driver/BaseAnnotationOrAttributeDriverTestCase.php
+++ b/tests/Metadata/Driver/BaseAnnotationOrAttributeDriverTestCase.php
@@ -5,6 +5,10 @@ declare(strict_types=1);
 namespace JMS\Serializer\Tests\Metadata\Driver;
 
 use JMS\Serializer\Tests\Fixtures\AllExcludedObject;
+use JMS\Serializer\Tests\Fixtures\MissingAttributeObject;
+use ReflectionClass;
+
+use const PHP_VERSION_ID;
 
 abstract class BaseAnnotationOrAttributeDriverTestCase extends BaseDriverTestCase
 {
@@ -25,5 +29,15 @@ abstract class BaseAnnotationOrAttributeDriverTestCase extends BaseDriverTestCas
     public function testShortExposeSyntax(): void
     {
         $this->markTestSkipped('Short expose syntax not supported on annotations or attribute');
+    }
+
+    public function testCanHandleMissingAttributes(): void
+    {
+        $metadata = $this->getDriver()->loadMetadataForClass(new ReflectionClass(MissingAttributeObject::class));
+        self::assertArrayHasKey('property', $metadata->propertyMetadata);
+
+        if (PHP_VERSION_ID >= 80000) {
+            self::assertArrayHasKey('propertyFromMethod', $metadata->propertyMetadata);
+        }
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| Tests pass?   | yes
| Fixed tickets | #1525
| License       | MIT

Fixes #1525 which points to some kind of BC break in v3.28.0 regarding missing attributes.