### PR TITLE
Introduce a marker interface for annotation/attribute classes

### DIFF
--- a/src/Annotation/AccessType.php
+++ b/src/Annotation/AccessType.php
@@ -11,7 +11,7 @@ namespace JMS\Serializer\Annotation;
  * @author Johannes M. Schmitt <schmittjoh@gmail.com>
  */
 #[\Attribute(\Attribute::TARGET_CLASS | \Attribute::TARGET_PROPERTY)]
-final class AccessType
+final class AccessType implements SerializerAttribute
 {
     use AnnotationUtilsTrait;
 

--- a/src/Annotation/Accessor.php
+++ b/src/Annotation/Accessor.php
@@ -11,7 +11,7 @@ namespace JMS\Serializer\Annotation;
  * @author Johannes M. Schmitt <schmittjoh@gmail.com>
  */
 #[\Attribute(\Attribute::TARGET_PROPERTY)]
-final class Accessor
+final class Accessor implements SerializerAttribute
 {
     use AnnotationUtilsTrait;
 

--- a/src/Annotation/AccessorOrder.php
+++ b/src/Annotation/AccessorOrder.php
@@ -13,7 +13,7 @@ namespace JMS\Serializer\Annotation;
  * @author Johannes M. Schmitt <schmittjoh@gmail.com>
  */
 #[\Attribute(\Attribute::TARGET_CLASS)]
-final class AccessorOrder
+final class AccessorOrder implements SerializerAttribute
 {
     use AnnotationUtilsTrait;
 

--- a/src/Annotation/Discriminator.php
+++ b/src/Annotation/Discriminator.php
@@ -9,7 +9,7 @@ namespace JMS\Serializer\Annotation;
  * @Target("CLASS")
  */
 #[\Attribute(\Attribute::TARGET_CLASS)]
-class Discriminator
+class Discriminator implements SerializerAttribute
 {
     use AnnotationUtilsTrait;
 

--- a/src/Annotation/Exclude.php
+++ b/src/Annotation/Exclude.php
@@ -9,7 +9,7 @@ namespace JMS\Serializer\Annotation;
  * @Target({"PROPERTY", "CLASS", "METHOD", "ANNOTATION"})
  */
 #[\Attribute(\Attribute::TARGET_CLASS | \Attribute::TARGET_PROPERTY | \Attribute::TARGET_METHOD)]
-final class Exclude
+final class Exclude implements SerializerAttribute
 {
     use AnnotationUtilsTrait;
 

--- a/src/Annotation/ExclusionPolicy.php
+++ b/src/Annotation/ExclusionPolicy.php
@@ -11,7 +11,7 @@ use JMS\Serializer\Exception\RuntimeException;
  * @Target("CLASS")
  */
 #[\Attribute(\Attribute::TARGET_CLASS)]
-final class ExclusionPolicy
+final class ExclusionPolicy implements SerializerAttribute
 {
     use AnnotationUtilsTrait;
 

--- a/src/Annotation/Expose.php
+++ b/src/Annotation/Expose.php
@@ -9,7 +9,7 @@ namespace JMS\Serializer\Annotation;
  * @Target({"PROPERTY", "METHOD", "ANNOTATION"})
  */
 #[\Attribute(\Attribute::TARGET_METHOD | \Attribute::TARGET_PROPERTY)]
-final class Expose
+final class Expose implements SerializerAttribute
 {
     use AnnotationUtilsTrait;
 

--- a/src/Annotation/Groups.php
+++ b/src/Annotation/Groups.php
@@ -9,7 +9,7 @@ namespace JMS\Serializer\Annotation;
  * @Target({"PROPERTY","METHOD","ANNOTATION"})
  */
 #[\Attribute(\Attribute::TARGET_METHOD | \Attribute::TARGET_PROPERTY)]
-final class Groups
+final class Groups implements SerializerAttribute
 {
     use AnnotationUtilsTrait;
 

--- a/src/Annotation/Inline.php
+++ b/src/Annotation/Inline.php
@@ -9,6 +9,6 @@ namespace JMS\Serializer\Annotation;
  * @Target({"PROPERTY","METHOD","ANNOTATION"})
  */
 #[\Attribute(\Attribute::TARGET_METHOD | \Attribute::TARGET_PROPERTY)]
-final class Inline
+final class Inline implements SerializerAttribute
 {
 }

--- a/src/Annotation/MaxDepth.php
+++ b/src/Annotation/MaxDepth.php
@@ -9,7 +9,7 @@ namespace JMS\Serializer\Annotation;
  * @Target({"PROPERTY","METHOD","ANNOTATION"})
  */
 #[\Attribute(\Attribute::TARGET_METHOD | \Attribute::TARGET_PROPERTY)]
-final class MaxDepth
+final class MaxDepth implements SerializerAttribute
 {
     use AnnotationUtilsTrait;
 

--- a/src/Annotation/PostDeserialize.php
+++ b/src/Annotation/PostDeserialize.php
@@ -16,6 +16,6 @@ namespace JMS\Serializer\Annotation;
  * @author Johannes M. Schmitt <schmittjoh@gmail.com>
  */
 #[\Attribute(\Attribute::TARGET_METHOD)]
-final class PostDeserialize
+final class PostDeserialize implements SerializerAttribute
 {
 }

--- a/src/Annotation/PostSerialize.php
+++ b/src/Annotation/PostSerialize.php
@@ -9,6 +9,6 @@ namespace JMS\Serializer\Annotation;
  * @Target("METHOD")
  */
 #[\Attribute(\Attribute::TARGET_METHOD)]
-final class PostSerialize
+final class PostSerialize implements SerializerAttribute
 {
 }

--- a/src/Annotation/PreSerialize.php
+++ b/src/Annotation/PreSerialize.php
@@ -17,6 +17,6 @@ namespace JMS\Serializer\Annotation;
  * @author Johannes M. Schmitt <schmittjoh@gmail.com>
  */
 #[\Attribute(\Attribute::TARGET_METHOD)]
-final class PreSerialize
+final class PreSerialize implements SerializerAttribute
 {
 }

--- a/src/Annotation/ReadOnlyProperty.php
+++ b/src/Annotation/ReadOnlyProperty.php
@@ -11,7 +11,7 @@ namespace JMS\Serializer\Annotation;
  * @final
  */
 #[\Attribute(\Attribute::TARGET_CLASS | \Attribute::TARGET_PROPERTY)]
-/* final */ class ReadOnlyProperty
+/* final */ class ReadOnlyProperty implements SerializerAttribute
 {
     use AnnotationUtilsTrait;
 

--- a/src/Annotation/SerializedName.php
+++ b/src/Annotation/SerializedName.php
@@ -9,7 +9,7 @@ namespace JMS\Serializer\Annotation;
  * @Target({"PROPERTY","METHOD", "ANNOTATION"})
  */
 #[\Attribute(\Attribute::TARGET_METHOD | \Attribute::TARGET_PROPERTY)]
-final class SerializedName
+final class SerializedName implements SerializerAttribute
 {
     use AnnotationUtilsTrait;
 

--- a/src/Annotation/SerializerAttribute.php
+++ b/src/Annotation/SerializerAttribute.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace JMS\Serializer\Annotation;
+
+/**
+ * Marker interface for serializer attributes
+ */
+interface SerializerAttribute
+{
+}

--- a/src/Annotation/SkipWhenEmpty.php
+++ b/src/Annotation/SkipWhenEmpty.php
@@ -9,6 +9,6 @@ namespace JMS\Serializer\Annotation;
  * @Target({"PROPERTY","METHOD","ANNOTATION"})
  */
 #[\Attribute(\Attribute::TARGET_METHOD | \Attribute::TARGET_PROPERTY)]
-final class SkipWhenEmpty
+final class SkipWhenEmpty implements SerializerAttribute
 {
 }

--- a/src/Annotation/Type.php
+++ b/src/Annotation/Type.php
@@ -9,7 +9,7 @@ namespace JMS\Serializer\Annotation;
  * @Target({"PROPERTY", "METHOD","ANNOTATION"})
  */
 #[\Attribute(\Attribute::TARGET_METHOD | \Attribute::TARGET_PROPERTY)]
-final class Type
+final class Type implements SerializerAttribute
 {
     use AnnotationUtilsTrait;
 

--- a/src/Annotation/Version.php
+++ b/src/Annotation/Version.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace JMS\Serializer\Annotation;
 
-abstract class Version
+abstract class Version implements SerializerAttribute
 {
     use AnnotationUtilsTrait;
 

--- a/src/Annotation/VirtualProperty.php
+++ b/src/Annotation/VirtualProperty.php
@@ -11,7 +11,7 @@ namespace JMS\Serializer\Annotation;
  * @author Alexander Klimenkov <alx.devel@gmail.com>
  */
 #[\Attribute(\Attribute::TARGET_METHOD | \Attribute::TARGET_CLASS | \Attribute::IS_REPEATABLE)]
-final class VirtualProperty
+final class VirtualProperty implements SerializerAttribute
 {
     use AnnotationUtilsTrait;
 

--- a/src/Annotation/XmlAttribute.php
+++ b/src/Annotation/XmlAttribute.php
@@ -9,7 +9,7 @@ namespace JMS\Serializer\Annotation;
  * @Target({"PROPERTY", "METHOD","ANNOTATION"})
  */
 #[\Attribute(\Attribute::TARGET_METHOD | \Attribute::TARGET_PROPERTY)]
-final class XmlAttribute
+final class XmlAttribute implements SerializerAttribute
 {
     use AnnotationUtilsTrait;
 

--- a/src/Annotation/XmlAttributeMap.php
+++ b/src/Annotation/XmlAttributeMap.php
@@ -9,6 +9,6 @@ namespace JMS\Serializer\Annotation;
  * @Target({"PROPERTY", "METHOD"})
  */
 #[\Attribute(\Attribute::TARGET_METHOD | \Attribute::TARGET_PROPERTY)]
-final class XmlAttributeMap
+final class XmlAttributeMap implements SerializerAttribute
 {
 }

--- a/src/Annotation/XmlCollection.php
+++ b/src/Annotation/XmlCollection.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace JMS\Serializer\Annotation;
 
-abstract class XmlCollection
+abstract class XmlCollection implements SerializerAttribute
 {
     use AnnotationUtilsTrait;
 

--- a/src/Annotation/XmlDiscriminator.php
+++ b/src/Annotation/XmlDiscriminator.php
@@ -9,7 +9,7 @@ namespace JMS\Serializer\Annotation;
  * @Target("CLASS")
  */
 #[\Attribute(\Attribute::TARGET_CLASS)]
-class XmlDiscriminator
+class XmlDiscriminator implements SerializerAttribute
 {
     use AnnotationUtilsTrait;
 

--- a/src/Annotation/XmlElement.php
+++ b/src/Annotation/XmlElement.php
@@ -9,7 +9,7 @@ namespace JMS\Serializer\Annotation;
  * @Target({"PROPERTY", "METHOD","ANNOTATION"})
  */
 #[\Attribute(\Attribute::TARGET_METHOD | \Attribute::TARGET_PROPERTY)]
-final class XmlElement
+final class XmlElement implements SerializerAttribute
 {
     use AnnotationUtilsTrait;
 

--- a/src/Annotation/XmlKeyValuePairs.php
+++ b/src/Annotation/XmlKeyValuePairs.php
@@ -9,6 +9,6 @@ namespace JMS\Serializer\Annotation;
  * @Target({"PROPERTY","METHOD","ANNOTATION"})
  */
 #[\Attribute(\Attribute::TARGET_METHOD | \Attribute::TARGET_PROPERTY)]
-final class XmlKeyValuePairs
+final class XmlKeyValuePairs implements SerializerAttribute
 {
 }

--- a/src/Annotation/XmlNamespace.php
+++ b/src/Annotation/XmlNamespace.php
@@ -9,7 +9,7 @@ namespace JMS\Serializer\Annotation;
  * @Target("CLASS")
  */
 #[\Attribute(\Attribute::TARGET_CLASS | \Attribute::IS_REPEATABLE)]
-final class XmlNamespace
+final class XmlNamespace implements SerializerAttribute
 {
     use AnnotationUtilsTrait;
 

--- a/src/Annotation/XmlRoot.php
+++ b/src/Annotation/XmlRoot.php
@@ -9,7 +9,7 @@ namespace JMS\Serializer\Annotation;
  * @Target("CLASS")
  */
 #[\Attribute(\Attribute::TARGET_CLASS)]
-final class XmlRoot
+final class XmlRoot implements SerializerAttribute
 {
     use AnnotationUtilsTrait;
 

--- a/src/Annotation/XmlValue.php
+++ b/src/Annotation/XmlValue.php
@@ -9,7 +9,7 @@ namespace JMS\Serializer\Annotation;
  * @Target({"PROPERTY","METHOD","ANNOTATION"})
  */
 #[\Attribute(\Attribute::TARGET_METHOD | \Attribute::TARGET_PROPERTY)]
-final class XmlValue
+final class XmlValue implements SerializerAttribute
 {
     use AnnotationUtilsTrait;
 

--- a/src/Metadata/Driver/AnnotationOrAttributeDriver.php
+++ b/src/Metadata/Driver/AnnotationOrAttributeDriver.php
@@ -20,6 +20,7 @@ use JMS\Serializer\Annotation\PostSerialize;
 use JMS\Serializer\Annotation\PreSerialize;
 use JMS\Serializer\Annotation\ReadOnlyProperty;
 use JMS\Serializer\Annotation\SerializedName;
+use JMS\Serializer\Annotation\SerializerAttribute;
 use JMS\Serializer\Annotation\Since;
 use JMS\Serializer\Annotation\SkipWhenEmpty;
 use JMS\Serializer\Annotation\Type;
@@ -47,8 +48,6 @@ use JMS\Serializer\Type\ParserInterface;
 use Metadata\ClassMetadata as BaseClassMetadata;
 use Metadata\Driver\DriverInterface;
 use Metadata\MethodMetadata;
-
-use function array_filter;
 
 class AnnotationOrAttributeDriver implements DriverInterface
 {
@@ -300,7 +299,7 @@ class AnnotationOrAttributeDriver implements DriverInterface
     }
 
     /**
-     * @return list<object>
+     * @return list<SerializerAttribute>
      */
     protected function getClassAnnotations(\ReflectionClass $class): array
     {
@@ -311,12 +310,7 @@ class AnnotationOrAttributeDriver implements DriverInterface
                 static function (\ReflectionAttribute $attribute): object {
                     return $attribute->newInstance();
                 },
-                array_filter(
-                    $class->getAttributes(),
-                    static function (\ReflectionAttribute $attribute): bool {
-                        return class_exists($attribute->getName());
-                    }
-                )
+                $class->getAttributes(SerializerAttribute::class, \ReflectionAttribute::IS_INSTANCEOF)
             );
         }
 
@@ -328,7 +322,7 @@ class AnnotationOrAttributeDriver implements DriverInterface
     }
 
     /**
-     * @return list<object>
+     * @return list<SerializerAttribute>
      */
     protected function getMethodAnnotations(\ReflectionMethod $method): array
     {
@@ -339,12 +333,7 @@ class AnnotationOrAttributeDriver implements DriverInterface
                 static function (\ReflectionAttribute $attribute): object {
                     return $attribute->newInstance();
                 },
-                array_filter(
-                    $method->getAttributes(),
-                    static function (\ReflectionAttribute $attribute): bool {
-                        return class_exists($attribute->getName());
-                    }
-                )
+                $method->getAttributes(SerializerAttribute::class, \ReflectionAttribute::IS_INSTANCEOF)
             );
         }
 
@@ -356,7 +345,7 @@ class AnnotationOrAttributeDriver implements DriverInterface
     }
 
     /**
-     * @return list<object>
+     * @return list<SerializerAttribute>
      */
     protected function getPropertyAnnotations(\ReflectionProperty $property): array
     {
@@ -367,12 +356,7 @@ class AnnotationOrAttributeDriver implements DriverInterface
                 static function (\ReflectionAttribute $attribute): object {
                     return $attribute->newInstance();
                 },
-                array_filter(
-                    $property->getAttributes(),
-                    static function (\ReflectionAttribute $attribute): bool {
-                        return class_exists($attribute->getName());
-                    }
-                )
+                $property->getAttributes(SerializerAttribute::class, \ReflectionAttribute::IS_INSTANCEOF)
             );
         }
 

--- a/src/Metadata/Driver/AttributeDriver.php
+++ b/src/Metadata/Driver/AttributeDriver.php
@@ -4,12 +4,12 @@ declare(strict_types=1);
 
 namespace JMS\Serializer\Metadata\Driver;
 
-use function array_filter;
+use JMS\Serializer\Annotation\SerializerAttribute;
 
 class AttributeDriver extends AnnotationOrAttributeDriver
 {
     /**
-     * @return list<object>
+     * @return list<SerializerAttribute>
      */
     protected function getClassAnnotations(\ReflectionClass $class): array
     {
@@ -17,17 +17,12 @@ class AttributeDriver extends AnnotationOrAttributeDriver
             static function (\ReflectionAttribute $attribute): object {
                 return $attribute->newInstance();
             },
-            array_filter(
-                $class->getAttributes(),
-                static function (\ReflectionAttribute $attribute): bool {
-                    return class_exists($attribute->getName());
-                }
-            )
+            $class->getAttributes(SerializerAttribute::class, \ReflectionAttribute::IS_INSTANCEOF)
         );
     }
 
     /**
-     * @return list<object>
+     * @return list<SerializerAttribute>
      */
     protected function getMethodAnnotations(\ReflectionMethod $method): array
     {
@@ -35,17 +30,12 @@ class AttributeDriver extends AnnotationOrAttributeDriver
             static function (\ReflectionAttribute $attribute): object {
                 return $attribute->newInstance();
             },
-            array_filter(
-                $method->getAttributes(),
-                static function (\ReflectionAttribute $attribute): bool {
-                    return class_exists($attribute->getName());
-                }
-            )
+            $method->getAttributes(SerializerAttribute::class, \ReflectionAttribute::IS_INSTANCEOF)
         );
     }
 
     /**
-     * @return list<object>
+     * @return list<SerializerAttribute>
      */
     protected function getPropertyAnnotations(\ReflectionProperty $property): array
     {
@@ -53,12 +43,7 @@ class AttributeDriver extends AnnotationOrAttributeDriver
             static function (\ReflectionAttribute $attribute): object {
                 return $attribute->newInstance();
             },
-            array_filter(
-                $property->getAttributes(),
-                static function (\ReflectionAttribute $attribute): bool {
-                    return class_exists($attribute->getName());
-                }
-            )
+            $property->getAttributes(SerializerAttribute::class, \ReflectionAttribute::IS_INSTANCEOF)
         );
     }
 }

--- a/src/Metadata/Driver/AttributeDriver/AttributeReader.php
+++ b/src/Metadata/Driver/AttributeDriver/AttributeReader.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace JMS\Serializer\Metadata\Driver\AttributeDriver;
 
 use Doctrine\Common\Annotations\Reader;
+use JMS\Serializer\Annotation\SerializerAttribute;
 use ReflectionClass;
 use ReflectionMethod;
 use ReflectionProperty;
@@ -26,42 +27,42 @@ class AttributeReader implements Reader
 
     public function getClassAnnotations(ReflectionClass $class): array
     {
-        $attributes = $class->getAttributes();
+        $attributes = $class->getAttributes(SerializerAttribute::class, \ReflectionAttribute::IS_INSTANCEOF);
 
         return array_merge($this->reader->getClassAnnotations($class), $this->buildAnnotations($attributes));
     }
 
     public function getClassAnnotation(ReflectionClass $class, $annotationName): ?object
     {
-        $attributes = $class->getAttributes($annotationName);
+        $attributes = $class->getAttributes($annotationName, \ReflectionAttribute::IS_INSTANCEOF);
 
         return $this->reader->getClassAnnotation($class, $annotationName) ?? $this->buildAnnotation($attributes);
     }
 
     public function getMethodAnnotations(ReflectionMethod $method): array
     {
-        $attributes = $method->getAttributes();
+        $attributes = $method->getAttributes(SerializerAttribute::class, \ReflectionAttribute::IS_INSTANCEOF);
 
         return array_merge($this->reader->getMethodAnnotations($method), $this->buildAnnotations($attributes));
     }
 
     public function getMethodAnnotation(ReflectionMethod $method, $annotationName): ?object
     {
-        $attributes = $method->getAttributes($annotationName);
+        $attributes = $method->getAttributes($annotationName, \ReflectionAttribute::IS_INSTANCEOF);
 
         return $this->reader->getClassAnnotation($method, $annotationName) ?? $this->buildAnnotation($attributes);
     }
 
     public function getPropertyAnnotations(ReflectionProperty $property): array
     {
-        $attributes = $property->getAttributes();
+        $attributes = $property->getAttributes(SerializerAttribute::class, \ReflectionAttribute::IS_INSTANCEOF);
 
         return array_merge($this->reader->getPropertyAnnotations($property), $this->buildAnnotations($attributes));
     }
 
     public function getPropertyAnnotation(ReflectionProperty $property, $annotationName): ?object
     {
-        $attributes = $property->getAttributes($annotationName);
+        $attributes = $property->getAttributes($annotationName, \ReflectionAttribute::IS_INSTANCEOF);
 
         return $this->reader->getClassAnnotation($property, $annotationName) ?? $this->buildAnnotation($attributes);
     }
@@ -75,15 +76,16 @@ class AttributeReader implements Reader
         return $attributes[0]->newInstance();
     }
 
+    /**
+     * @return list<SerializerAttribute>
+     */
     private function buildAnnotations(array $attributes): array
     {
-        $result = [];
-        foreach ($attributes as $attribute) {
-            if (0 === strpos($attribute->getName(), 'JMS\Serializer\Annotation\\')) {
-                $result[] = $attribute->newInstance();
-            }
-        }
-
-        return $result;
+        return array_map(
+            static function (\ReflectionAttribute $attribute): object {
+                return $attribute->newInstance();
+            },
+            $attributes
+        );
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | yes
| Doc updated   | no
| BC breaks?    | yes and no...
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | schmittjoh/JMSSerializerBundle#944, #1525
| License       | MIT

The standalone attribute driver doesn't do any kind of filtering on attribute classes that it tries to use, compared to the deprecated attribute reader decorator (implementing the `doctrine/annotations` reader interface) which uses a namespace filter.  This PR introduces a marker interface for the serializer's annotation/attribute classes and adjusts the Reflection `getAttributes()` calls to filter down to attribute classes that implement the interface.  This solves the issue of trying to handle missing classes or trying to work with incompatible attributes by telling the engine to filter down to only supported classes without the need for other creative checks.

Since #1525 added tests dealing with missing classes, there's no need to add any other test cases as the fixtures already have classes with attributes from mixed providers.  If anything, the benchmark slightly improves since it won't try to instantiate unsupported attribute classes anymore (or have to check those in the driver while building the metadata object).