### PR TITLE
Fix serialization of BackedEnum - annotation without name/value 

### DIFF
--- a/doc/reference/annotations.rst
+++ b/doc/reference/annotations.rst
@@ -387,8 +387,10 @@ Available Types:
 |                                                            | Examples: array<string, string>,                 |
 |                                                            | array<string, MyNamespace\MyObject>, etc.        |
 +------------------------------------------------------------+--------------------------------------------------+
-| enum<'Color'>                                              | Enum of type Color, use its case names           |
-|                                                            | for serialization and deserialization.           |
+| enum<'Color'>                                              | Enum of type Color, use its case values          |
+|                                                            | for serialization and deserialization            |
+|                                                            | if the enum is a backed enum,                    |
+|                                                            | use its case names if it is not a backed enum.   |
 +------------------------------------------------------------+--------------------------------------------------+
 | enum<'Color', 'name'>                                      | Enum of type Color, use its case names           |
 |                                                            | (as string) for serialization                    |

--- a/doc/reference/annotations.rst
+++ b/doc/reference/annotations.rst
@@ -387,10 +387,8 @@ Available Types:
 |                                                            | Examples: array<string, string>,                 |
 |                                                            | array<string, MyNamespace\MyObject>, etc.        |
 +------------------------------------------------------------+--------------------------------------------------+
-| enum<'Color'>                                              | Enum of type Color, use its case values          |
-|                                                            | for serialization and deserialization            |
-|                                                            | if the enum is a backed enum,                    |
-|                                                            | use its case names if it is not a backed enum.   |
+| enum<'Color'>                                              | Enum of type Color, use its case names           |
+|                                                            | for serialization and deserialization.           |
 +------------------------------------------------------------+--------------------------------------------------+
 | enum<'Color', 'name'>                                      | Enum of type Color, use its case names           |
 |                                                            | (as string) for serialization                    |

--- a/src/Handler/EnumHandler.php
+++ b/src/Handler/EnumHandler.php
@@ -44,7 +44,7 @@ final class EnumHandler implements SubscribingHandlerInterface
         array $type,
         SerializationContext $context
     ) {
-        if (isset($type['params'][1]) && 'value' === $type['params'][1]) {
+        if ((isset($type['params'][1]) && 'value' === $type['params'][1]) || (!isset($type['params'][1]) && is_a($enum, \BackedEnum::class, true))) {
             if (!$enum instanceof \BackedEnum) {
                 throw new InvalidMetadataException(sprintf('The type "%s" is not a backed enum, thus you can not use "value" as serialization mode for its value.', get_class($enum)));
             }

--- a/src/Handler/EnumHandler.php
+++ b/src/Handler/EnumHandler.php
@@ -44,7 +44,7 @@ final class EnumHandler implements SubscribingHandlerInterface
         array $type,
         SerializationContext $context
     ) {
-        if ((isset($type['params'][1]) && 'value' === $type['params'][1]) || (!isset($type['params'][1]) && is_a($enum, \BackedEnum::class, true))) {
+        if ((isset($type['params'][1]) && 'value' === $type['params'][1]) || (!isset($type['params'][1]) && $enum instanceof \BackedEnum)) {
             if (!$enum instanceof \BackedEnum) {
                 throw new InvalidMetadataException(sprintf('The type "%s" is not a backed enum, thus you can not use "value" as serialization mode for its value.', get_class($enum)));
             }

--- a/tests/Fixtures/ObjectWithEnums.php
+++ b/tests/Fixtures/ObjectWithEnums.php
@@ -15,10 +15,16 @@ class ObjectWithEnums
      * @Serializer\Type("enum<'JMS\Serializer\Tests\Fixtures\Enum\Suit', 'name'>")
      */
     public Suit $ordinary;
+
     /**
      * @Serializer\Type("enum<'JMS\Serializer\Tests\Fixtures\Enum\BackedSuit', 'value'>")
      */
-    public BackedSuit $backed;
+    public BackedSuit $backedValue;
+
+    /**
+     * @Serializer\Type("enum<'JMS\Serializer\Tests\Fixtures\Enum\BackedSuit'>")
+     */
+    public BackedSuit $backedWithoutParam;
 
     /**
      * @Serializer\Type("array<enum<'JMS\Serializer\Tests\Fixtures\Enum\Suit'>>")
@@ -29,6 +35,11 @@ class ObjectWithEnums
      * @Serializer\Type("array<enum<'JMS\Serializer\Tests\Fixtures\Enum\BackedSuit', 'value'>>")
      */
     public array $backedArray;
+
+    /**
+     * @Serializer\Type("array<enum<'JMS\Serializer\Tests\Fixtures\Enum\BackedSuit'>>")
+     */
+    public array $backedArrayWithoutParam;
 
     public Suit $ordinaryAutoDetect;
 
@@ -46,9 +57,11 @@ class ObjectWithEnums
     {
         $this->ordinary = Suit::Clubs;
 
-        $this->backed = BackedSuit::Clubs;
+        $this->backedValue = BackedSuit::Clubs;
+        $this->backedWithoutParam = BackedSuit::Clubs;
 
         $this->backedArray = [BackedSuit::Clubs, BackedSuit::Hearts];
+        $this->backedArrayWithoutParam = [BackedSuit::Clubs, BackedSuit::Hearts];
         $this->ordinaryArray = [Suit::Clubs, Suit::Spades];
 
         $this->ordinaryAutoDetect = Suit::Clubs;

--- a/tests/Serializer/JsonSerializationTest.php
+++ b/tests/Serializer/JsonSerializationTest.php
@@ -141,7 +141,7 @@ class JsonSerializationTest extends BaseSerializationTestCase
             $outputs['custom_datetimeinterface'] = '{"custom":"2021-09-07"}';
             $outputs['data_integer'] = '{"data":10000}';
             $outputs['uid'] = '"66b3177c-e03b-4a22-9dee-ddd7d37a04d5"';
-            $outputs['object_with_enums'] = '{"ordinary":"Clubs","backed":"C","ordinary_array":["Clubs","Spades"],"backed_array":["C","H"],"ordinary_auto_detect":"Clubs","backed_auto_detect":"C","backed_int_auto_detect":3,"backed_int":3,"backed_name":"C","backed_int_forced_str":3}';
+            $outputs['object_with_enums'] = '{"ordinary":"Clubs","backed_value":"C","backed_without_param":"C","ordinary_array":["Clubs","Spades"],"backed_array":["C","H"],"backed_array_without_param":["C","H"],"ordinary_auto_detect":"Clubs","backed_auto_detect":"C","backed_int_auto_detect":3,"backed_int":3,"backed_name":"C","backed_int_forced_str":3}';
             $outputs['object_with_autodetect_enums'] = '{"ordinary_array_auto_detect":["Clubs","Spades"],"backed_array_auto_detect":["C","H"],"mixed_array_auto_detect":["Clubs","H"]}';
             $outputs['object_with_enums_disabled'] = '{"ordinary_array_auto_detect":[{"name":"Clubs"},{"name":"Spades"}],"backed_array_auto_detect":[{"name":"Clubs","value":"C"},{"name":"Hearts","value":"H"}],"mixed_array_auto_detect":[{"name":"Clubs"},{"name":"Hearts","value":"H"}]}';
         }

--- a/tests/Serializer/xml/object_with_enums.xml
+++ b/tests/Serializer/xml/object_with_enums.xml
@@ -1,7 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <result>
   <ordinary><![CDATA[Clubs]]></ordinary>
-  <backed><![CDATA[C]]></backed>
+  <backed_value><![CDATA[C]]></backed_value>
+  <backed_without_param><![CDATA[C]]></backed_without_param>
   <ordinary_array>
     <entry><![CDATA[Clubs]]></entry>
     <entry><![CDATA[Spades]]></entry>
@@ -10,6 +11,10 @@
     <entry><![CDATA[C]]></entry>
     <entry><![CDATA[H]]></entry>
   </backed_array>
+  <backed_array_without_param>
+    <entry><![CDATA[C]]></entry>
+    <entry><![CDATA[H]]></entry>
+  </backed_array_without_param>
   <ordinary_auto_detect><![CDATA[Clubs]]></ordinary_auto_detect>
   <backed_auto_detect><![CDATA[C]]></backed_auto_detect>
   <backed_int_auto_detect>3</backed_int_auto_detect>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Doc updated   | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
| License       | MIT

Serialization of Backed Enum, when property has Serializer annotation with specified Enum Class but second parameter (name/value), is not provided was not behaving according to documentation.