### PR TITLE
Update JsonSerializationVisitor.php - Make 'skipWhenEmpty' work with all types not just \ArrayObject or array, using empty(..) to decide skipping attribute.

### DIFF
--- a/src/JsonSerializationVisitor.php
+++ b/src/JsonSerializationVisitor.php
@@ -147,7 +147,7 @@ final class JsonSerializationVisitor extends AbstractVisitor implements Serializ
             return;
         }
 
-        if (true === $metadata->skipWhenEmpty && ($v instanceof \ArrayObject || \is_array($v)) && 0 === count($v)) {
+        if (true === $metadata->skipWhenEmpty && empty($v)) {
             return;
         }
 


### PR DESCRIPTION
Make 'skipWhenEmpty' work with all types not just \ArrayObject or array, using empty(..) to decide skipping attribute.

| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| Doc updated   | no
| BC breaks?    | no 
| Deprecations? | no
| Tests pass?   | no
| Fixed tickets | 
| License       | MIT

