### PR TITLE
Allow union deserialization using discriminator map

### DIFF
--- a/.github/workflows/static-analysis.yaml
+++ b/.github/workflows/static-analysis.yaml
@@ -12,6 +12,7 @@ jobs:
     runs-on: "ubuntu-20.04"
 
     strategy:
+      fail-fast: false
       matrix:
         php-version:
           - "7.4"

--- a/doc/reference/annotations.rst
+++ b/doc/reference/annotations.rst
@@ -9,6 +9,8 @@ JMS serializer now supports PHP 8 attributes, with a few caveats:
 - There is an edge case when setting this exact serialization group ``#[Groups(['value' => 'any value here'])]``.
 (when there is only one item in th serialization groups array and has as key ``value`` the attribute will not work as expected,
 please use the alternative syntax ``#[Groups(groups: ['value' => 'any value here'])]`` that works with no issues),
+- Some support for unions exists.  For unions of primitive types, the system will try to resolve them automatically.  For
+classes that contain union attributes, the ``#[UnionDiscriminator]`` attribute must be used to specify the type of the union.
 
 Converting your annotations to attributes
 -----------------------------------------
@@ -383,6 +385,22 @@ to the least super type:
 .. note ::
 
     `groups` is optional and is used as exclusion policy.
+
+#[UnionDiscriminator]
+~~~~~~~~~~~~~~~~~~~~~
+
+This attribute allows deserialization of unions.  The ``#[UnionDiscriminator]`` attribute has to be applied
+to an attribute that can be one of many types.
+
+.. code-block :: php
+
+    class Vehicle {
+        #[UnionDiscriminator(field: 'typeField', map: ['manual' => 'FullyQualified/Path/Manual', 'automatic' => 'FullyQualified/Path/Automatic'])]
+        private Manual|Automatic $transmission;
+    }
+
+In the case of this example, both Manual and Automatic should contain a string attribute named `typeField`.  The value of that field will be passed
+to the `map` option to determine which class to instantiate.
 
 #[Type]
 ~~~~~~~

--- a/doc/reference/xml_reference.rst
+++ b/doc/reference/xml_reference.rst
@@ -46,6 +46,13 @@ XML Reference
                     <value>foo</value>
                     <value>bar</value>
                 </groups>
+                <union-discriminator field="foo">
+                    <map>
+                       <class key="a">SomeClassFQCN1</class>
+                       <class key="b">SomeClassFQCN2</class>
+                       <class key="c">SomeClassFQCN3</class>
+                    </map>
+                </union-discriminator>
             </property>
             <callback-method name="foo" type="pre-serialize" />
             <callback-method name="bar" type="post-serialize" />

--- a/doc/reference/yml_reference.rst
+++ b/doc/reference/yml_reference.rst
@@ -72,6 +72,12 @@ YAML Reference
                     cdata: false
                     namespace: http://www.w3.org/2005/Atom
                 max_depth: 2
+                union_discriminator:
+                    filed: foo
+                    map:
+                     a: SomeClassFQCN1
+                     b: SomeClassFQCN2
+                     c: SomeClassFQCN3
 
         callback_methods:
             pre_serialize: [foo, bar]

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -6,7 +6,6 @@ parameters:
         - '~Class Doctrine\\Common\\Persistence\\Proxy not found~'
         - '~Class Doctrine\\ODM\\MongoDB\\PersistentCollection not found~'
         - '~Class Symfony\\(Contracts|Component)\\Translation\\TranslatorInterface not found~'
-        - '#Constructor of class JMS\\Serializer\\Annotation\\.*? has an unused parameter#'
         - '#Class JMS\\Serializer\\Annotation\\DeprecatedReadOnly extends @final class JMS\\Serializer\\Annotation\\ReadOnlyProperty.#'
         - '#^Call to an undefined method Doctrine\\Persistence\\Mapping\\ClassMetadata\<object\>\:\:getFieldValue\(\)\.$#'
         - '#^Call to an undefined method JMS\\Serializer\\Visitor\\DeserializationVisitorInterface\:\:getCurrentObject\(\)\.$#'

--- a/phpstan/ignore-by-php-version.neon.php
+++ b/phpstan/ignore-by-php-version.neon.php
@@ -6,6 +6,7 @@ use Symfony\Component\Uid\UuidV7;
 $includes = [];
 if (PHP_VERSION_ID < 80000) {
     $includes[] = __DIR__ . '/no-typed-prop.neon';
+    $includes[] = __DIR__ . '/no-unions.neon';
     $includes[] = __DIR__ . '/no-attributes.neon';
     $includes[] = __DIR__ . '/no-promoted-properties.neon';
 }

--- a/phpstan/no-unions.neon
+++ b/phpstan/no-unions.neon
@@ -1,0 +1,3 @@
+parameters:
+    excludePaths:
+        - %currentWorkingDirectory%/tests/Fixtures/TypedProperties/ComplexDiscriminatedUnion.php

--- a/src/Annotation/UnionDiscriminator.php
+++ b/src/Annotation/UnionDiscriminator.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace JMS\Serializer\Annotation;
+
+/**
+ * @Annotation
+ * @Target({"PROPERTY"})
+ */
+#[\Attribute(\Attribute::TARGET_PROPERTY)]
+final class UnionDiscriminator implements SerializerAttribute
+{
+    use AnnotationUtilsTrait;
+
+    /** @var array<string> */
+    public $map = [];
+
+    /** @var string */
+    public $field = 'type';
+
+    public function __construct(array $values = [], string $field = 'type', array $map = [])
+    {
+        $this->loadAnnotationParameters(get_defined_vars());
+    }
+}

--- a/src/GraphNavigator/SerializationGraphNavigator.php
+++ b/src/GraphNavigator/SerializationGraphNavigator.php
@@ -177,6 +177,16 @@ final class SerializationGraphNavigator extends GraphNavigator
 
                 throw new RuntimeException($msg);
 
+            case 'union':
+                if (null !== $handler = $this->handlerRegistry->getHandler(GraphNavigatorInterface::DIRECTION_SERIALIZATION, $type['name'], $this->format)) {
+                    try {
+                        return \call_user_func($handler, $this->visitor, $data, $type, $this->context);
+                    } catch (SkipHandlerException $e) {
+                        // Skip handler, fallback to default behavior
+                    }
+                }
+
+                break;
             default:
                 if (null !== $data) {
                     if ($this->context->isVisiting($data)) {

--- a/src/Metadata/Driver/AnnotationOrAttributeDriver.php
+++ b/src/Metadata/Driver/AnnotationOrAttributeDriver.php
@@ -24,6 +24,7 @@ use JMS\Serializer\Annotation\SerializerAttribute;
 use JMS\Serializer\Annotation\Since;
 use JMS\Serializer\Annotation\SkipWhenEmpty;
 use JMS\Serializer\Annotation\Type;
+use JMS\Serializer\Annotation\UnionDiscriminator;
 use JMS\Serializer\Annotation\Until;
 use JMS\Serializer\Annotation\VirtualProperty;
 use JMS\Serializer\Annotation\XmlAttribute;
@@ -258,6 +259,12 @@ class AnnotationOrAttributeDriver implements DriverInterface
                         $propertyMetadata->xmlAttributeMap = true;
                     } elseif ($annot instanceof MaxDepth) {
                         $propertyMetadata->maxDepth = $annot->depth;
+                    } elseif ($annot instanceof UnionDiscriminator) {
+                        $propertyMetadata->setUnionDiscriminator($annot->field, $annot->map);
+                        $propertyMetadata->setType([
+                            'name' => 'union',
+                            'params' => [$annot->field, $annot->map],
+                        ]);
                     }
                 }
 

--- a/src/Metadata/Driver/AnnotationOrAttributeDriver.php
+++ b/src/Metadata/Driver/AnnotationOrAttributeDriver.php
@@ -263,7 +263,7 @@ class AnnotationOrAttributeDriver implements DriverInterface
                         $propertyMetadata->setUnionDiscriminator($annot->field, $annot->map);
                         $propertyMetadata->setType([
                             'name' => 'union',
-                            'params' => [$annot->field, $annot->map],
+                            'params' => [null, $annot->field, $annot->map],
                         ]);
                     }
                 }

--- a/src/Metadata/Driver/TypedPropertiesDriver.php
+++ b/src/Metadata/Driver/TypedPropertiesDriver.php
@@ -57,17 +57,15 @@ class TypedPropertiesDriver implements DriverInterface
      * For determining types of primitives, it is necessary to reorder primitives so that they are tested from lowest specificity to highest:
      * i.e. null, true, false, int, float, bool, string
      */
-    private function reorderTypes(array $type): array
+    private function reorderTypes(array $types): array
     {
-        if ($type['params']) {
-            uasort($type['params'], static function ($a, $b) {
-                $order = ['null' => 0, 'true' => 1, 'false' => 2, 'bool' => 3, 'int' => 4, 'float' => 5, 'string' => 6];
+        uasort($types, static function ($a, $b) {
+            $order = ['null' => 0, 'true' => 1, 'false' => 2, 'bool' => 3, 'int' => 4, 'float' => 5, 'string' => 6];
 
-                return ($order[$a['name']] ?? 7) <=> ($order[$b['name']] ?? 7);
-            });
-        }
+            return ($order[$a['name']] ?? 7) <=> ($order[$b['name']] ?? 7);
+        });
 
-        return $type;
+        return $types;
     }
 
     private function getDefaultWhiteList(): array
@@ -102,30 +100,24 @@ class TypedPropertiesDriver implements DriverInterface
         foreach ($classMetadata->propertyMetadata as $propertyMetadata) {
             // If the inner driver provides a type, don't guess anymore.
             if ($propertyMetadata->type) {
-                if ('union' === $propertyMetadata->type['name']) {
-                    // If this union is discriminated, the params will not contain types.
-                    // If the union isn't discriminated, the params will contain types, and we should reorder them
-                    if (is_array($propertyMetadata->type['params'][0]) && $propertyMetadata->type['params'][0]['name']) {
-                        $propertyMetadata->setType($this->reorderTypes($propertyMetadata->type));
-                    }
-                }
-            } else {
-                try {
-                    $reflectionType = $this->getReflectionType($propertyMetadata);
+                continue;
+            }
 
-                    if ($this->shouldTypeHint($reflectionType)) {
-                        $type = $reflectionType->getName();
+            try {
+                $reflectionType = $this->getReflectionType($propertyMetadata);
 
-                        $propertyMetadata->setType($this->typeParser->parse($type));
-                    } elseif ($this->shouldTypeHintUnion($reflectionType)) {
-                        $propertyMetadata->setType($this->reorderTypes([
-                            'name' => 'union',
-                            'params' => array_map(fn (string $type) => $this->typeParser->parse($type), $reflectionType->getTypes()),
-                        ]));
-                    }
-                } catch (ReflectionException $e) {
-                    continue;
+                if ($this->shouldTypeHint($reflectionType)) {
+                    $type = $reflectionType->getName();
+
+                    $propertyMetadata->setType($this->typeParser->parse($type));
+                } elseif ($this->shouldTypeHintUnion($reflectionType)) {
+                    $propertyMetadata->setType([
+                        'name' => 'union',
+                        'params' => [$this->reorderTypes(array_map(fn (string $type) => $this->typeParser->parse($type), $reflectionType->getTypes()))],
+                    ]);
                 }
+            } catch (ReflectionException $e) {
+                continue;
             }
         }
 

--- a/src/Metadata/Driver/XmlDriver.php
+++ b/src/Metadata/Driver/XmlDriver.php
@@ -321,6 +321,21 @@ class XmlDriver extends AbstractFileDriver
                         $pMetadata->readOnly = $pMetadata->readOnly || $readOnlyClass;
                     }
 
+                    if (isset($pElem->{'union-discriminator'})) {
+                        $colConfig = $pElem->{'union-discriminator'};
+
+                        $map = [];
+                        foreach ($pElem->xpath('./union-discriminator/map/class') as $entry) {
+                            $map[(string) $entry->attributes()->key] = (string) $entry;
+                        }
+
+                        $pMetadata->setUnionDiscriminator((string) $colConfig->attributes()->field, $map);
+                        $pMetadata->setType([
+                            'name' => 'union',
+                            'params' => [null, (string) $colConfig->attributes()->field, $map],
+                        ]);
+                    }
+
                     $getter = $pElem->attributes()->{'accessor-getter'};
                     $setter = $pElem->attributes()->{'accessor-setter'};
                     $pMetadata->setAccessor(

--- a/src/Metadata/Driver/YamlDriver.php
+++ b/src/Metadata/Driver/YamlDriver.php
@@ -300,6 +300,14 @@ class YamlDriver extends AbstractFileDriver
                     if (isset($pConfig['max_depth'])) {
                         $pMetadata->maxDepth = (int) $pConfig['max_depth'];
                     }
+
+                    if (isset($pConfig['union_discriminator'])) {
+                        $pMetadata->setUnionDiscriminator($pConfig['union_discriminator']['field'], $pConfig['union_discriminator']['map']);
+                        $pMetadata->setType([
+                            'name' => 'union',
+                            'params' => [null, $pConfig['union_discriminator']['field'], $pConfig['union_discriminator']['map']],
+                        ]);
+                    }
                 }
 
                 if (!$pMetadata->serializedName) {

--- a/src/Metadata/PropertyMetadata.php
+++ b/src/Metadata/PropertyMetadata.php
@@ -34,6 +34,16 @@ class PropertyMetadata extends BasePropertyMetadata
     public $serializedName;
 
     /**
+     * @var string|null
+     */
+    public $unionDiscriminatorField;
+
+    /**
+     * @var array<string, string>|null
+     */
+    public $unionDiscriminatorMap;
+
+    /**
      * @var array|null
      */
     public $type;
@@ -196,6 +206,12 @@ class PropertyMetadata extends BasePropertyMetadata
         $this->setter = $setter;
     }
 
+    public function setUnionDiscriminator(string $field, array $map): void
+    {
+        $this->unionDiscriminatorField = $field;
+        $this->unionDiscriminatorMap = $map;
+    }
+
     public function setType(array $type): void
     {
         $this->type = $type;
@@ -224,6 +240,8 @@ class PropertyMetadata extends BasePropertyMetadata
             $this->untilVersion,
             $this->groups,
             $this->serializedName,
+            $this->unionDiscriminatorField,
+            $this->unionDiscriminatorMap,
             $this->type,
             $this->xmlCollection,
             $this->xmlCollectionInline,
@@ -258,6 +276,8 @@ class PropertyMetadata extends BasePropertyMetadata
             $this->untilVersion,
             $this->groups,
             $this->serializedName,
+            $this->unionDiscriminatorField,
+            $this->unionDiscriminatorMap,
             $this->type,
             $this->xmlCollection,
             $this->xmlCollectionInline,

--- a/tests/Fixtures/DiscriminatedAuthor.php
+++ b/tests/Fixtures/DiscriminatedAuthor.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace JMS\Serializer\Tests\Fixtures;
+
+use JMS\Serializer\Annotation\SerializedName;
+use JMS\Serializer\Annotation\Type;
+
+class DiscriminatedAuthor
+{
+    /**
+     * @Type("string")
+     * @SerializedName("full_name")
+     */
+    #[Type(name: 'string')]
+    #[SerializedName(name: 'full_name')]
+    private $name;
+
+    /**
+     * @Type("string")
+     * @SerializedName("objectType")
+     */
+    #[Type(name: 'string')]
+    #[SerializedName(name: 'objectType')]
+    private $objectType = 'author';
+
+    public function __construct($name)
+    {
+        $this->name = $name;
+    }
+
+    public function getName()
+    {
+        return $this->name;
+    }
+
+    public function getObjectType()
+    {
+        return $this->objectType;
+    }
+}

--- a/tests/Fixtures/DiscriminatedComment.php
+++ b/tests/Fixtures/DiscriminatedComment.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace JMS\Serializer\Tests\Fixtures;
+
+use JMS\Serializer\Annotation\Type;
+use JMS\Serializer\Annotation\SerializedName;
+
+class DiscriminatedComment
+{
+    /**
+     * @Type("JMS\Serializer\Tests\Fixtures\Author")
+     */
+    #[Type(name: 'JMS\Serializer\Tests\Fixtures\Author')]
+    private $author;
+
+    /**
+     * @Type("string")
+     */
+    #[Type(name: 'string')]
+    private $text;
+
+    /**
+     * @Type("string")
+     * @SerializedName("objectType")
+     */
+    #[Type(name: 'string')]
+    #[SerializedName(name: 'objectType')]
+    private $objectType = 'comment';
+
+    public function __construct(?Author $author, $text)
+    {
+        $this->author = $author;
+        $this->text = $text;
+    }
+
+    public function getAuthor()
+    {
+        return $this->author;
+    }
+
+    public function getObjectType()
+    {
+        return $this->objectType;
+    }
+}

--- a/tests/Fixtures/DiscriminatedComment.php
+++ b/tests/Fixtures/DiscriminatedComment.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 namespace JMS\Serializer\Tests\Fixtures;
 
-use JMS\Serializer\Annotation\Type;
 use JMS\Serializer\Annotation\SerializedName;
+use JMS\Serializer\Annotation\Type;
 
 class DiscriminatedComment
 {

--- a/tests/Fixtures/MoreSpecificAuthor.php
+++ b/tests/Fixtures/MoreSpecificAuthor.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace JMS\Serializer\Tests\Fixtures;
+
+use JMS\Serializer\Annotation\SerializedName;
+use JMS\Serializer\Annotation\Type;
+
+class MoreSpecificAuthor
+{
+    /**
+     * @Type("string")
+     * @SerializedName("full_name")
+     */
+    #[Type(name: 'string')]
+    #[SerializedName(name: 'full_name')]
+    private $name;
+
+    /**
+     * @Type("bool")
+     */
+    #[Type(name: 'bool')]
+    private $isMoreSpecific;
+
+    public function __construct($name, $isMoreSpecific)
+    {
+        $this->name = $name;
+        $this->isMoreSpecific = $isMoreSpecific;
+    }
+
+    public function getName()
+    {
+        return $this->name;
+    }
+
+    public function getIsMoreSpecific()
+    {
+        return $this->isMoreSpecific;
+    }
+}

--- a/tests/Fixtures/TypedProperties/ComplexDiscriminatedUnion.php
+++ b/tests/Fixtures/TypedProperties/ComplexDiscriminatedUnion.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace JMS\Serializer\Tests\Fixtures\TypedProperties;
+
+use JMS\Serializer\Annotation\UnionDiscriminator;
+use JMS\Serializer\Tests\Fixtures\DiscriminatedAuthor;
+use JMS\Serializer\Tests\Fixtures\DiscriminatedComment;
+
+class ComplexDiscriminatedUnion
+{
+    #[UnionDiscriminator(field: 'objectType', map: ['author' => 'JMS\Serializer\Tests\Fixtures\DiscriminatedAuthor', 'comment' => 'JMS\Serializer\Tests\Fixtures\DiscriminatedComment'])]
+    private DiscriminatedAuthor|DiscriminatedComment $data;
+
+    public function __construct($data)
+    {
+        $this->data = $data;
+    }
+
+    public function getData(): DiscriminatedAuthor|DiscriminatedComment
+    {
+        return $this->data;
+    }
+}

--- a/tests/Fixtures/TypedProperties/ComplexDiscriminatedUnion.php
+++ b/tests/Fixtures/TypedProperties/ComplexDiscriminatedUnion.php
@@ -10,6 +10,12 @@ use JMS\Serializer\Tests\Fixtures\DiscriminatedComment;
 
 class ComplexDiscriminatedUnion
 {
+    /**
+     * @UnionDiscriminator(
+     *     field = "objectType",
+     *     map = {"author": "JMS\Serializer\Tests\Fixtures\DiscriminatedAuthor", "comment": "JMS\Serializer\Tests\Fixtures\DiscriminatedComment"}
+     * )"
+     */
     #[UnionDiscriminator(field: 'objectType', map: ['author' => 'JMS\Serializer\Tests\Fixtures\DiscriminatedAuthor', 'comment' => 'JMS\Serializer\Tests\Fixtures\DiscriminatedComment'])]
     private DiscriminatedAuthor|DiscriminatedComment $data;
 

--- a/tests/Metadata/Driver/BaseDriverTestCase.php
+++ b/tests/Metadata/Driver/BaseDriverTestCase.php
@@ -29,6 +29,7 @@ use JMS\Serializer\Tests\Fixtures\ObjectWithVirtualPropertiesAndDuplicatePropNam
 use JMS\Serializer\Tests\Fixtures\ObjectWithVirtualPropertiesAndExcludeAll;
 use JMS\Serializer\Tests\Fixtures\ParentSkipWithEmptyChild;
 use JMS\Serializer\Tests\Fixtures\Person;
+use JMS\Serializer\Tests\Fixtures\TypedProperties\ComplexDiscriminatedUnion;
 use Metadata\Driver\DriverInterface;
 use Metadata\MethodMetadata;
 use PHPUnit\Framework\TestCase;
@@ -131,6 +132,17 @@ abstract class BaseDriverTestCase extends TestCase
         self::assertTrue($m->propertyMetadata['absent']->xmlCollectionSkipWhenEmpty);
         self::assertTrue($m->propertyMetadata['skipDefault']->xmlCollectionSkipWhenEmpty);
         self::assertFalse($m->propertyMetadata['present']->xmlCollectionSkipWhenEmpty);
+    }
+
+    public function testUnionDiscriminator()
+    {
+        $m = $this->getDriver()->loadMetadataForClass(new \ReflectionClass(ComplexDiscriminatedUnion::class));
+        \assert($m instanceof ClassMetadata);
+
+        $p = $m->propertyMetadata['data'];
+        assert($p instanceof PropertyMetadata);
+        self::assertEquals('objectType', $p->unionDiscriminatorField);
+        self::assertEquals(['author' => 'JMS\Serializer\Tests\Fixtures\DiscriminatedAuthor', 'comment' => 'JMS\Serializer\Tests\Fixtures\DiscriminatedComment'], $p->unionDiscriminatorMap);
     }
 
     public function testVirtualProperty()

--- a/tests/Metadata/Driver/BaseDriverTestCase.php
+++ b/tests/Metadata/Driver/BaseDriverTestCase.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace JMS\Serializer\Tests\Metadata\Driver;
 
+use JMS\Serializer\Annotation\UnionDiscriminator;
 use JMS\Serializer\Exception\InvalidMetadataException;
 use JMS\Serializer\Expression\ExpressionEvaluator;
 use JMS\Serializer\Metadata\ClassMetadata;
@@ -136,6 +137,12 @@ abstract class BaseDriverTestCase extends TestCase
 
     public function testUnionDiscriminator()
     {
+        if (PHP_VERSION_ID < 80000) {
+            $this->markTestSkipped(sprintf('%s requires PHP 8.0', UnionDiscriminator::class));
+
+            return;
+        }
+
         $m = $this->getDriver()->loadMetadataForClass(new \ReflectionClass(ComplexDiscriminatedUnion::class));
         \assert($m instanceof ClassMetadata);
 

--- a/tests/Metadata/Driver/UnionTypedPropertiesDriverTest.php
+++ b/tests/Metadata/Driver/UnionTypedPropertiesDriverTest.php
@@ -31,24 +31,27 @@ final class UnionTypedPropertiesDriverTest extends TestCase
         self::assertEquals(
             [
                 'name' => 'union',
-                'params' => [
+                'params' =>
                     [
-                        'name' => 'string',
-                        'params' => [],
+                        [
+                            [
+                                'name' => 'string',
+                                'params' => [],
+                            ],
+                            [
+                                'name' => 'int',
+                                'params' => [],
+                            ],
+                            [
+                                'name' => 'float',
+                                'params' => [],
+                            ],
+                            [
+                                'name' => 'bool',
+                                'params' => [],
+                            ],
+                        ],
                     ],
-                    [
-                        'name' => 'int',
-                        'params' => [],
-                    ],
-                    [
-                        'name' => 'float',
-                        'params' => [],
-                    ],
-                    [
-                        'name' => 'bool',
-                        'params' => [],
-                    ],
-                ],
             ],
             $m->propertyMetadata['data']->type,
         );

--- a/tests/Metadata/Driver/xml/TypedProperties.ComplexDiscriminatedUnion.xml
+++ b/tests/Metadata/Driver/xml/TypedProperties.ComplexDiscriminatedUnion.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<serializer>
+    <class name="JMS\Serializer\Tests\Fixtures\TypedProperties\ComplexDiscriminatedUnion">
+        <property name="data">
+            <union-discriminator field="objectType">
+                <map>
+                    <class key="author">JMS\Serializer\Tests\Fixtures\DiscriminatedAuthor</class>
+                    <class key="comment">JMS\Serializer\Tests\Fixtures\DiscriminatedComment</class>
+                </map>
+            </union-discriminator>
+        </property>
+    </class>
+</serializer>

--- a/tests/Metadata/Driver/yml/TypedProperties.ComplexDiscriminatedUnion.yml
+++ b/tests/Metadata/Driver/yml/TypedProperties.ComplexDiscriminatedUnion.yml
@@ -1,0 +1,8 @@
+JMS\Serializer\Tests\Fixtures\TypedProperties\ComplexDiscriminatedUnion:
+  properties:
+    data:
+      union_discriminator:
+        field: objectType
+        map:
+          author: 'JMS\Serializer\Tests\Fixtures\DiscriminatedAuthor'
+          comment: 'JMS\Serializer\Tests\Fixtures\DiscriminatedComment'

--- a/tests/Serializer/JsonSerializationTest.php
+++ b/tests/Serializer/JsonSerializationTest.php
@@ -14,11 +14,14 @@ use JMS\Serializer\Metadata\Driver\TypedPropertiesDriver;
 use JMS\Serializer\SerializationContext;
 use JMS\Serializer\Tests\Fixtures\Author;
 use JMS\Serializer\Tests\Fixtures\AuthorList;
+use JMS\Serializer\Tests\Fixtures\DiscriminatedAuthor;
+use JMS\Serializer\Tests\Fixtures\DiscriminatedComment;
 use JMS\Serializer\Tests\Fixtures\FirstClassMapCollection;
 use JMS\Serializer\Tests\Fixtures\ObjectWithEmptyArrayAndHash;
 use JMS\Serializer\Tests\Fixtures\ObjectWithInlineArray;
 use JMS\Serializer\Tests\Fixtures\ObjectWithObjectProperty;
 use JMS\Serializer\Tests\Fixtures\Tag;
+use JMS\Serializer\Tests\Fixtures\TypedProperties\ComplexDiscriminatedUnion;
 use JMS\Serializer\Tests\Fixtures\TypedProperties\UnionTypedProperties;
 use JMS\Serializer\Visitor\Factory\JsonSerializationVisitorFactory;
 use JMS\Serializer\Visitor\SerializationVisitorInterface;
@@ -147,6 +150,10 @@ class JsonSerializationTest extends BaseSerializationTestCase
             $outputs['data_float'] = '{"data":1.236}';
             $outputs['data_bool'] = '{"data":false}';
             $outputs['data_string'] = '{"data":"foo"}';
+            $outputs['data_author'] = '{"data":{"full_name":"foo"}}';
+            $outputs['data_comment'] = '{"data":{"author":{"full_name":"foo"},"text":"bar"}}';
+            $outputs['data_discriminated_author'] = '{"data":{"full_name":"foo","objectType":"author"}}';
+            $outputs['data_discriminated_comment'] = '{"data":{"author":{"full_name":"foo"},"text":"bar","objectType":"comment"}}';
             $outputs['uid'] = '"66b3177c-e03b-4a22-9dee-ddd7d37a04d5"';
             $outputs['object_with_enums'] = '{"ordinary":"Clubs","backed_value":"C","backed_without_param":"C","ordinary_array":["Clubs","Spades"],"backed_array":["C","H"],"backed_array_without_param":["C","H"],"ordinary_auto_detect":"Clubs","backed_auto_detect":"C","backed_int_auto_detect":3,"backed_int":3,"backed_name":"C","backed_int_forced_str":3}';
             $outputs['object_with_autodetect_enums'] = '{"ordinary_array_auto_detect":["Clubs","Spades"],"backed_array_auto_detect":["C","H"],"mixed_array_auto_detect":["Clubs","H"]}';
@@ -449,7 +456,7 @@ class JsonSerializationTest extends BaseSerializationTestCase
         self::assertEquals($object, $this->deserialize(static::getContent('data_string'), UnionTypedProperties::class));
     }
 
-    public function testSerializeUnionProperties()
+    public function testSerializingUnionProperties()
     {
         if (PHP_VERSION_ID < 80000) {
             $this->markTestSkipped(sprintf('%s requires PHP 8.0', TypedPropertiesDriver::class));
@@ -459,6 +466,46 @@ class JsonSerializationTest extends BaseSerializationTestCase
 
         $serialized = $this->serialize(new UnionTypedProperties(10000));
         self::assertEquals(static::getContent('data_integer'), $serialized);
+
+        $serialized = $this->serialize(new UnionTypedProperties(1.236));
+        self::assertEquals(static::getContent('data_float'), $serialized);
+
+        $serialized = $this->serialize(new UnionTypedProperties(false));
+        self::assertEquals(static::getContent('data_bool'), $serialized);
+
+        $serialized = $this->serialize(new UnionTypedProperties('foo'));
+        self::assertEquals(static::getContent('data_string'), $serialized);
+    }
+
+    public function testDeserializingComplexDiscriminatedUnionProperties()
+    {
+        if (PHP_VERSION_ID < 80000) {
+            $this->markTestSkipped(sprintf('%s requires PHP 8.0', TypedPropertiesDriver::class));
+
+            return;
+        }
+
+        $authorUnion = new ComplexDiscriminatedUnion(new DiscriminatedAuthor('foo'));
+        self::assertEquals($authorUnion, $this->deserialize(static::getContent('data_discriminated_author'), ComplexDiscriminatedUnion::class));
+
+        $commentUnion = new ComplexDiscriminatedUnion(new DiscriminatedComment(new Author('foo'), 'bar'));
+
+        self::assertEquals($commentUnion, $this->deserialize(static::getContent('data_discriminated_comment'), ComplexDiscriminatedUnion::class));
+    }
+
+    public function testSerializeingComplexDiscriminatedUnionProperties()
+    {
+        if (PHP_VERSION_ID < 80000) {
+            $this->markTestSkipped(sprintf('%s requires PHP 8.0', TypedPropertiesDriver::class));
+
+            return;
+        }
+
+        $serialized = $this->serialize(new ComplexDiscriminatedUnion(new DiscriminatedAuthor('foo')));
+        self::assertEquals(static::getContent('data_discriminated_author'), $serialized);
+
+        $serialized = $this->serialize(new ComplexDiscriminatedUnion(new DiscriminatedComment(new Author('foo'), 'bar')));
+        self::assertEquals(static::getContent('data_discriminated_comment'), $serialized);
     }
 
     /**

--- a/tests/Serializer/JsonSerializationTest.php
+++ b/tests/Serializer/JsonSerializationTest.php
@@ -8,6 +8,7 @@ use JMS\Serializer\Context;
 use JMS\Serializer\EventDispatcher\Event;
 use JMS\Serializer\EventDispatcher\EventSubscriberInterface;
 use JMS\Serializer\EventDispatcher\ObjectEvent;
+use JMS\Serializer\Exception\NonVisitableTypeException;
 use JMS\Serializer\Exception\RuntimeException;
 use JMS\Serializer\GraphNavigatorInterface;
 use JMS\Serializer\Metadata\Driver\TypedPropertiesDriver;
@@ -154,6 +155,8 @@ class JsonSerializationTest extends BaseSerializationTestCase
             $outputs['data_comment'] = '{"data":{"author":{"full_name":"foo"},"text":"bar"}}';
             $outputs['data_discriminated_author'] = '{"data":{"full_name":"foo","objectType":"author"}}';
             $outputs['data_discriminated_comment'] = '{"data":{"author":{"full_name":"foo"},"text":"bar","objectType":"comment"}}';
+            $outputs['data_discriminated_comment_wrong_discriminator'] = '{"data":{"author":{"full_name":"foo"},"text":"bar","objectType":"comment_wrong"}}';
+            $outputs['data_discriminated_comment_missing_discriminator'] = '{"data":{"author":{"full_name":"foo"},"text":"bar"}}';
             $outputs['uid'] = '"66b3177c-e03b-4a22-9dee-ddd7d37a04d5"';
             $outputs['object_with_enums'] = '{"ordinary":"Clubs","backed_value":"C","backed_without_param":"C","ordinary_array":["Clubs","Spades"],"backed_array":["C","H"],"backed_array_without_param":["C","H"],"ordinary_auto_detect":"Clubs","backed_auto_detect":"C","backed_int_auto_detect":3,"backed_int":3,"backed_name":"C","backed_int_forced_str":3}';
             $outputs['object_with_autodetect_enums'] = '{"ordinary_array_auto_detect":["Clubs","Spades"],"backed_array_auto_detect":["C","H"],"mixed_array_auto_detect":["Clubs","H"]}';
@@ -491,6 +494,32 @@ class JsonSerializationTest extends BaseSerializationTestCase
         $commentUnion = new ComplexDiscriminatedUnion(new DiscriminatedComment(new Author('foo'), 'bar'));
 
         self::assertEquals($commentUnion, $this->deserialize(static::getContent('data_discriminated_comment'), ComplexDiscriminatedUnion::class));
+    }
+
+    public function testDeserializingComplexDiscriminatedUnionPropertiesFailsWhenDiscriminatorNotInMap()
+    {
+        if (PHP_VERSION_ID < 80000) {
+            $this->markTestSkipped(sprintf('%s requires PHP 8.0', TypedPropertiesDriver::class));
+
+            return;
+        }
+
+        $this->expectException(NonVisitableTypeException::class);
+        $this->expectExceptionMessage('Union Discriminator Map does not contain key "comment_wrong"');
+        $this->deserialize(static::getContent('data_discriminated_comment_wrong_discriminator'), ComplexDiscriminatedUnion::class);
+    }
+
+    public function testDeserializingComplexDiscriminatedUnionPropertiesFailsWhenDiscriminatorIsMissing()
+    {
+        if (PHP_VERSION_ID < 80000) {
+            $this->markTestSkipped(sprintf('%s requires PHP 8.0', TypedPropertiesDriver::class));
+
+            return;
+        }
+
+        $this->expectException(NonVisitableTypeException::class);
+        $this->expectExceptionMessage('Union Discriminator Field "objectType" not found in data');
+        $this->deserialize(static::getContent('data_discriminated_comment_missing_discriminator'), ComplexDiscriminatedUnion::class);
     }
 
     public function testSerializeingComplexDiscriminatedUnionProperties()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| Doc updated   | no
| BC breaks?    | no <!-- don't forget updating UPGRADING.md file -->
| Deprecations? | no <!-- don't forget updating UPGRADING.md file -->
| Tests pass?   | yes
| Fixed tickets | #1549
| License       | MIT

Hi @goetas here's a simpler version of PR #1549 - this one only adds support for discriminated complex unions.
