### PR TITLE
introduce requireAllRequiredProperties context

### DIFF
--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -104,3 +104,16 @@ a serialization context from your callable and use it.
     You can also set a default DeserializationContextFactory with
     ``->setDeserializationContextFactory(function () { /* ... */ })``
     to be used with methods ``deserialize()`` and ``fromArray()``.
+
+Fail Deserialization When Required Properties Are Missing
+---------------------------------------------------------
+By default, the deserializer will ignore missing required properties -
+deserialization will succeed and the properties will be left unset.
+
+You may want, instead, for deserialization to fail in this case.  You can
+configure the deserializer to fail in this way by using the `DeserializationContext`
+
+For example:
+    $object = $serializer->deserialize($json, 'MyObject`, 'json', DeserializationContext::create()->setRequireAllRequiredProperties(true));
+
+If you would like this behaviour to be the default, you can set the `DeserializationContextFactory` as described above.

--- a/src/DeserializationContext.php
+++ b/src/DeserializationContext.php
@@ -13,6 +13,11 @@ class DeserializationContext extends Context
      */
     private $depth = 0;
 
+    /**
+     * @var bool
+     */
+    private $requireAllRequiredProperties = false;
+
     public static function create(): self
     {
         return new self();
@@ -40,5 +45,16 @@ class DeserializationContext extends Context
         }
 
         $this->depth -= 1;
+    }
+    public function setRequireAllRequiredProperties(bool $require): self
+    {
+        $this->requireAllRequiredProperties = $require;
+
+        return $this;
+    }
+
+    public function getRequireAllRequiredProperties(): bool
+    {
+        return $this->requireAllRequiredProperties;
     }
 }

--- a/src/DeserializationContext.php
+++ b/src/DeserializationContext.php
@@ -46,6 +46,7 @@ class DeserializationContext extends Context
 
         $this->depth -= 1;
     }
+
     public function setRequireAllRequiredProperties(bool $require): self
     {
         $this->requireAllRequiredProperties = $require;

--- a/src/Exception/PropertyMissingException.php
+++ b/src/Exception/PropertyMissingException.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace JMS\Serializer\Exception;
+
+final class PropertyMissingException extends RuntimeException
+{
+}

--- a/src/GraphNavigator/DeserializationGraphNavigator.php
+++ b/src/GraphNavigator/DeserializationGraphNavigator.php
@@ -268,10 +268,10 @@ final class DeserializationGraphNavigator extends GraphNavigator implements Grap
         }
     }
 
-    private function allowsNull(array $type)
+    private function allowsNull(array $type): bool
     {
         $allowsNull = false;
-        if ('union' === $type['name']) {
+        if ('union' === $type['name'] && isset($type['params'][0])) {
             foreach ($type['params'] as $param) {
                 if ('NULL' === $param['name']) {
                     $allowsNull = true;

--- a/tests/Serializer/JsonSerializationTest.php
+++ b/tests/Serializer/JsonSerializationTest.php
@@ -5,15 +5,15 @@ declare(strict_types=1);
 namespace JMS\Serializer\Tests\Serializer;
 
 use JMS\Serializer\Context;
+use JMS\Serializer\DeserializationContext;
 use JMS\Serializer\EventDispatcher\Event;
 use JMS\Serializer\EventDispatcher\EventSubscriberInterface;
 use JMS\Serializer\EventDispatcher\ObjectEvent;
 use JMS\Serializer\Exception\NonVisitableTypeException;
-use JMS\Serializer\Exception\RuntimeException;
 use JMS\Serializer\Exception\PropertyMissingException;
+use JMS\Serializer\Exception\RuntimeException;
 use JMS\Serializer\GraphNavigatorInterface;
 use JMS\Serializer\Metadata\Driver\TypedPropertiesDriver;
-use JMS\Serializer\DeserializationContext;
 use JMS\Serializer\SerializationContext;
 use JMS\Serializer\Tests\Fixtures\Author;
 use JMS\Serializer\Tests\Fixtures\AuthorList;

--- a/tests/Serializer/JsonSerializationTest.php
+++ b/tests/Serializer/JsonSerializationTest.php
@@ -10,7 +10,7 @@ use JMS\Serializer\EventDispatcher\EventSubscriberInterface;
 use JMS\Serializer\EventDispatcher\ObjectEvent;
 use JMS\Serializer\Exception\NonVisitableTypeException;
 use JMS\Serializer\Exception\RuntimeException;
-use \JMS\Serializer\Exception\PropertyMissingException;
+use JMS\Serializer\Exception\PropertyMissingException;
 use JMS\Serializer\GraphNavigatorInterface;
 use JMS\Serializer\Metadata\Driver\TypedPropertiesDriver;
 use JMS\Serializer\DeserializationContext;

--- a/tests/Serializer/JsonSerializationTest.php
+++ b/tests/Serializer/JsonSerializationTest.php
@@ -13,6 +13,7 @@ use JMS\Serializer\Exception\RuntimeException;
 use JMS\Serializer\GraphNavigatorInterface;
 use JMS\Serializer\Metadata\Driver\TypedPropertiesDriver;
 use JMS\Serializer\SerializationContext;
+use JMS\Serializer\DeserializationContext;
 use JMS\Serializer\Tests\Fixtures\Author;
 use JMS\Serializer\Tests\Fixtures\AuthorList;
 use JMS\Serializer\Tests\Fixtures\DiscriminatedAuthor;
@@ -436,6 +437,12 @@ class JsonSerializationTest extends BaseSerializationTestCase
 
             [[$tag], '{"0":{"name":"tag"}}', SerializationContext::create()->setInitialType('array<integer,JMS\Serializer\Tests\Fixtures\Tag>')],
         ];
+    }
+
+    public function testDeserializationFailureOnPropertyMissing()
+    {
+        self::expectException(\JMS\Serializer\Exception\PropertyMissingException::class);
+        $this->deserialize(static::getContent('empty_object'), Author::class, DeserializationContext::create()->setRequireAllRequiredProperties(true));
     }
 
     public function testDeserializingUnionProperties()

--- a/tests/Serializer/JsonSerializationTest.php
+++ b/tests/Serializer/JsonSerializationTest.php
@@ -10,10 +10,11 @@ use JMS\Serializer\EventDispatcher\EventSubscriberInterface;
 use JMS\Serializer\EventDispatcher\ObjectEvent;
 use JMS\Serializer\Exception\NonVisitableTypeException;
 use JMS\Serializer\Exception\RuntimeException;
+use \JMS\Serializer\Exception\PropertyMissingException;
 use JMS\Serializer\GraphNavigatorInterface;
 use JMS\Serializer\Metadata\Driver\TypedPropertiesDriver;
-use JMS\Serializer\SerializationContext;
 use JMS\Serializer\DeserializationContext;
+use JMS\Serializer\SerializationContext;
 use JMS\Serializer\Tests\Fixtures\Author;
 use JMS\Serializer\Tests\Fixtures\AuthorList;
 use JMS\Serializer\Tests\Fixtures\DiscriminatedAuthor;
@@ -441,7 +442,7 @@ class JsonSerializationTest extends BaseSerializationTestCase
 
     public function testDeserializationFailureOnPropertyMissing()
     {
-        self::expectException(\JMS\Serializer\Exception\PropertyMissingException::class);
+        self::expectException(PropertyMissingException::class);
         $this->deserialize(static::getContent('empty_object'), Author::class, DeserializationContext::create()->setRequireAllRequiredProperties(true));
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| Doc updated   | no
| BC breaks?    | no <!-- don't forget updating UPGRADING.md file -->
| Deprecations? | no <!-- don't forget updating UPGRADING.md file -->
| Tests pass?   | yes
| Fixed tickets | #... <!-- #-prefixed issue number(s), if any -->
| License       | MIT

This pull request introduces a new `DeserializationContext` attribute that allows you to specify that you'd like deserialization to fail if the JSON is missing required properties. 