### PR TITLE
Doctrine ODM: fix tests for 2.0

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -43,9 +43,6 @@ jobs:
         if: ${{ matrix.composer-stability }}
         run: composer config minimum-stability ${{ matrix.composer-stability }}
 
-      - name: Uninstall Doctrine ODM
-        run: composer remove doctrine/phpcr-odm jackalope/jackalope-doctrine-dbal --no-update --dev
-
       - name: "Install dependencies with Composer"
         uses: "ramsey/composer-install@v1"
         with:

--- a/phpstan/no-attributes.neon
+++ b/phpstan/no-attributes.neon
@@ -1,3 +1,4 @@
 parameters:
     ignoreErrors:
         - '~Call to an undefined method Reflection.*::getAttributes\(\)~'
+        - '~Instantiated class Doctrine\\ODM\\PHPCR\\Mapping\\Driver\\AttributeDriver not found~'

--- a/tests/Fixtures/DoctrinePHPCR/Author.php
+++ b/tests/Fixtures/DoctrinePHPCR/Author.php
@@ -5,14 +5,19 @@ declare(strict_types=1);
 namespace JMS\Serializer\Tests\Fixtures\DoctrinePHPCR;
 
 use Doctrine\ODM\PHPCR\Mapping\Annotations as PHPCRODM;
+use Doctrine\ODM\PHPCR\Mapping\Attributes\Document;
+use Doctrine\ODM\PHPCR\Mapping\Attributes\Field;
+use Doctrine\ODM\PHPCR\Mapping\Attributes\Id;
 use JMS\Serializer\Annotation\SerializedName;
 
 /** @PHPCRODM\Document */
+#[Document]
 class Author
 {
     /**
      * @PHPCRODM\Id()
      */
+    #[Id]
     protected $id;
 
     /**
@@ -20,6 +25,7 @@ class Author
      * @SerializedName("full_name")
      */
     #[SerializedName(name: 'full_name')]
+    #[Field(type: 'string')]
     private $name;
 
     public function __construct($name)

--- a/tests/Fixtures/DoctrinePHPCR/BlogPost.php
+++ b/tests/Fixtures/DoctrinePHPCR/BlogPost.php
@@ -6,6 +6,11 @@ namespace JMS\Serializer\Tests\Fixtures\DoctrinePHPCR;
 
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\ODM\PHPCR\Mapping\Annotations as PHPCRODM;
+use Doctrine\ODM\PHPCR\Mapping\Attributes\Document;
+use Doctrine\ODM\PHPCR\Mapping\Attributes\Field;
+use Doctrine\ODM\PHPCR\Mapping\Attributes\Id;
+use Doctrine\ODM\PHPCR\Mapping\Attributes\ReferenceMany;
+use Doctrine\ODM\PHPCR\Mapping\Attributes\ReferenceOne;
 use JMS\Serializer\Annotation\Groups;
 use JMS\Serializer\Annotation\SerializedName;
 use JMS\Serializer\Annotation\Type;
@@ -18,11 +23,13 @@ use JMS\Serializer\Annotation\XmlRoot;
  * @XmlRoot("blog-post")
  */
 #[XmlRoot(name: 'blog-post')]
+#[Document]
 class BlogPost
 {
     /**
      * @PHPCRODM\Id()
      */
+    #[Id]
     protected $id;
 
     /**
@@ -30,11 +37,13 @@ class BlogPost
      * @Groups({"comments","post"})
      */
     #[Groups(groups: ['comments', 'post'])]
+    #[Field(type: 'string')]
     private $title;
 
     /**
      * @PHPCRODM\Field(type="string")
      */
+    #[Field(type: 'string')]
     protected $slug;
 
     /**
@@ -42,6 +51,7 @@ class BlogPost
      * @XmlAttribute
      */
     #[XmlAttribute]
+    #[Field(type: 'date')]
     private $createdAt;
 
     /**
@@ -54,6 +64,7 @@ class BlogPost
      * @Groups({"post"})
      * @XmlAttribute
      */
+    #[Field(type: 'boolean')]
     #[Type(name: 'integer')]
     #[SerializedName(name: 'is_published')]
     #[Groups(groups: ['post'])]
@@ -67,6 +78,7 @@ class BlogPost
      */
     #[XmlList(entry: 'comment', inline: true)]
     #[Groups(groups: ['comments'])]
+    #[ReferenceMany(targetDocument:'Comment', property:'blogPost')]
     private $comments;
 
     /**
@@ -74,6 +86,7 @@ class BlogPost
      * @Groups({"post"})
      */
     #[Groups(groups: ['post'])]
+    #[ReferenceOne(targetDocument:'Author')]
     private $author;
 
     public function __construct($title, Author $author, \DateTime $createdAt)

--- a/tests/Fixtures/DoctrinePHPCR/Comment.php
+++ b/tests/Fixtures/DoctrinePHPCR/Comment.php
@@ -6,18 +6,25 @@ namespace JMS\Serializer\Tests\Fixtures\DoctrinePHPCR;
 
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\ODM\PHPCR\Mapping\Annotations as PHPCRODM;
+use Doctrine\ODM\PHPCR\Mapping\Attributes\Document;
+use Doctrine\ODM\PHPCR\Mapping\Attributes\Field;
+use Doctrine\ODM\PHPCR\Mapping\Attributes\Id;
+use Doctrine\ODM\PHPCR\Mapping\Attributes\ReferenceOne;
 
 /** @PHPCRODM\Document */
+#[Document]
 class Comment
 {
     /**
      * @PHPCRODM\Id()
      */
+    #[Id]
     protected $id;
 
     /**
      * @PHPCRODM\ReferenceOne(targetDocument="Author")
      */
+    #[ReferenceOne(targetDocument:'Author')]
     private $author;
 
     /** @PHPCRODM\ReferenceOne(targetDocument="BlogPost") */
@@ -26,6 +33,7 @@ class Comment
     /**
      * @PHPCRODM\Field(type="string")
      */
+    #[Field(type: 'string')]
     private $text;
 
     public function __construct(Author $author, $text)


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| Doc updated   | no
| BC breaks?    | no <!-- don't forget updating UPGRADING.md file -->
| Deprecations? | no <!-- don't forget updating UPGRADING.md file -->
| Tests pass?   | yes
| Fixed tickets | #1544
| License       | MIT


## Backstory: 
The development of ODM 2.0 was stopping us from testing other Doctrine components in newest version (without annotations). As the tests was passing for dev versions, we decided to uninstall them from in CI tests. 
Now the tests are not passing, so let's fix them. 
