### PR TITLE
DateTime - Deserialize from more formats (default)

### DIFF
--- a/src/Handler/DateHandler.php
+++ b/src/Handler/DateHandler.php
@@ -16,7 +16,7 @@ final class DateHandler implements SubscribingHandlerInterface
     /**
      * @var string
      */
-    private $defaultFormat;
+    private $defaultSerializationFormat;
 
     /**
      * @var array<string>
@@ -83,7 +83,7 @@ final class DateHandler implements SubscribingHandlerInterface
         bool $xmlCData = true,
         array $defaultDeserializationFormats = []
     ) {
-        $this->defaultFormat = $defaultFormat;
+        $this->defaultSerializationFormat = $defaultFormat;
         $this->defaultDeserializationFormats = [] === $defaultDeserializationFormats ? [$defaultFormat] : $defaultDeserializationFormats;
         $this->defaultTimezone = new \DateTimeZone($defaultTimezone);
         $this->xmlCData = $xmlCData;
@@ -307,7 +307,7 @@ final class DateHandler implements SubscribingHandlerInterface
 
     private function getSerializationFormat(array $type): string
     {
-        return $type['params'][0] ?? $this->defaultFormat;
+        return $type['params'][0] ?? $this->defaultSerializationFormat;
     }
 
     public function format(\DateInterval $dateInterval): string

--- a/src/Handler/DateHandler.php
+++ b/src/Handler/DateHandler.php
@@ -81,10 +81,10 @@ final class DateHandler implements SubscribingHandlerInterface
         string $defaultFormat = \DateTime::ATOM,
         string $defaultTimezone = 'UTC',
         bool $xmlCData = true,
-        array $defaultDeserializationFormats = [\DateTime::ATOM]
+        array $defaultDeserializationFormats = []
     ) {
         $this->defaultFormat = $defaultFormat;
-        $this->defaultDeserializationFormats = $defaultDeserializationFormats;
+        $this->defaultDeserializationFormats = [] === $defaultDeserializationFormats ? [$defaultFormat] : $defaultDeserializationFormats;
         $this->defaultTimezone = new \DateTimeZone($defaultTimezone);
         $this->xmlCData = $xmlCData;
     }
@@ -299,7 +299,7 @@ final class DateHandler implements SubscribingHandlerInterface
         }
 
         if (isset($type['params'][0])) {
-            return is_array($type['params'][0]) ? $type['params'][0] : [$type['params'][0]];
+            return [$type['params'][0]];
         }
 
         return $this->defaultDeserializationFormats;

--- a/tests/Handler/DateHandlerTest.php
+++ b/tests/Handler/DateHandlerTest.php
@@ -169,4 +169,15 @@ class DateHandlerTest extends TestCase
             $actualDateTime->format(\DateTime::RFC3339),
         );
     }
+
+    public function testDefaultFormat()
+    {
+        $visitor = new JsonDeserializationVisitor();
+
+        $type = ['name' => 'DateTime'];
+        self::assertEquals(
+            \DateTime::createFromFormat('Y/m/d H:i:s', '2017/06/18 17:32:11', $this->timezone),
+            $this->handler->deserializeDateTimeFromJson($visitor, '2017-06-18T17:32:11Z', $type),
+        );
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| Doc updated   | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
| License       | MIT

This change allows the setting of multiple default deserialization formats of Date.

