### PR TITLE
Do not use single quotes in enum type definition

### DIFF
--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -104,6 +104,7 @@ If you are on version `1.x`, it is suggested to migrate directly to `3.0.0` (sin
 - `JsonSerializationVisitor::hasData` will be removed 
 - `VisitorInterface` is internal, use `SerializationVisitorInterface` and `DeserializationVisitorInterface` instead
 - `GraphNavigator` is internal, use `GraphNavigatorInterface` instead
+- `enum<'Type'>` and similar are deprecated, use `enum<Type>` instead
 
 **Other**
 - Elements (as classes, interfaces, methods, properties...)

--- a/doc/reference/annotations.rst
+++ b/doc/reference/annotations.rst
@@ -454,19 +454,19 @@ Available Types:
 |                                                            | Examples: array<string, string>,                 |
 |                                                            | array<string, MyNamespace\MyObject>, etc.        |
 +------------------------------------------------------------+--------------------------------------------------+
-| enum<'Color'>                                              | Enum of type Color, use its case values          |
+| enum<T>                                                    | Enum of type Color, use its case values          |
 |                                                            | for serialization and deserialization            |
 |                                                            | if the enum is a backed enum,                    |
 |                                                            | use its case names if it is not a backed enum.   |
 +------------------------------------------------------------+--------------------------------------------------+
-| enum<'Color', 'name'>                                      | Enum of type Color, use its case names           |
+| enum<T, 'name'>                                            | Enum of type Color, use its case names           |
 |                                                            | (as string) for serialization                    |
 |                                                            | and deserialization.                             |
 +------------------------------------------------------------+--------------------------------------------------+
-| enum<'Color', 'value'>                                     | Backed Enum of type Color, use its case value    |
+| enum<T, 'value'>                                           | Backed Enum of type Color, use its case value    |
 |                                                            | for serialization and deserialization.           |
 +------------------------------------------------------------+--------------------------------------------------+
-| enum<'Color', 'value', 'integer'>                          | Backed Enum of type Color, use its case value    |
+| enum<T, 'value', 'integer'>                                | Backed Enum of type Color, use its case value    |
 |                                                            | (forced as integer) for serialization            |
 |                                                            | and deserialization.                             |
 +------------------------------------------------------------+--------------------------------------------------+

--- a/src/Handler/EnumHandler.php
+++ b/src/Handler/EnumHandler.php
@@ -64,6 +64,12 @@ final class EnumHandler implements SubscribingHandlerInterface
     public function deserializeEnum(DeserializationVisitorInterface $visitor, $data, array $type): ?\UnitEnum
     {
         $enumType = $type['params'][0];
+        if (isset($enumType['name'])) {
+            $enumType = $enumType['name'];
+        } else {
+            trigger_deprecation('jms/serializer', '3.31', "Using enum<'Type'> or similar is deprecated, use enum<Type> instead.");
+        }
+
         $caseValue = (string) $data;
 
         $ref = new \ReflectionEnum($enumType);

--- a/src/Metadata/Driver/EnumPropertiesDriver.php
+++ b/src/Metadata/Driver/EnumPropertiesDriver.php
@@ -48,7 +48,13 @@ class EnumPropertiesDriver implements DriverInterface
             try {
                 $propertyReflection = $this->getReflection($propertyMetadata);
                 if ($enum = $this->getEnumReflection($propertyReflection)) {
-                    $serializerType = ['name' => 'enum', 'params' => [$enum->getName(), $enum->isBacked() ? 'value' : 'name']];
+                    $serializerType = [
+                        'name' => 'enum',
+                        'params' => [
+                            ['name' => $enum->getName(), 'params' => []],
+                            $enum->isBacked() ? 'value' : 'name',
+                        ],
+                    ];
                     $propertyMetadata->setType($serializerType);
                 }
             } catch (ReflectionException $e) {

--- a/tests/Fixtures/ObjectWithEnums.php
+++ b/tests/Fixtures/ObjectWithEnums.php
@@ -12,32 +12,34 @@ use JMS\Serializer\Tests\Fixtures\Enum\Suit;
 class ObjectWithEnums
 {
     /**
-     * @Serializer\Type("enum<'JMS\Serializer\Tests\Fixtures\Enum\Suit', 'name'>")
+     * @Serializer\Type("enum<JMS\Serializer\Tests\Fixtures\Enum\Suit, 'name'>")
      */
     public Suit $ordinary;
 
     /**
-     * @Serializer\Type("enum<'JMS\Serializer\Tests\Fixtures\Enum\BackedSuit', 'value'>")
+     * @Serializer\Type("enum<JMS\Serializer\Tests\Fixtures\Enum\BackedSuit, 'value'>")
      */
     public BackedSuit $backedValue;
 
     /**
+     * Deprecated, remove single quote around type with 4.0.
+     *
      * @Serializer\Type("enum<'JMS\Serializer\Tests\Fixtures\Enum\BackedSuit'>")
      */
     public BackedSuit $backedWithoutParam;
 
     /**
-     * @Serializer\Type("array<enum<'JMS\Serializer\Tests\Fixtures\Enum\Suit'>>")
+     * @Serializer\Type("array<enum<JMS\Serializer\Tests\Fixtures\Enum\Suit>>")
      */
     public array $ordinaryArray;
 
     /**
-     * @Serializer\Type("array<enum<'JMS\Serializer\Tests\Fixtures\Enum\BackedSuit', 'value'>>")
+     * @Serializer\Type("array<enum<JMS\Serializer\Tests\Fixtures\Enum\BackedSuit, 'value'>>")
      */
     public array $backedArray;
 
     /**
-     * @Serializer\Type("array<enum<'JMS\Serializer\Tests\Fixtures\Enum\BackedSuit'>>")
+     * @Serializer\Type("array<enum<JMS\Serializer\Tests\Fixtures\Enum\BackedSuit>>")
      */
     public array $backedArrayWithoutParam;
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | Inconsistency fix
| New feature?  | no
| Doc updated   | yes
| BC breaks?    | no <!-- don't forget updating UPGRADING.md file -->
| Deprecations? | yes <!-- don't forget updating UPGRADING.md file -->
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT

When enum support was added, it was chosen to use quotes around the type in its type annotation, for example `enum<'Color'>`. However, when compared with the other type annotations such as array and iterable, those quotes are inconsistent.

This PR makes the enum type annotation behaviour similar to the others and deprecated passing a direct string. This deprecation is only triggered during deserialization, as the serialization path has never used the type parameter.

I found this while using NelmioApiDocBundle, see https://github.com/nelmio/NelmioApiDocBundle/issues/2327. I am also making an update for that bundle so it can support both syntaxes.