### PR TITLE
fix(unions): Filter out null type

### DIFF
--- a/src/Metadata/Driver/TypedPropertiesDriver.php
+++ b/src/Metadata/Driver/TypedPropertiesDriver.php
@@ -113,7 +113,14 @@ class TypedPropertiesDriver implements DriverInterface
                 } elseif ($this->shouldTypeHintUnion($reflectionType)) {
                     $propertyMetadata->setType([
                         'name' => 'union',
-                        'params' => [$this->reorderTypes(array_map(fn (string $type) => $this->typeParser->parse($type), $reflectionType->getTypes()))],
+                        'params' => [
+                            $this->reorderTypes(
+                                array_map(
+                                    fn (string $type) => $this->typeParser->parse($type),
+                                    array_filter($reflectionType->getTypes(), [$this, 'shouldTypeHint']),
+                                ),
+                            ),
+                        ],
                     ]);
                 }
             } catch (ReflectionException $e) {

--- a/tests/Fixtures/TypedProperties/UnionTypedProperties.php
+++ b/tests/Fixtures/TypedProperties/UnionTypedProperties.php
@@ -8,6 +8,8 @@ class UnionTypedProperties
 {
     private int|bool|float|string $data;
 
+    private int|bool|float|string|null $nullableData;
+
     public function __construct($data)
     {
         $this->data = $data;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Doc updated   | no
| BC breaks?    | no <!-- don't forget updating UPGRADING.md file -->
| Deprecations? | no <!-- don't forget updating UPGRADING.md file -->
| Tests pass?   | yes
| Fixed tickets | #1562
| License       | MIT

In Parser the null is handled as a null type, not as a type. In result it returns wrong value in parser - this part needs to be refactored. 

https://wiki.php.net/rfc/null-false-standalone-types

Let's filter out null type in the same way as we do in other parts of the TypedDriver. 
