### PR TITLE
Support value types in serialization

### DIFF
--- a/src/GraphNavigator/DeserializationGraphNavigator.php
+++ b/src/GraphNavigator/DeserializationGraphNavigator.php
@@ -128,6 +128,8 @@ final class DeserializationGraphNavigator extends GraphNavigator implements Grap
 
             case 'bool':
             case 'boolean':
+            case 'false':
+            case 'true':
                 return $this->visitor->visitBoolean($data, $type);
 
             case 'double':

--- a/src/GraphNavigator/SerializationGraphNavigator.php
+++ b/src/GraphNavigator/SerializationGraphNavigator.php
@@ -156,6 +156,8 @@ final class SerializationGraphNavigator extends GraphNavigator
 
             case 'bool':
             case 'boolean':
+            case 'true':
+            case 'false':
                 return $this->visitor->visitBoolean((bool) $data, $type);
 
             case 'double':

--- a/src/Metadata/Driver/TypedPropertiesDriver.php
+++ b/src/Metadata/Driver/TypedPropertiesDriver.php
@@ -75,6 +75,8 @@ class TypedPropertiesDriver implements DriverInterface
             'float',
             'bool',
             'boolean',
+            'true',
+            'false',
             'string',
             'double',
             'iterable',

--- a/tests/Fixtures/DataFalse.php
+++ b/tests/Fixtures/DataFalse.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace JMS\Serializer\Tests\Fixtures;
+
+class DataFalse
+{
+    public function __construct(
+        public false $data
+    ) {
+    }
+}

--- a/tests/Fixtures/DataFalse.php
+++ b/tests/Fixtures/DataFalse.php
@@ -6,8 +6,11 @@ namespace JMS\Serializer\Tests\Fixtures;
 
 class DataFalse
 {
+    public false $data;
+
     public function __construct(
-        public false $data
+        false $data
     ) {
+        $this->data = $data;
     }
 }

--- a/tests/Fixtures/DataTrue.php
+++ b/tests/Fixtures/DataTrue.php
@@ -7,4 +7,10 @@ namespace JMS\Serializer\Tests\Fixtures;
 class DataTrue
 {
     public true $data;
+
+    public function __construct(
+        true $data
+    ) {
+        $this->data = $data;
+    }
 }

--- a/tests/Fixtures/DataTrue.php
+++ b/tests/Fixtures/DataTrue.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace JMS\Serializer\Tests\Fixtures;
+
+class DataTrue
+{
+    public true $data;
+}

--- a/tests/Fixtures/TypedProperties/UnionTypedProperties.php
+++ b/tests/Fixtures/TypedProperties/UnionTypedProperties.php
@@ -10,6 +10,8 @@ class UnionTypedProperties
 
     private int|bool|float|string|null $nullableData;
 
+    private string|false $valueTypedUnion;
+
     public function __construct($data)
     {
         $this->data = $data;

--- a/tests/Metadata/Driver/UnionTypedPropertiesDriverTest.php
+++ b/tests/Metadata/Driver/UnionTypedPropertiesDriverTest.php
@@ -57,6 +57,31 @@ final class UnionTypedPropertiesDriverTest extends TestCase
         );
     }
 
+    public function testInferUnionTypesShouldIncludeValueTypes()
+    {
+        $m = $this->resolve(UnionTypedProperties::class);
+
+        self::assertEquals(
+            [
+                'name' => 'union',
+                'params' =>
+                    [
+                        [
+                            [
+                                'name' => 'string',
+                                'params' => [],
+                            ],
+                            [
+                                'name' => 'false',
+                                'params' => [],
+                            ],
+                        ],
+                    ],
+            ],
+            $m->propertyMetadata['valueTypedUnion']->type,
+        );
+    }
+
     private function resolve(string $classToResolve): ClassMetadata
     {
         $namingStrategy = new IdenticalPropertyNamingStrategy();

--- a/tests/Serializer/JsonSerializationTest.php
+++ b/tests/Serializer/JsonSerializationTest.php
@@ -15,6 +15,7 @@ use JMS\Serializer\Metadata\Driver\TypedPropertiesDriver;
 use JMS\Serializer\SerializationContext;
 use JMS\Serializer\Tests\Fixtures\Author;
 use JMS\Serializer\Tests\Fixtures\AuthorList;
+use JMS\Serializer\Tests\Fixtures\DataFalse;
 use JMS\Serializer\Tests\Fixtures\DiscriminatedAuthor;
 use JMS\Serializer\Tests\Fixtures\DiscriminatedComment;
 use JMS\Serializer\Tests\Fixtures\FirstClassMapCollection;
@@ -151,6 +152,8 @@ class JsonSerializationTest extends BaseSerializationTestCase
             $outputs['data_float'] = '{"data":1.236}';
             $outputs['data_bool'] = '{"data":false}';
             $outputs['data_string'] = '{"data":"foo"}';
+            $outputs['data_true'] = '{"data":true}';
+            $outputs['data_false'] = '{"data":false}';
             $outputs['data_author'] = '{"data":{"full_name":"foo"}}';
             $outputs['data_comment'] = '{"data":{"author":{"full_name":"foo"},"text":"bar"}}';
             $outputs['data_discriminated_author'] = '{"data":{"full_name":"foo","objectType":"author"}}';
@@ -478,6 +481,30 @@ class JsonSerializationTest extends BaseSerializationTestCase
 
         $serialized = $this->serialize(new UnionTypedProperties('foo'));
         self::assertEquals(static::getContent('data_string'), $serialized);
+    }
+
+    public function testFalseDataType()
+    {
+        if (PHP_VERSION_ID < 80200) {
+            $this->markTestSkipped('False type requires PHP 8.2');
+            return;
+        }
+
+        self::assertEquals(
+            static::getContent('data_false'),
+            $this->serialize(new DataFalse(false)),
+        );
+
+        self::assertEquals(
+            new DataFalse(false),
+            $this->deserialize(static::getContent('data_false'), DataFalse::class),
+        );
+
+        //What should we expect here?
+        self::assertEquals(
+            null,
+            $this->deserialize(static::getContent('data_true'), DataFalse::class),
+        );
     }
 
     public function testDeserializingComplexDiscriminatedUnionProperties()

--- a/tests/Serializer/JsonSerializationTest.php
+++ b/tests/Serializer/JsonSerializationTest.php
@@ -16,6 +16,7 @@ use JMS\Serializer\SerializationContext;
 use JMS\Serializer\Tests\Fixtures\Author;
 use JMS\Serializer\Tests\Fixtures\AuthorList;
 use JMS\Serializer\Tests\Fixtures\DataFalse;
+use JMS\Serializer\Tests\Fixtures\DataTrue;
 use JMS\Serializer\Tests\Fixtures\DiscriminatedAuthor;
 use JMS\Serializer\Tests\Fixtures\DiscriminatedComment;
 use JMS\Serializer\Tests\Fixtures\FirstClassMapCollection;
@@ -28,6 +29,7 @@ use JMS\Serializer\Tests\Fixtures\TypedProperties\UnionTypedProperties;
 use JMS\Serializer\Visitor\Factory\JsonSerializationVisitorFactory;
 use JMS\Serializer\Visitor\SerializationVisitorInterface;
 use PHPUnit\Framework\Attributes\DataProvider;
+use TypeError;
 
 class JsonSerializationTest extends BaseSerializationTestCase
 {
@@ -483,10 +485,33 @@ class JsonSerializationTest extends BaseSerializationTestCase
         self::assertEquals(static::getContent('data_string'), $serialized);
     }
 
+    public function testTrueDataType()
+    {
+        if (PHP_VERSION_ID < 80200) {
+            $this->markTestSkipped('True type requires PHP 8.2');
+
+            return;
+        }
+
+        self::assertEquals(
+            static::getContent('data_true'),
+            $this->serialize(new DataTrue(true)),
+        );
+
+        self::assertEquals(
+            new DataTrue(true),
+            $this->deserialize(static::getContent('data_true'), DataTrue::class),
+        );
+
+        $this->expectException(TypeError::class);
+        $this->deserialize(static::getContent('data_false'), DataTrue::class);
+    }
+
     public function testFalseDataType()
     {
         if (PHP_VERSION_ID < 80200) {
             $this->markTestSkipped('False type requires PHP 8.2');
+
             return;
         }
 
@@ -500,11 +525,8 @@ class JsonSerializationTest extends BaseSerializationTestCase
             $this->deserialize(static::getContent('data_false'), DataFalse::class),
         );
 
-        //What should we expect here?
-        self::assertEquals(
-            null,
-            $this->deserialize(static::getContent('data_true'), DataFalse::class),
-        );
+        $this->expectException(TypeError::class);
+        $this->deserialize(static::getContent('data_true'), DataFalse::class);
     }
 
     public function testDeserializingComplexDiscriminatedUnionProperties()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | yes (kinda, but I think this is how you'd expect the library to work)
| Doc updated   | no (not applicable)
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #1568
| License       | MIT

Allows serialization of value types (i.e. `true` and `false`, as opposed to `bool`), including in union types (e.g. `string|false`).

Otherwise, tries to create class with FQCN "true" and, for union types, filters out value types as non-primitive.

Fixes #1568