### PR TITLE
Fix syntax error in annotations.rst

### DIFF
--- a/doc/reference/annotations.rst
+++ b/doc/reference/annotations.rst
@@ -1,10 +1,10 @@
 Attributes and annotations
 ==========================
 
-.. warning::
-Starting from release 3.30.0 [doctrine/annotations](https://github.com/doctrine/annotations) is an optional package. 
-If you still want to use them, please make sure that you require in `composer.json` file.
+.. warning ::
 
+    Starting from release 3.30.0 [doctrine/annotations](https://github.com/doctrine/annotations) is an optional package. 
+    If you still want to use them, please make sure that you require in `composer.json` file.
 
 PHP 8 support
 ~~~~~~~~~~~~~~~


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| Doc updated   | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | no
| Fixed tickets | N/A
| License       | MIT

Block contents need to be indented, formatting copied from notes elsewhere in the file.

Hopefully fixes the docs build error on the pipeline