### PR TITLE
feat(unions): Add support for simple arrays

### DIFF
--- a/src/Handler/UnionHandler.php
+++ b/src/Handler/UnionHandler.php
@@ -115,12 +115,15 @@ final class UnionHandler implements SubscribingHandlerInterface
 
     private function isPrimitiveType(string $type): bool
     {
-        return in_array($type, ['int', 'integer', 'float', 'double', 'bool', 'boolean', 'string'], true);
+        return in_array($type, ['int', 'integer', 'float', 'double', 'bool', 'boolean', 'string', 'array'], true);
     }
 
     private function testPrimitive(mixed $data, string $type, string $format): bool
     {
         switch ($type) {
+            case 'array':
+                return is_array($data);
+
             case 'integer':
             case 'int':
                 return (string) (int) $data === (string) $data;
@@ -134,7 +137,7 @@ final class UnionHandler implements SubscribingHandlerInterface
                 return (string) (bool) $data === (string) $data;
 
             case 'string':
-                return (string) $data === (string) $data;
+                return is_string($data);
         }
 
         return false;

--- a/src/Metadata/Driver/TypedPropertiesDriver.php
+++ b/src/Metadata/Driver/TypedPropertiesDriver.php
@@ -60,9 +60,9 @@ class TypedPropertiesDriver implements DriverInterface
     private function reorderTypes(array $types): array
     {
         uasort($types, static function ($a, $b) {
-            $order = ['null' => 0, 'true' => 1, 'false' => 2, 'bool' => 3, 'int' => 4, 'float' => 5, 'string' => 6];
+            $order = ['null' => 0, 'true' => 1, 'false' => 2, 'bool' => 3, 'int' => 4, 'float' => 5, 'array' => 6, 'string' => 7];
 
-            return ($order[$a['name']] ?? 7) <=> ($order[$b['name']] ?? 7);
+            return ($order[$a['name']] ?? 8) <=> ($order[$b['name']] ?? 8);
         });
 
         return $types;
@@ -117,7 +117,7 @@ class TypedPropertiesDriver implements DriverInterface
                             $this->reorderTypes(
                                 array_map(
                                     fn (string $type) => $this->typeParser->parse($type),
-                                    array_filter($reflectionType->getTypes(), [$this, 'shouldTypeHint']),
+                                    array_filter($reflectionType->getTypes(), [$this, 'shouldTypeHintInsideUnion']),
                                 ),
                             ),
                         ],
@@ -179,11 +179,16 @@ class TypedPropertiesDriver implements DriverInterface
         }
 
         foreach ($reflectionType->getTypes() as $type) {
-            if ($this->shouldTypeHint($type)) {
+            if ($this->shouldTypeHintInsideUnion($type)) {
                 return true;
             }
         }
 
         return false;
+    }
+
+    private function shouldTypeHintInsideUnion(ReflectionNamedType $reflectionType)
+    {
+        return $this->shouldTypeHint($reflectionType) || 'array' === $reflectionType->getName();
     }
 }

--- a/tests/Fixtures/TypedProperties/UnionTypedProperties.php
+++ b/tests/Fixtures/TypedProperties/UnionTypedProperties.php
@@ -6,7 +6,7 @@ namespace JMS\Serializer\Tests\Fixtures\TypedProperties;
 
 class UnionTypedProperties
 {
-    private int|bool|float|string $data;
+    private int|bool|float|string|array $data;
 
     private int|bool|float|string|null $nullableData;
 

--- a/tests/Metadata/Driver/UnionTypedPropertiesDriverTest.php
+++ b/tests/Metadata/Driver/UnionTypedPropertiesDriverTest.php
@@ -35,6 +35,10 @@ final class UnionTypedPropertiesDriverTest extends TestCase
                     [
                         [
                             [
+                                'name' => 'array',
+                                'params' => [],
+                            ],
+                            [
                                 'name' => 'string',
                                 'params' => [],
                             ],

--- a/tests/Serializer/JsonSerializationTest.php
+++ b/tests/Serializer/JsonSerializationTest.php
@@ -151,6 +151,7 @@ class JsonSerializationTest extends BaseSerializationTestCase
             $outputs['data_float'] = '{"data":1.236}';
             $outputs['data_bool'] = '{"data":false}';
             $outputs['data_string'] = '{"data":"foo"}';
+            $outputs['data_array'] = '{"data":[1,2,3]}';
             $outputs['data_author'] = '{"data":{"full_name":"foo"}}';
             $outputs['data_comment'] = '{"data":{"author":{"full_name":"foo"},"text":"bar"}}';
             $outputs['data_discriminated_author'] = '{"data":{"full_name":"foo","objectType":"author"}}';
@@ -438,28 +439,20 @@ class JsonSerializationTest extends BaseSerializationTestCase
         ];
     }
 
-    public function testDeserializingUnionProperties()
+    public static function getSimpleUnionProperties(): iterable
     {
-        if (PHP_VERSION_ID < 80000) {
-            $this->markTestSkipped(sprintf('%s requires PHP 8.0', TypedPropertiesDriver::class));
-
-            return;
-        }
-
-        $object = new UnionTypedProperties(10000);
-        self::assertEquals($object, $this->deserialize(static::getContent('data_integer'), UnionTypedProperties::class));
-
-        $object = new UnionTypedProperties(1.236);
-        self::assertEquals($object, $this->deserialize(static::getContent('data_float'), UnionTypedProperties::class));
-
-        $object = new UnionTypedProperties(false);
-        self::assertEquals($object, $this->deserialize(static::getContent('data_bool'), UnionTypedProperties::class));
-
-        $object = new UnionTypedProperties('foo');
-        self::assertEquals($object, $this->deserialize(static::getContent('data_string'), UnionTypedProperties::class));
+        yield 'int' => [10000, 'data_integer'];
+        yield [1.236, 'data_float'];
+        yield [false, 'data_bool'];
+        yield ['foo', 'data_string'];
+        yield [[1, 2, 3], 'data_array'];
     }
 
-    public function testSerializingUnionProperties()
+    /**
+     * @dataProvider getSimpleUnionProperties
+     */
+    #[DataProvider('getSimpleUnionProperties')]
+    public function testUnionProperties($data, string $expected): void
     {
         if (PHP_VERSION_ID < 80000) {
             $this->markTestSkipped(sprintf('%s requires PHP 8.0', TypedPropertiesDriver::class));
@@ -467,17 +460,9 @@ class JsonSerializationTest extends BaseSerializationTestCase
             return;
         }
 
-        $serialized = $this->serialize(new UnionTypedProperties(10000));
-        self::assertEquals(static::getContent('data_integer'), $serialized);
-
-        $serialized = $this->serialize(new UnionTypedProperties(1.236));
-        self::assertEquals(static::getContent('data_float'), $serialized);
-
-        $serialized = $this->serialize(new UnionTypedProperties(false));
-        self::assertEquals(static::getContent('data_bool'), $serialized);
-
-        $serialized = $this->serialize(new UnionTypedProperties('foo'));
-        self::assertEquals(static::getContent('data_string'), $serialized);
+        $object = new UnionTypedProperties($data);
+        self::assertEquals($object, $this->deserialize(static::getContent($expected), UnionTypedProperties::class));
+        self::assertEquals($this->serialize($object), static::getContent($expected));
     }
 
     public function testDeserializingComplexDiscriminatedUnionProperties()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | yes
| Doc updated   | no
| BC breaks?    | no <!-- don't forget updating UPGRADING.md file -->
| Deprecations? | no <!-- don't forget updating UPGRADING.md file -->
| Tests pass?   | yes
| Fixed tickets | #1566
| License       | MIT

Add support for array (de)serialization in Union types. Only basic one. For the future there might be needed some some refactoring as the code debugging is terrible here :D  