### PR TITLE
fix detection of primitive types on union type

### DIFF
--- a/src/Handler/UnionHandler.php
+++ b/src/Handler/UnionHandler.php
@@ -131,7 +131,7 @@ final class UnionHandler implements SubscribingHandlerInterface
 
             case 'bool':
             case 'boolean':
-                return (string) (bool) $data === (string) $data;
+                return (string) (bool) $data === (string) $data && 1 !== $data; // prevent false positive for 1/true
 
             case 'string':
                 return (string) $data === (string) $data;

--- a/src/Metadata/Driver/TypedPropertiesDriver.php
+++ b/src/Metadata/Driver/TypedPropertiesDriver.php
@@ -60,12 +60,12 @@ class TypedPropertiesDriver implements DriverInterface
     private function reorderTypes(array $types): array
     {
         uasort($types, static function ($a, $b) {
-            $order = ['null' => 0, 'true' => 1, 'false' => 2, 'bool' => 3, 'int' => 4, 'float' => 5, 'string' => 6];
+            $order = ['null' => 0, 'true' => 1, 'false' => 2, 'int' => 3, 'float' => 4, 'bool' => 5, 'string' => 6];
 
             return ($order[$a['name']] ?? 7) <=> ($order[$b['name']] ?? 7);
         });
 
-        return $types;
+        return \array_values($types);
     }
 
     private function getDefaultWhiteList(): array

--- a/tests/Metadata/Driver/UnionTypedPropertiesDriverTest.php
+++ b/tests/Metadata/Driver/UnionTypedPropertiesDriverTest.php
@@ -28,16 +28,12 @@ final class UnionTypedPropertiesDriverTest extends TestCase
     {
         $m = $this->resolve(UnionTypedProperties::class);
 
-        self::assertEquals(
+        self::assertSame(
             [
                 'name' => 'union',
                 'params' =>
                     [
                         [
-                            [
-                                'name' => 'string',
-                                'params' => [],
-                            ],
                             [
                                 'name' => 'int',
                                 'params' => [],
@@ -48,6 +44,10 @@ final class UnionTypedPropertiesDriverTest extends TestCase
                             ],
                             [
                                 'name' => 'bool',
+                                'params' => [],
+                            ],
+                            [
+                                'name' => 'string',
                                 'params' => [],
                             ],
                         ],
@@ -61,18 +61,18 @@ final class UnionTypedPropertiesDriverTest extends TestCase
     {
         $m = $this->resolve(UnionTypedProperties::class);
 
-        self::assertEquals(
+        self::assertSame(
             [
                 'name' => 'union',
                 'params' =>
                     [
                         [
                             [
-                                'name' => 'string',
+                                'name' => 'false',
                                 'params' => [],
                             ],
                             [
-                                'name' => 'false',
+                                'name' => 'string',
                                 'params' => [],
                             ],
                         ],

--- a/tests/Serializer/JsonSerializationTest.php
+++ b/tests/Serializer/JsonSerializationTest.php
@@ -151,6 +151,7 @@ class JsonSerializationTest extends BaseSerializationTestCase
             $outputs['uninitialized_typed_props'] = '{"virtual_role":{},"id":1,"role":{},"tags":[]}';
             $outputs['custom_datetimeinterface'] = '{"custom":"2021-09-07"}';
             $outputs['data_integer'] = '{"data":10000}';
+            $outputs['data_integer_one'] = '{"data":1}';
             $outputs['data_float'] = '{"data":1.236}';
             $outputs['data_bool'] = '{"data":false}';
             $outputs['data_string'] = '{"data":"foo"}';
@@ -454,6 +455,9 @@ class JsonSerializationTest extends BaseSerializationTestCase
         $object = new UnionTypedProperties(10000);
         self::assertEquals($object, $this->deserialize(static::getContent('data_integer'), UnionTypedProperties::class));
 
+        $object = new UnionTypedProperties(1);
+        self::assertEquals($object, $this->deserialize(static::getContent('data_integer_one'), UnionTypedProperties::class));
+
         $object = new UnionTypedProperties(1.236);
         self::assertEquals($object, $this->deserialize(static::getContent('data_float'), UnionTypedProperties::class));
 
@@ -474,6 +478,9 @@ class JsonSerializationTest extends BaseSerializationTestCase
 
         $serialized = $this->serialize(new UnionTypedProperties(10000));
         self::assertEquals(static::getContent('data_integer'), $serialized);
+
+        $serialized = $this->serialize(new UnionTypedProperties(1));
+        self::assertEquals(static::getContent('data_integer_one'), $serialized);
 
         $serialized = $this->serialize(new UnionTypedProperties(1.236));
         self::assertEquals(static::getContent('data_float'), $serialized);


### PR DESCRIPTION
detect int before boolean and exclude int(1) from boolean detection
fixes #1573

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Doc updated   | no
| BC breaks?    | no (except someone relied on the invalid conversion from 1 to true)
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #1573
| License       | MIT

