### PR TITLE
Do not change types during deseralization

### DIFF
--- a/.github/workflows/benchmark.yaml
+++ b/.github/workflows/benchmark.yaml
@@ -9,7 +9,7 @@ on:
 jobs:
   phpbench:
     name: "PHPBench"
-    runs-on: "ubuntu-20.04"
+    runs-on: ubuntu-latest
 
     strategy:
       matrix:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -9,7 +9,7 @@ on:
 jobs:
   phpunit:
     name: "PHPUnit"
-    runs-on: "ubuntu-20.04"
+    runs-on: ubuntu-latest
 
     strategy:
       fail-fast: false

--- a/.github/workflows/coding-standards.yaml
+++ b/.github/workflows/coding-standards.yaml
@@ -9,7 +9,7 @@ on:
 jobs:
   coding-standards:
     name: "Coding Standards"
-    runs-on: "ubuntu-20.04"
+    runs-on: ubuntu-latest
 
     strategy:
       matrix:

--- a/.github/workflows/static-analysis.yaml
+++ b/.github/workflows/static-analysis.yaml
@@ -9,7 +9,7 @@ on:
 jobs:
   static-analysis-phpstan:
     name: "Static Analysis with PHPStan"
-    runs-on: "ubuntu-20.04"
+    runs-on: ubuntu-latest
 
     strategy:
       fail-fast: false

--- a/tests/Fixtures/TypedProperties/BoolOrString.php
+++ b/tests/Fixtures/TypedProperties/BoolOrString.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace JMS\Serializer\Tests\Fixtures\TypedProperties;
+
+class BoolOrString
+{
+    public bool|string $data;
+
+    public function __construct($data)
+    {
+        $this->data = $data;
+    }
+}

--- a/tests/Fixtures/TypedProperties/FalseOrString.php
+++ b/tests/Fixtures/TypedProperties/FalseOrString.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace JMS\Serializer\Tests\Fixtures\TypedProperties;
+
+class FalseOrString
+{
+    public false|string $data;
+
+    public function __construct(false|string $data)
+    {
+        $this->data = $data;
+    }
+}

--- a/tests/Fixtures/TypedProperties/UnionTypedProperties.php
+++ b/tests/Fixtures/TypedProperties/UnionTypedProperties.php
@@ -6,7 +6,7 @@ namespace JMS\Serializer\Tests\Fixtures\TypedProperties;
 
 class UnionTypedProperties
 {
-    private int|bool|float|string|array $data;
+    public bool|float|string|array|int $data;
 
     private int|bool|float|string|null $nullableData = null;
 

--- a/tests/Serializer/JsonSerializationTest.php
+++ b/tests/Serializer/JsonSerializationTest.php
@@ -24,6 +24,7 @@ use JMS\Serializer\Tests\Fixtures\ObjectWithEmptyArrayAndHash;
 use JMS\Serializer\Tests\Fixtures\ObjectWithInlineArray;
 use JMS\Serializer\Tests\Fixtures\ObjectWithObjectProperty;
 use JMS\Serializer\Tests\Fixtures\Tag;
+use JMS\Serializer\Tests\Fixtures\TypedProperties\BoolOrString;
 use JMS\Serializer\Tests\Fixtures\TypedProperties\ComplexDiscriminatedUnion;
 use JMS\Serializer\Tests\Fixtures\TypedProperties\UnionTypedProperties;
 use JMS\Serializer\Visitor\Factory\JsonSerializationVisitorFactory;
@@ -151,9 +152,12 @@ class JsonSerializationTest extends BaseSerializationTestCase
             $outputs['uninitialized_typed_props'] = '{"virtual_role":{},"id":1,"role":{},"tags":[]}';
             $outputs['custom_datetimeinterface'] = '{"custom":"2021-09-07"}';
             $outputs['data_integer'] = '{"data":10000}';
+            $outputs['data_integer_one'] = '{"data":1}';
             $outputs['data_float'] = '{"data":1.236}';
             $outputs['data_bool'] = '{"data":false}';
             $outputs['data_string'] = '{"data":"foo"}';
+            $outputs['data_string_empty'] = '{"data":""}';
+            $outputs['data_string_zero'] = '{"data":"0"}';
             $outputs['data_array'] = '{"data":[1,2,3]}';
             $outputs['data_true'] = '{"data":true}';
             $outputs['data_false'] = '{"data":false}';
@@ -452,12 +456,16 @@ class JsonSerializationTest extends BaseSerializationTestCase
 
     public static function getSimpleUnionProperties(): iterable
     {
-        yield 'int' => [[10000, null, false], 'union_typed_properties_integer'];
-        yield 'float' => [[1.236, null, false], 'union_typed_properties_float'];
-        yield 'bool' => [[false, null, false], 'union_typed_properties_bool'];
-        yield 'string' => [['foo', null, false], 'union_typed_properties_string'];
-        yield 'array' => [[[1, 2, 3], null, false], 'union_typed_properties_array'];
-        yield 'false_array' => [[false, null, 'foo'], 'union_typed_properties_false_string'];
+        yield [10000, 'data_integer'];
+        yield [1.236, 'data_float'];
+        yield [false, 'data_bool'];
+        yield ['foo', 'data_string'];
+        yield [[1, 2, 3], 'data_array'];
+        yield [1, 'data_integer_one'];
+        yield ['0', 'data_string_zero'];
+        yield ['', 'data_string_empty'];
+        yield [true, 'data_true'];
+        yield [false, 'data_false'];
     }
 
     /**
@@ -472,9 +480,57 @@ class JsonSerializationTest extends BaseSerializationTestCase
             return;
         }
 
-        $object = new UnionTypedProperties(...$data);
-        self::assertEquals($object, $this->deserialize(static::getContent($expected), UnionTypedProperties::class));
-        self::assertEquals($this->serialize($object), static::getContent($expected));
+        $deserialized = $this->deserialize(static::getContent($expected), UnionTypedProperties::class);
+
+        self::assertSame($data, $deserialized->data);
+        self::assertSame($this->serialize($deserialized), static::getContent($expected));
+    }
+
+    public static function getUnionCastableTypes(): iterable
+    {
+        yield ['10000', 'data_integer'];
+        yield ['1.236', 'data_float'];
+        yield [true, 'data_integer_one'];
+    }
+
+    /**
+     * @dataProvider getUnionCastableTypes
+     */
+    #[DataProvider('getUnionCastableTypes')]
+    public function testUnionPropertiesWithCastableType($data, string $expected)
+    {
+        if (PHP_VERSION_ID < 80000) {
+            $this->markTestSkipped(sprintf('%s requires PHP 8.0', TypedPropertiesDriver::class));
+
+            return;
+        }
+
+        $deserialized = $this->deserialize(static::getContent($expected), BoolOrString::class);
+
+        self::assertSame($data, $deserialized->data);
+    }
+
+    public static function getUnionNotCastableTypes(): iterable
+    {
+        yield ['data_array'];
+    }
+
+    /**
+     * @dataProvider getUnionNotCastableTypes
+     */
+    #[DataProvider('getUnionNotCastableTypes')]
+    public function testUnionPropertiesWithNotCastableType(string $expected)
+    {
+        if (PHP_VERSION_ID < 80000) {
+            $this->markTestSkipped(sprintf('%s requires PHP 8.0', TypedPropertiesDriver::class));
+
+            return;
+        }
+
+        $deserialized = $this->deserialize(static::getContent($expected), BoolOrString::class);
+
+        $this->expectException(\Error::class);
+        $deserialized->data;
     }
 
     public function testTrueDataType()
@@ -489,7 +545,6 @@ class JsonSerializationTest extends BaseSerializationTestCase
             static::getContent('data_true'),
             $this->serialize(new DataTrue(true)),
         );
-
         self::assertEquals(
             new DataTrue(true),
             $this->deserialize(static::getContent('data_true'), DataTrue::class),

--- a/tests/Serializer/JsonSerializationTest.php
+++ b/tests/Serializer/JsonSerializationTest.php
@@ -26,6 +26,7 @@ use JMS\Serializer\Tests\Fixtures\ObjectWithObjectProperty;
 use JMS\Serializer\Tests\Fixtures\Tag;
 use JMS\Serializer\Tests\Fixtures\TypedProperties\BoolOrString;
 use JMS\Serializer\Tests\Fixtures\TypedProperties\ComplexDiscriminatedUnion;
+use JMS\Serializer\Tests\Fixtures\TypedProperties\FalseOrString;
 use JMS\Serializer\Tests\Fixtures\TypedProperties\UnionTypedProperties;
 use JMS\Serializer\Visitor\Factory\JsonSerializationVisitorFactory;
 use JMS\Serializer\Visitor\SerializationVisitorInterface;
@@ -570,6 +571,16 @@ class JsonSerializationTest extends BaseSerializationTestCase
         self::assertEquals(
             new DataFalse(false),
             $this->deserialize(static::getContent('data_false'), DataFalse::class),
+        );
+
+        self::assertEquals(
+            static::getContent('data_false'),
+            $this->serialize(new FalseOrString(false)),
+        );
+
+        self::assertEquals(
+            new FalseOrString(false),
+            $this->deserialize(static::getContent('data_false'), FalseOrString::class),
         );
 
         $this->expectException(TypeError::class);

--- a/tests/Serializer/JsonStrictSerializationTest.php
+++ b/tests/Serializer/JsonStrictSerializationTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace JMS\Serializer\Tests\Serializer;
 
+use JMS\Serializer\Exception\NonVisitableTypeException;
 use JMS\Serializer\SerializerBuilder;
 use JMS\Serializer\Visitor\Factory\JsonDeserializationVisitorFactory;
 use PHPUnit\Framework\Attributes\DataProvider;
@@ -24,5 +25,16 @@ class JsonStrictSerializationTest extends JsonSerializationTest
     public function testFirstClassMapCollections(array $items, string $expected): void
     {
         self::markTestIncomplete('Fixtures are broken');
+    }
+
+    /**
+     * @dataProvider getUnionCastableTypes
+     */
+    #[DataProvider('getUnionCastableTypes')]
+    public function testUnionPropertiesWithCastableType($data, string $expected): void
+    {
+        $this->expectException(NonVisitableTypeException::class);
+
+        parent::testUnionPropertiesWithCastableType($data, $expected);
     }
 }

--- a/tests/Serializer/XmlSerializationTest.php
+++ b/tests/Serializer/XmlSerializationTest.php
@@ -50,7 +50,6 @@ use JMS\Serializer\Visitor\Factory\XmlSerializationVisitorFactory;
 use JMS\Serializer\XmlSerializationVisitor;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\DoesNotPerformAssertions;
-use PHPUnit\Framework\Attributes\Group;
 
 class XmlSerializationTest extends BaseSerializationTestCase
 {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Doc updated   | no
| BC breaks?    | no <!-- don't forget updating UPGRADING.md file -->
| Deprecations? | no <!-- don't forget updating UPGRADING.md file -->
| Tests pass?   | no
| Fixed tickets | #1573 #1566
| License       | MIT

Let's make tests more strict, as `self::assertEquals(1, true);` is true... 🤡 

It shows the change of thet type during serialization. 
During deserialization - if the type is possible for the property - let's keep it. If not possible - let's try to guess.