### PR TITLE
Add true/false as primitive types

### DIFF
--- a/src/Handler/UnionHandler.php
+++ b/src/Handler/UnionHandler.php
@@ -115,7 +115,7 @@ final class UnionHandler implements SubscribingHandlerInterface
 
     private function isPrimitiveType(string $type): bool
     {
-        return in_array($type, ['int', 'integer', 'float', 'double', 'bool', 'boolean', 'string', 'array'], true);
+        return in_array($type, ['int', 'integer', 'float', 'double', 'bool', 'boolean', 'true', 'false', 'string', 'array'], true);
     }
 
     private function testPrimitive(mixed $data, string $type, string $format): bool
@@ -135,6 +135,12 @@ final class UnionHandler implements SubscribingHandlerInterface
             case 'bool':
             case 'boolean':
                 return (string) (bool) $data === (string) $data;
+
+            case 'true':
+                return true === $data;
+
+            case 'false':
+                return false === $data;
 
             case 'string':
                 return is_string($data);

--- a/tests/Fixtures/TypedProperties/UnionTypedProperties.php
+++ b/tests/Fixtures/TypedProperties/UnionTypedProperties.php
@@ -8,12 +8,14 @@ class UnionTypedProperties
 {
     private int|bool|float|string|array $data;
 
-    private int|bool|float|string|null $nullableData;
+    private int|bool|float|string|null $nullableData = null;
 
     private string|false $valueTypedUnion;
 
-    public function __construct($data)
+    public function __construct($data, $nullableData, $valueTypedUnion)
     {
         $this->data = $data;
+        $this->nullableData = $nullableData;
+        $this->valueTypedUnion = $valueTypedUnion;
     }
 }

--- a/tests/Serializer/BaseSerializationTestCase.php
+++ b/tests/Serializer/BaseSerializationTestCase.php
@@ -1973,9 +1973,9 @@ abstract class BaseSerializationTestCase extends TestCase
             $this->markTestSkipped(sprintf('%s requires PHP 8.0', TypedPropertiesDriver::class));
         }
 
-        $object = new TypedProperties\UnionTypedProperties(10000);
+        $object = new TypedProperties\UnionTypedProperties(10000, null, false);
 
-        self::assertEquals(static::getContent('data_integer'), $this->serialize($object));
+        self::assertEquals(static::getContent('union_typed_properties_integer'), $this->serialize($object));
     }
 
     public function testSerializingUnionDocBlockTypesProperties()

--- a/tests/Serializer/JsonSerializationTest.php
+++ b/tests/Serializer/JsonSerializationTest.php
@@ -167,6 +167,12 @@ class JsonSerializationTest extends BaseSerializationTestCase
             $outputs['object_with_enums'] = '{"ordinary":"Clubs","backed_value":"C","backed_without_param":"C","ordinary_array":["Clubs","Spades"],"backed_array":["C","H"],"backed_array_without_param":["C","H"],"ordinary_auto_detect":"Clubs","backed_auto_detect":"C","backed_int_auto_detect":3,"backed_int":3,"backed_name":"C","backed_int_forced_str":3}';
             $outputs['object_with_autodetect_enums'] = '{"ordinary_array_auto_detect":["Clubs","Spades"],"backed_array_auto_detect":["C","H"],"mixed_array_auto_detect":["Clubs","H"]}';
             $outputs['object_with_enums_disabled'] = '{"ordinary_array_auto_detect":[{"name":"Clubs"},{"name":"Spades"}],"backed_array_auto_detect":[{"name":"Clubs","value":"C"},{"name":"Hearts","value":"H"}],"mixed_array_auto_detect":[{"name":"Clubs"},{"name":"Hearts","value":"H"}]}';
+            $outputs['union_typed_properties_integer'] = '{"data":10000,"value_typed_union":false}';
+            $outputs['union_typed_properties_float'] = '{"data":1.236,"value_typed_union":false}';
+            $outputs['union_typed_properties_bool'] = '{"data":false,"value_typed_union":false}';
+            $outputs['union_typed_properties_string'] = '{"data":"foo","value_typed_union":false}';
+            $outputs['union_typed_properties_array'] = '{"data":[1,2,3],"value_typed_union":false}';
+            $outputs['union_typed_properties_false_string'] = '{"data":false,"value_typed_union":"foo"}';
         }
 
         if (!isset($outputs[$key])) {
@@ -446,11 +452,12 @@ class JsonSerializationTest extends BaseSerializationTestCase
 
     public static function getSimpleUnionProperties(): iterable
     {
-        yield 'int' => [10000, 'data_integer'];
-        yield [1.236, 'data_float'];
-        yield [false, 'data_bool'];
-        yield ['foo', 'data_string'];
-        yield [[1, 2, 3], 'data_array'];
+        yield 'int' => [[10000, null, false], 'union_typed_properties_integer'];
+        yield 'float' => [[1.236, null, false], 'union_typed_properties_float'];
+        yield 'bool' => [[false, null, false], 'union_typed_properties_bool'];
+        yield 'string' => [['foo', null, false], 'union_typed_properties_string'];
+        yield 'array' => [[[1, 2, 3], null, false], 'union_typed_properties_array'];
+        yield 'false_array' => [[false, null, 'foo'], 'union_typed_properties_false_string'];
     }
 
     /**
@@ -465,7 +472,7 @@ class JsonSerializationTest extends BaseSerializationTestCase
             return;
         }
 
-        $object = new UnionTypedProperties($data);
+        $object = new UnionTypedProperties(...$data);
         self::assertEquals($object, $this->deserialize(static::getContent($expected), UnionTypedProperties::class));
         self::assertEquals($this->serialize($object), static::getContent($expected));
     }

--- a/tests/Serializer/XmlSerializationTest.php
+++ b/tests/Serializer/XmlSerializationTest.php
@@ -616,7 +616,7 @@ class XmlSerializationTest extends BaseSerializationTestCase
 
         $this->expectException(RuntimeException::class);
 
-        $object = new UnionTypedProperties(10000);
+        $object = new UnionTypedProperties(10000, null, false);
         self::assertEquals($object, $this->deserialize(static::getContent('data_integer'), UnionTypedProperties::class));
     }
 

--- a/tests/Serializer/xml/union_typed_properties_integer.xml
+++ b/tests/Serializer/xml/union_typed_properties_integer.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<result>
+  <data>10000</data>
+  <value_typed_union>false</value_typed_union>
+</result>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Doc updated   | no
| BC breaks?    | no <!-- don't forget updating UPGRADING.md file -->
| Deprecations? | no <!-- don't forget updating UPGRADING.md file -->
| Tests pass?   | yes
| Fixed tickets | 
| License       | MIT

The new union handler does not consider `false` or `true` as a primitive type, causing my `array|false` with an array value to be serialised as `true`.
