### PR TITLE
Do not typehint DNF union types

### DIFF
--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -107,6 +107,10 @@
         <exclude-pattern>tests/*</exclude-pattern>
     </rule>
 
+    <rule ref="Squiz.NamingConventions.ValidVariableName.MemberNotCamelCaps">
+        <exclude-pattern>tests/Fixtures/TypedProperties/NotSupportedDNFTypes.php</exclude-pattern>
+    </rule>
+
     <rule ref="SlevomatCodingStandard.Commenting.DocCommentSpacing">
         <properties>
             <property name="annotationsGroups" type="array">

--- a/src/Metadata/Driver/TypedPropertiesDriver.php
+++ b/src/Metadata/Driver/TypedPropertiesDriver.php
@@ -180,7 +180,15 @@ class TypedPropertiesDriver implements DriverInterface
             return false;
         }
 
-        foreach ($reflectionType->getTypes() as $type) {
+        $types = $reflectionType->getTypes();
+
+        foreach ($types as $type) {
+            if ($type instanceof \ReflectionIntersectionType) {
+                return false;
+            }
+        }
+
+        foreach ($types as $type) {
             if ($this->shouldTypeHintInsideUnion($type)) {
                 return true;
             }

--- a/tests/Fixtures/TypedProperties/NotSupportedDNFTypes.php
+++ b/tests/Fixtures/TypedProperties/NotSupportedDNFTypes.php
@@ -1,0 +1,71 @@
+<?php
+
+declare(strict_types=1);
+
+namespace JMS\Serializer\Tests\Fixtures\TypedProperties;
+
+/**
+ * @link https://wiki.php.net/rfc/dnf_types
+ * Changing this file may create some BC change.
+ */
+class NotSupportedDNFTypes
+{
+    // Accepts an object that implements both A and B,
+    // OR an object that implements D.
+    private (A&B)|D $CandBorD;
+
+    // Accepts an object that implements C,
+    // OR a child of X that also implements D,
+    // OR null.
+    private C|(X&D)|null $CorXandDorNULL;
+
+    // Accepts an object that implements all three of A, B, and D,
+    // OR an int,
+    // OR null.
+    private (A&B&D)|int|null $AandBandCorINTorNULL;
+
+    // Accepts an object that implements both A and B,
+    // OR an object that implements both A and D.
+    private (A&B)|(A&D ) $AandBorAandD;
+
+    // Accepts an object that implements A and B,
+    // OR an object that implements both B and D,
+    // OR a child of W that also implements B,
+    // OR null.
+    private A|(B&D)|(B&W)|null $AorBandDorBandWorNULL;
+
+    public function __construct(
+        private (A&B)|D $promotedCandBorD,
+        private C|(X&D)|null $promotedCorXandDorNULL,
+        private (A&B&D)|int|null $promotedAandBandCorINTorNULL,
+        private (A&B)|(A&D ) $promotedAandBorAandD,
+        private A|(B&D)|(B&W)|null $promotedAorBandDorBandWorNULL,
+    ) {
+    }
+}
+
+interface A
+{
+}
+interface B
+{
+}
+interface C extends A
+{
+}
+interface D
+{
+}
+
+class W implements A
+{
+}
+class X implements B
+{
+}
+class Y implements A, B
+{
+}
+class Z extends Y implements C
+{
+}

--- a/tests/Metadata/Driver/UnionTypedPropertiesDriverTest.php
+++ b/tests/Metadata/Driver/UnionTypedPropertiesDriverTest.php
@@ -10,6 +10,7 @@ use JMS\Serializer\Metadata\Driver\AnnotationDriver;
 use JMS\Serializer\Metadata\Driver\NullDriver;
 use JMS\Serializer\Metadata\Driver\TypedPropertiesDriver;
 use JMS\Serializer\Naming\IdenticalPropertyNamingStrategy;
+use JMS\Serializer\Tests\Fixtures\TypedProperties\NotSupportedDNFTypes;
 use JMS\Serializer\Tests\Fixtures\TypedProperties\UnionTypedProperties;
 use Metadata\Driver\DriverChain;
 use PHPUnit\Framework\TestCase;
@@ -84,6 +85,20 @@ final class UnionTypedPropertiesDriverTest extends TestCase
             ],
             $m->propertyMetadata['valueTypedUnion']->type,
         );
+    }
+
+    public function testDNFTypes()
+    {
+        if (PHP_VERSION_ID < 80200) {
+            self::markTestSkipped();
+        }
+
+        $m = $this->resolve(NotSupportedDNFTypes::class);
+
+        self::assertCount(10, $m->propertyMetadata);
+        foreach ($m->propertyMetadata as $propertyMetadata) {
+            self::assertNull($propertyMetadata->type, 'Breaking Change: TypeResolved for: ' . $propertyMetadata->name);
+        }
     }
 
     private function resolve(string $classToResolve): ClassMetadata


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Doc updated   | no
| BC breaks?    | no <!-- don't forget updating UPGRADING.md file -->
| Deprecations? | no <!-- don't forget updating UPGRADING.md file -->
| Tests pass?   | yes
| Fixed tickets | #1584
| License       | MIT

Tests coverage based on: https://wiki.php.net/rfc/dnf_types

@goetas I need your opinion on that:
1. Current implementation skips any cases of Disjunctive Normal Form Types.
2. Alternative solution would be to skip only Intersection types, so `(A&B)|D` could be resolved into `D`, when `(A&B)|C|D` into `union<C,D>`

Looking at the use cases like ArrayCollections from Doctrine I guess second option might be more intuitive for users, when first safer as it brings back behavior from prev lib versions. 🤔 
