### PR TITLE
Parse list into `list` type instead of `array`

### DIFF
--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -4,6 +4,7 @@ Unreleased
 - Use symfony/cache for FileSystem cache implementation instead of doctrine/cache
 - Deprecated the `@ReadOnly` annotation due to `readonly` becoming a keyword in PHP 8.1, use the `@ReadOnlyProperty` annotation instead
 - Doctrine type `decimal` is now correctly mapped to `string` instead of `float`
+- `@var/param list<T>` is now mapped to `list<T>` type instead of `array<int, T>`
 
 From 3.x to 3.30.0
 ==================

--- a/src/Metadata/Driver/DocBlockDriver/DocBlockTypeResolver.php
+++ b/src/Metadata/Driver/DocBlockDriver/DocBlockTypeResolver.php
@@ -140,7 +140,7 @@ final class DocBlockTypeResolver
             if ($this->isSimpleType($type->type, 'list')) {
                 $resolvedTypes = array_map(fn (TypeNode $node) => $this->resolveTypeFromTypeNode($node, $reflector), $type->genericTypes);
 
-                return 'array<int, ' . implode(',', $resolvedTypes) . '>';
+                return 'list<' . implode(',', $resolvedTypes) . '>';
             }
 
             throw new \InvalidArgumentException(sprintf("Can't use non-array generic type %s for collection in %s:%s", (string) $type->type, $reflector->getDeclaringClass()->getName(), $reflector->getName()));

--- a/tests/Metadata/Driver/DocBlockDriverTest.php
+++ b/tests/Metadata/Driver/DocBlockDriverTest.php
@@ -88,7 +88,7 @@ class DocBlockDriverTest extends TestCase
         $m = $this->resolve(CollectionAsList::class);
 
         self::assertEquals(
-            ['name' => 'array', 'params' => [['name' => 'int', 'params' => []], ['name' => 'string', 'params' => []]]],
+            ['name' => 'list', 'params' => [['name' => 'string', 'params' => []]]],
             $m->propertyMetadata['productIds']->type,
         );
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| Doc updated   | no
| BC breaks?    | yes
| Deprecations? | no <!-- don't forget updating UPGRADING.md file -->
| Tests pass?   | yes
| License       | MIT

I noticed in tests we already expect `list<>` input for serialization https://github.com/schmittjoh/serializer/blob/4dc94aa9093f1c0447c10544f5b645dc675bf856/tests/Serializer/JsonSerializationTest.php#L403 therefore I deduced we can use `list` type internally.