### PR TITLE
Test for null or empty strings when deserializing dates

### DIFF
--- a/src/Handler/DateHandler.php
+++ b/src/Handler/DateHandler.php
@@ -211,7 +211,7 @@ final class DateHandler implements SubscribingHandlerInterface
      */
     public function deserializeDateTimeFromJson(DeserializationVisitorInterface $visitor, $data, array $type): ?\DateTimeInterface
     {
-        if (null === $data) {
+        if (empty($data)) {
             return null;
         }
 
@@ -224,7 +224,7 @@ final class DateHandler implements SubscribingHandlerInterface
      */
     public function deserializeDateTimeImmutableFromJson(DeserializationVisitorInterface $visitor, $data, array $type): ?\DateTimeInterface
     {
-        if (null === $data) {
+        if (empty($data)) {
             return null;
         }
 
@@ -237,7 +237,7 @@ final class DateHandler implements SubscribingHandlerInterface
      */
     public function deserializeDateIntervalFromJson(DeserializationVisitorInterface $visitor, $data, array $type): ?\DateInterval
     {
-        if (null === $data) {
+        if (empty($data)) {
             return null;
         }
 

--- a/tests/Handler/DateHandlerTest.php
+++ b/tests/Handler/DateHandlerTest.php
@@ -83,6 +83,14 @@ class DateHandlerTest extends TestCase
         ];
     }
 
+    public function testGetEmptyDateStringReturnsNull()
+    {
+        $visitor = new JsonDeserializationVisitor();
+
+        $type = ['name' => 'DateTime', 'params' => ['Y-m-d', '', 'Y-m-d|']];
+        self::assertNull($this->handler->deserializeDateTimeFromJson($visitor, '', $type));
+    }
+
     public function testTimePartGetsRemoved()
     {
         $visitor = new JsonDeserializationVisitor();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Doc updated   | no
| BC breaks?    | not sure
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #... <!-- #-prefixed issue number(s), if any -->
| License       | MIT

Some APIs send empty dates instead of null or omitting the field. For example
```
{
"someDateField": ""
}
```

Currently only `"someDateField": null` works. Changing the null test to an empty test allows for the system to skip deserializing empty date fields.