### PR TITLE
Params of TypeArray are optional

### DIFF
--- a/src/Type/Type.php
+++ b/src/Type/Type.php
@@ -7,7 +7,7 @@ namespace JMS\Serializer\Type;
 /**
  * @internal
  *
- * @phpstan-type TypeArray array{name: string, params: array}
+ * @phpstan-type TypeArray array{name: string, params?: array}
  */
 final class Type
 {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Doc updated   | no
| BC breaks?    | no <!-- don't forget updating UPGRADING.md file -->
| Deprecations? | no <!-- don't forget updating UPGRADING.md file -->
| Tests pass?   | no
| Fixed tickets | #... <!-- #-prefixed issue number(s), if any -->
| License       | MIT

The params where at current state not required and so should be marked as optional. Stumbled over this after getting PHPStan error in @sulu code base.

Related: https://github.com/schmittjoh/serializer/pull/1597
