### PR TITLE
Do not call Reflection*::setAccessible() in PHP >= 8.1

### DIFF
--- a/src/Accessor/DefaultAccessorStrategy.php
+++ b/src/Accessor/DefaultAccessorStrategy.php
@@ -77,7 +77,10 @@ final class DefaultAccessorStrategy implements AccessorStrategyInterface
             $ref = $this->propertyReflectionCache[$metadata->class][$metadata->name] ?? null;
             if (null === $ref) {
                 $ref = new \ReflectionProperty($metadata->class, $metadata->name);
-                $ref->setAccessible(true);
+                if (\PHP_VERSION_ID < 80100) {
+                    $ref->setAccessible(true);
+                }
+
                 $this->propertyReflectionCache[$metadata->class][$metadata->name] = $ref;
             }
 
@@ -121,7 +124,10 @@ final class DefaultAccessorStrategy implements AccessorStrategyInterface
             $ref = $this->propertyReflectionCache[$metadata->class][$metadata->name] ?? null;
             if (null === $ref) {
                 $ref = new \ReflectionProperty($metadata->class, $metadata->name);
-                $ref->setAccessible(true);
+                if (\PHP_VERSION_ID < 80100) {
+                    $ref->setAccessible(true);
+                }
+
                 $this->propertyReflectionCache[$metadata->class][$metadata->name] = $ref;
             }
 

--- a/tests/Handler/FormErrorHandlerTest.php
+++ b/tests/Handler/FormErrorHandlerTest.php
@@ -300,7 +300,9 @@ class FormErrorHandlerTest extends TestCase
     protected function invokeMethod($object, $method, array $args = [])
     {
         $reflectionMethod = new \ReflectionMethod($object, $method);
-        $reflectionMethod->setAccessible(true);
+        if (\PHP_VERSION_ID < 80100) {
+            $reflectionMethod->setAccessible(true);
+        }
 
         return $reflectionMethod->invokeArgs($object, $args);
     }

--- a/tests/Metadata/Driver/XmlDriverTest.php
+++ b/tests/Metadata/Driver/XmlDriverTest.php
@@ -18,7 +18,9 @@ class XmlDriverTest extends BaseDriverTestCase
         $driver = $this->getDriver();
 
         $ref = new \ReflectionMethod($driver, 'loadMetadataFromFile');
-        $ref->setAccessible(true);
+        if (\PHP_VERSION_ID < 80100) {
+            $ref->setAccessible(true);
+        }
 
         $this->expectException(InvalidMetadataException::class);
         $this->expectExceptionMessage('Invalid XML content for metadata');

--- a/tests/Serializer/BaseSerializationTestCase.php
+++ b/tests/Serializer/BaseSerializationTestCase.php
@@ -2167,7 +2167,9 @@ abstract class BaseSerializationTestCase extends TestCase
     protected function getField($obj, $name)
     {
         $ref = new \ReflectionProperty($obj, $name);
-        $ref->setAccessible(true);
+        if (\PHP_VERSION_ID < 80100) {
+            $ref->setAccessible(true);
+        }
 
         return $ref->getValue($obj);
     }
@@ -2175,7 +2177,10 @@ abstract class BaseSerializationTestCase extends TestCase
     private function setField($obj, $name, $value)
     {
         $ref = new \ReflectionProperty($obj, $name);
-        $ref->setAccessible(true);
+        if (\PHP_VERSION_ID < 80100) {
+            $ref->setAccessible(true);
+        }
+
         $ref->setValue($obj, $value);
     }
 }

--- a/tests/Serializer/EventDispatcher/EventDispatcherTestCase.php
+++ b/tests/Serializer/EventDispatcher/EventDispatcherTestCase.php
@@ -179,7 +179,9 @@ class EventDispatcherTestCase extends TestCase
         $this->dispatcher->addSubscriber($subscriber);
 
         $listenersReflection = new \ReflectionProperty(EventDispatcher::class, 'listeners');
-        $listenersReflection->setAccessible(true);
+        if (\PHP_VERSION_ID < 80100) {
+            $listenersReflection->setAccessible(true);
+        }
 
         self::assertSame([
             'foo.bar_baz' => [

--- a/tests/SerializerBuilderTest.php
+++ b/tests/SerializerBuilderTest.php
@@ -305,7 +305,9 @@ class SerializerBuilderTest extends TestCase
     private function getField($obj, $name)
     {
         $ref = new \ReflectionProperty($obj, $name);
-        $ref->setAccessible(true);
+        if (\PHP_VERSION_ID < 80100) {
+            $ref->setAccessible(true);
+        }
 
         return $ref->getValue($obj);
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| Doc updated   | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
| License       | MIT

> As of PHP 8.1.0, calling this method has no effect; all methods are invokable by default.

(https://www.php.net/manual/en/reflectionmethod.setaccessible.php and https://www.php.net/manual/en/reflectionproperty.setaccessible.php).

There're even plans to deprecate the method in PHP 8.5: https://wiki.php.net/rfc/deprecations_php_8_5#extreflection_deprecations