### PR TITLE
Improve subscribing handler return PHPDoc

### DIFF
--- a/src/Handler/SubscribingHandlerInterface.php
+++ b/src/Handler/SubscribingHandlerInterface.php
@@ -4,23 +4,17 @@ declare(strict_types=1);
 
 namespace JMS\Serializer\Handler;
 
+use JMS\Serializer\GraphNavigatorInterface;
+
 interface SubscribingHandlerInterface
 {
     /**
-     * Return format:
-     *
-     *      array(
-     *          array(
-     *              'direction' => GraphNavigatorInterface::DIRECTION_SERIALIZATION,
-     *              'format' => 'json',
-     *              'type' => 'DateTime',
-     *              'method' => 'serializeDateTimeToJson',
-     *          ),
-     *      )
-     *
-     * The direction and method keys can be omitted.
-     *
-     * @return array
+     * @return iterable<array{
+     *     type: string,
+     *     format: string,
+     *     direction?: GraphNavigatorInterface::DIRECTION_*,
+     *     method?: string,
+     * }>
      *
      * @phpcsSuppress SlevomatCodingStandard.TypeHints.TypeHintDeclaration.MissingReturnTypeHint
      */


### PR DESCRIPTION
Updates the SubscribingHandlerInterface return PHPDoc to use an iterable array shape and removes the redundant prose example.