### PR TITLE
Update .gitattributes to exclude dev files from composer dist

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,8 +1,14 @@
 /tests export-ignore
 /phpcs.xml.dist export-ignore
-/phpstan.xml.dist export-ignore
 /phpunit.xml.dist export-ignore
 /.gitattributes export-ignore
 /.github export-ignore
 /.gitignore export-ignore
+/.run export-ignore
 /phpstan export-ignore
+/doc/ export-ignore
+/phpstan.neon.dist export-ignore
+/phpbench.json export-ignore
+/rector.php export-ignore
+/CONTRIBUTING.md export-ignore
+/META.md export-ignore

--- a/.gitattributes
+++ b/.gitattributes
@@ -11,4 +11,5 @@
 /phpbench.json export-ignore
 /rector.php export-ignore
 /CONTRIBUTING.md export-ignore
+/CHANGELOG.md export-ignore
 /META.md export-ignore


### PR DESCRIPTION
This avoids shipping dev/tooling files in the composer dist that aren't needed at runtime.

Last `.gitattributes` update was cd24e3c (2023-01-06).

### Stale entry to remove
- `/phpstan.xml.dist export-ignore` - file does not exist upstream (the config is `phpstan.neon.dist`, which is added below).

### Entries to add
Files added or modified since the last `.gitattributes` update, still shipped in the composer dist:
- `/.run export-ignore` - last touched in 1aa5bfa (2021-10-28). PhpStorm run configurations.
- `/doc/ export-ignore` - last touched in e5baafe (2025-07-17, #1604).
- `/phpstan.neon.dist export-ignore` - last touched in 3d937ad (2024-11-25).
- `/phpbench.json export-ignore` - last touched in 77b8c5f (2023-01-21).
- `/rector.php export-ignore` - last touched in 48434b3 (2025-04-02).
- `/CONTRIBUTING.md export-ignore` - last touched in f674fba (2026-03-26).
- `/META.md export-ignore` - last touched in e5baafe (2025-07-17, #1604).

Background reading: https://blog.madewithlove.be/post/gitattributes/