### PR TITLE
Keep fractional seconds when formatting DateInterval

### DIFF
--- a/src/Handler/DateHandler.php
+++ b/src/Handler/DateHandler.php
@@ -393,7 +393,7 @@ final class DateHandler implements SubscribingHandlerInterface
             $format .= $dateInterval->d . 'D';
         }
 
-        if (0 < $dateInterval->h || 0 < $dateInterval->i || 0 < $dateInterval->s) {
+        if (0 < $dateInterval->h || 0 < $dateInterval->i || 0 < $dateInterval->s || 0 < $dateInterval->f) {
             $format .= 'T';
         }
 
@@ -405,7 +405,9 @@ final class DateHandler implements SubscribingHandlerInterface
             $format .= $dateInterval->i . 'M';
         }
 
-        if (0 < $dateInterval->s) {
+        if (0 < $dateInterval->f) {
+            $format .= rtrim(rtrim(sprintf('%.6F', $dateInterval->s + $dateInterval->f), '0'), '.') . 'S';
+        } elseif (0 < $dateInterval->s) {
             $format .= $dateInterval->s . 'S';
         }
 

--- a/tests/Serializer/DateIntervalFormatTest.php
+++ b/tests/Serializer/DateIntervalFormatTest.php
@@ -31,4 +31,21 @@ class DateIntervalFormatTest extends TestCase
 
         self::assertEquals('P2Y4DT6H8M16S', $ATOMDateIntervalString);
     }
+
+    public function testFormatKeepsFractionalSeconds()
+    {
+        $dtf = new DateHandler();
+
+        $interval = new \DateInterval('PT10S');
+        $interval->f = 0.5;
+        self::assertEquals('PT10.5S', $dtf->format($interval));
+
+        $interval = new \DateInterval('PT0S');
+        $interval->f = 0.25;
+        self::assertEquals('PT0.25S', $dtf->format($interval));
+
+        $start = new \DateTimeImmutable('2021-01-01 00:00:00.000000');
+        $end = new \DateTimeImmutable('2021-01-01 00:00:10.500000');
+        self::assertEquals('PT10.5S', $dtf->format($start->diff($end)));
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Doc updated   | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets |
| License       | MIT

`DateHandler::format()` builds the ISO 8601 duration from `y`, `m`, `d`, `h`, `i` and `s` only and never reads the `f` property, although `parseDateInterval()` specifically parses fractional seconds into `f`. Fractional seconds are silently dropped on serialization:

```php
$handler = new DateHandler();

$i = new DateInterval('PT10S');
$i->f = 0.5;
$handler->format($i); // "PT10S", 0.5s lost

// round trip
$parsed = /* deserialize */ 'PT0.5S';   // s=0, f=0.5
$handler->format($parsed);              // "P0DT0S" - the value vanishes entirely
```

The `f` property is also populated natively, so intervals coming from `DateTime::diff()` lose their sub-second part the same way:

```php
$a = new DateTimeImmutable('2021-01-01 00:00:00.000000');
$b = new DateTimeImmutable('2021-01-01 00:00:10.500000');
$handler->format($a->diff($b)); // "PT10S" instead of "PT10.5S"
```

This PR renders the seconds component from `s + f` when `f` is non-zero (trimming the trailing zeros of the fixed-point `%.6F` representation, which matches DateInterval's native microsecond resolution), and lets a non-zero `f` alone introduce the `T` separator so `PT0.5S` no longer collapses to `P0DT0S`.

Full suite passes (1139 tests), phpstan and phpcs are clean on the touched files.
